### PR TITLE
Smooth freelook and weapon recoil

### DIFF
--- a/src/doom/d_player.h
+++ b/src/doom/d_player.h
@@ -166,11 +166,11 @@ typedef struct player_s
 
     // [crispy] additional fields for crispy features
     char*	centermessage;
-    int	lookdir;
+    int	lookdir, oldlookdir;
     boolean	centering;
     unsigned int	jumpTics;
     boolean	mapcoords;
-    fixed_t	recoilpitch;
+    fixed_t	recoilpitch, oldrecoilpitch;
 } player_t;
 
 

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -274,6 +274,8 @@ void P_PlayerThink (player_t* player)
     player->mo->oldz = player->mo->z;
     player->mo->oldangle = player->mo->angle;
     player->oldviewz = player->viewz;
+    player->oldlookdir = player->lookdir;
+    player->oldrecoilpitch = player->recoilpitch;
 
     // fixme: do this in the cheat code
     if (player->cheats & CF_NOCLIP)

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -925,6 +925,9 @@ void R_SetupFrame (player_t* player)
         viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
         viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
         viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+
+        pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT
+                + (player->oldrecoilpitch + FixedMul(player->recoilpitch - player->oldrecoilpitch, fractionaltic) >> FRACBITS);
     }
     else
     {
@@ -932,12 +935,13 @@ void R_SetupFrame (player_t* player)
         viewy = player->mo->y;
         viewz = player->viewz;
         viewangle = player->mo->angle + viewangleoffset;
+
+        // [crispy] pitch is actual lookdir and weapon pitch
+        pitch = player->lookdir / MLOOKUNIT + (player->recoilpitch >> FRACBITS);
     }
 
     extralight = player->extralight;
 
-    // [crispy] pitch is actual lookdir and weapon pitch
-    pitch = player->lookdir/MLOOKUNIT + (player->recoilpitch>>FRACBITS);
     if (pitch > LOOKDIRMAX)
 	pitch = LOOKDIRMAX;
     else


### PR DESCRIPTION
This patch gets rid of the unpleasant jerkiness when you have freelook or weapon recoil enabled with >35 framecap.