### PR TITLE
Hacked together a playmusic option

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -2151,6 +2151,16 @@ void D_DoomMain (void)
 
     PrintGameVersion();
 
+    p = M_CheckParmWithArgs("-playmusic", 1);
+    if (p)
+    {
+        DEH_printf("Now playing %s\n", myargv[p+1]);
+        S_PlayMusicLump(myargv[p+1]);
+        while (I_MusicIsPlaying());
+        DEH_printf("Music done playing\n");
+        return;
+    }
+
     DEH_printf("HU_Init: Setting up heads up display.\n");
     HU_Init ();
 

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -764,6 +764,20 @@ void S_StartMusic(int m_id)
     S_ChangeMusic(m_id, false);
 }
 
+void S_PlayMusicLump(char *lumpname)
+{
+    musicinfo_t *music = NULL;
+    void *handle;
+
+    music = &S_music[0];
+    music->lumpnum = W_GetNumForName(lumpname);
+    music->data = W_CacheLumpNum(music->lumpnum, PU_STATIC);
+
+    handle = I_RegisterSong(music->data, W_LumpLength(music->lumpnum));
+    music->handle = handle;
+    I_PlaySong(handle, 4);
+}
+
 void S_ChangeMusic(int musicnum, int looping)
 {
     musicinfo_t *music = NULL;

--- a/src/doom/s_sound.h
+++ b/src/doom/s_sound.h
@@ -62,6 +62,8 @@ boolean S_SoundIsPlaying(mobj_t *origin, int sfx_id);
 // Start music using <music_id> from sounds.h
 void S_StartMusic(int music_id);
 
+void S_PlayMusicLump(char *lumpname);
+
 // Start music using <music_id> from sounds.h,
 //  and set whether looping
 void S_ChangeMusic(int music_id, int looping);

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1358,6 +1358,8 @@ static void ProcessEvent(opl_track_data_t *track, midi_event_t *event)
 static void ScheduleTrack(opl_track_data_t *track);
 static void InitChannel(opl_channel_data_t *channel);
 
+static void FinishSong(void *unused);
+
 // Restart a song from the beginning.
 
 static void RestartSong(void *unused)
@@ -1413,7 +1415,19 @@ static void TrackTimerCallback(void *arg)
 
         if (running_tracks <= 0 && song_looping)
         {
-            OPL_SetCallback(5000, RestartSong, NULL);
+            if (song_looping > 2)
+            {
+                --song_looping;
+            }
+
+            if (song_looping == 2)
+            {
+                OPL_SetCallback(3000000, FinishSong, NULL);
+            }
+            else
+            {
+                OPL_SetCallback(5000, RestartSong, NULL);
+            }
         }
 
         return;
@@ -1891,3 +1905,7 @@ void I_OPL_DevMessages(char *result, size_t result_len)
     } while (lines < 25 && i != last_perc_count);
 }
 
+static void FinishSong(void *unused)
+{
+    I_OPL_StopSong();
+}


### PR DESCRIPTION
Try it out with: `crispy-doom -playmusic d_runnin` for example. Ctrl-C to stop the music. It always loops twice, and that's hardcoded for now.

See #238 