### PR TITLE
Heretic: upgrade renderer to use 32-bit integer math

### DIFF
--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -88,8 +88,8 @@ void P_LoadVertexes(int lump)
         li->y = SHORT(ml->y) << FRACBITS;
 
         // [crispy] initialize pseudovertexes with actual vertex coordinates
-        li->px = li->x;
-        li->py = li->y;
+        li->r_x = li->x;
+        li->r_y = li->y;
         li->moved = false;
     }
 
@@ -538,7 +538,7 @@ void P_GroupLines(void)
 // [crispy] remove slime trails
 // mostly taken from Lee Killough's implementation in mbfsrc/P_SETUP.C:849-924,
 // with the exception that not the actual vertex coordinates are modified,
-// but pseudovertexes which are dummies that are *only* used in rendering,
+// but separate coordinates that are *only* used in rendering,
 // i.e. r_bsp.c:R_AddLine()
 
 static void P_RemoveSlimeTrails(void)
@@ -547,35 +547,44 @@ static void P_RemoveSlimeTrails(void)
 
     for (i = 0; i < numsegs; i++)
     {
-        const line_t *l = segs[i].linedef;
-        vertex_t *v = segs[i].v1;
+	const line_t *l = segs[i].linedef;
+	vertex_t *v = segs[i].v1;
 
-        // [crispy] ignore exactly vertical or horizontal linedefs
-        if (l->dx && l->dy)
-        {
-            do
-            {
-                if (!v->moved) // [crispy] vertex wasn't already moved
-                {
-                    v->moved = true; // [crispy] ignore endpoints of linedefs
-                    if (v != l->v1 && v != l->v2)
-                    {
-                        // [crispy] move the vertex towards the linedef
-                        // by projecting it using the law of cosines
-                        int64_t dx2 = (l->dx >> FRACBITS) * (l->dx >> FRACBITS);
-                        int64_t dy2 = (l->dy >> FRACBITS) * (l->dy >> FRACBITS);
-                        int64_t dxy = (l->dx >> FRACBITS) * (l->dy >> FRACBITS);
-                        int64_t s = dx2 + dy2;
-                        int x0 = v->x, y0 = v->y, x1 = l->v1->x, y1 = l->v1->y;
+	// [crispy] ignore exactly vertical or horizontal linedefs
+	if (l->dx && l->dy)
+	{
+	    do
+	    {
+		// [crispy] vertex wasn't already moved
+		if (!v->moved)
+		{
+		    v->moved = true;
+		    // [crispy] ignore endpoints of linedefs
+		    if (v != l->v1 && v != l->v2)
+		    {
+			// [crispy] move the vertex towards the linedef
+			// by projecting it using the law of cosines
+			int64_t dx2 = (l->dx >> FRACBITS) * (l->dx >> FRACBITS);
+			int64_t dy2 = (l->dy >> FRACBITS) * (l->dy >> FRACBITS);
+			int64_t dxy = (l->dx >> FRACBITS) * (l->dy >> FRACBITS);
+			int64_t s = dx2 + dy2;
 
-                        // [crispy] MBF actually overrides v->x and v->y here
-                        v->px = (fixed_t)((dx2 * x0 + dy2 * x1 + dxy * (y0 - y1)) / s);
-                        v->py = (fixed_t)((dy2 * y0 + dx2 * y1 + dxy * (x0 - x1)) / s);
-                    }
-                }
-            // [crispy] if v doesn't point to the second vertex of the seg already, point it there
-            } while ((v != segs[i].v2) && (v = segs[i].v2));
-        }
+			// [crispy] MBF actually overrides v->x and v->y here
+			v->r_x = (fixed_t)((dx2 * v->x + dy2 * l->v1->x + dxy * (v->y - l->v1->y)) / s);
+			v->r_y = (fixed_t)((dy2 * v->y + dx2 * l->v1->y + dxy * (v->x - l->v1->x)) / s);
+
+			// [crispy] wait a minute... moved more than 8 map units?
+			// maybe that's a linguortal then, back to the original coordinates
+			if (abs(v->r_x - v->x) > 8*FRACUNIT || abs(v->r_y - v->y) > 8*FRACUNIT)
+			{
+			    v->r_x = v->x;
+			    v->r_y = v->y;
+			}
+		    }
+		}
+	    // [crispy] if v doesn't point to the second vertex of the seg already, point it there
+	    } while ((v != segs[i].v2) && (v = segs[i].v2));
+	}
     }
 }
 

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -86,6 +86,11 @@ void P_LoadVertexes(int lump)
     {
         li->x = SHORT(ml->x) << FRACBITS;
         li->y = SHORT(ml->y) << FRACBITS;
+
+        // [crispy] initialize pseudovertexes with actual vertex coordinates
+        li->px = li->x;
+        li->py = li->y;
+        li->moved = false;
     }
 
     W_ReleaseLumpNum(lump);
@@ -530,6 +535,49 @@ void P_GroupLines(void)
 
 //=============================================================================
 
+// [crispy] remove slime trails
+// mostly taken from Lee Killough's implementation in mbfsrc/P_SETUP.C:849-924,
+// with the exception that not the actual vertex coordinates are modified,
+// but pseudovertexes which are dummies that are *only* used in rendering,
+// i.e. r_bsp.c:R_AddLine()
+
+static void P_RemoveSlimeTrails(void)
+{
+    int i;
+
+    for (i = 0; i < numsegs; i++)
+    {
+        const line_t *l = segs[i].linedef;
+        vertex_t *v = segs[i].v1;
+
+        // [crispy] ignore exactly vertical or horizontal linedefs
+        if (l->dx && l->dy)
+        {
+            do
+            {
+                if (!v->moved) // [crispy] vertex wasn't already moved
+                {
+                    v->moved = true; // [crispy] ignore endpoints of linedefs
+                    if (v != l->v1 && v != l->v2)
+                    {
+                        // [crispy] move the vertex towards the linedef
+                        // by projecting it using the law of cosines
+                        int64_t dx2 = (l->dx >> FRACBITS) * (l->dx >> FRACBITS);
+                        int64_t dy2 = (l->dy >> FRACBITS) * (l->dy >> FRACBITS);
+                        int64_t dxy = (l->dx >> FRACBITS) * (l->dy >> FRACBITS);
+                        int64_t s = dx2 + dy2;
+                        int x0 = v->x, y0 = v->y, x1 = l->v1->x, y1 = l->v1->y;
+
+                        // [crispy] MBF actually overrides v->x and v->y here
+                        v->px = (fixed_t)((dx2 * x0 + dy2 * x1 + dxy * (y0 - y1)) / s);
+                        v->py = (fixed_t)((dy2 * y0 + dx2 * y1 + dxy * (x0 - x1)) / s);
+                    }
+                }
+            // [crispy] if v doesn't point to the second vertex of the seg already, point it there
+            } while ((v != segs[i].v2) && (v = segs[i].v2));
+        }
+    }
+}
 
 /*
 =================
@@ -586,6 +634,9 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 
     rejectmatrix = W_CacheLumpNum(lumpnum + ML_REJECT, PU_LEVEL);
     P_GroupLines();
+
+    // [crispy] remove slime trails
+    P_RemoveSlimeTrails();
 
     bodyqueslot = 0;
     deathmatch_p = deathmatchstarts;

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -223,8 +223,9 @@ void R_AddLine(seg_t * line)
 
 // OPTIMIZE: quickly reject orthogonal back sides
 
-    angle1 = R_PointToAngle(line->v1->x, line->v1->y);
-    angle2 = R_PointToAngle(line->v2->x, line->v2->y);
+    // [crispy] remove slime trails
+    angle1 = R_PointToAngle(line->v1->px, line->v1->py);
+    angle2 = R_PointToAngle(line->v2->px, line->v2->py);
 
 //
 // clip to view edges

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -224,8 +224,8 @@ void R_AddLine(seg_t * line)
 // OPTIMIZE: quickly reject orthogonal back sides
 
     // [crispy] remove slime trails
-    angle1 = R_PointToAngle(line->v1->px, line->v1->py);
-    angle2 = R_PointToAngle(line->v2->px, line->v2->py);
+    angle1 = R_PointToAngle(line->v1->r_x, line->v1->r_y);
+    angle2 = R_PointToAngle(line->v2->r_x, line->v2->r_y);
 
 //
 // clip to view edges

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -61,6 +61,14 @@
 typedef struct
 {
     fixed_t x, y;
+
+    // [crispy] remove slime trails
+    // pseudovertexes are dummies that have their coordinates modified to get
+    // moved towards the linedef associated with their seg by projecting them
+    // using the law of cosines in p_setup.c:P_RemoveSlimeTrails();
+    // they are *only* used in rendering
+    fixed_t px, py;
+    boolean moved;
 } vertex_t;
 
 struct line_s;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -62,13 +62,13 @@ typedef struct
 {
     fixed_t x, y;
 
-    // [crispy] remove slime trails
-    // pseudovertexes are dummies that have their coordinates modified to get
-    // moved towards the linedef associated with their seg by projecting them
-    // using the law of cosines in p_setup.c:P_RemoveSlimeTrails();
-    // they are *only* used in rendering
-    fixed_t px, py;
-    boolean moved;
+// [crispy] remove slime trails
+// vertex coordinates *only* used in rendering that have been
+// moved towards the linedef associated with their seg by projecting them
+// using the law of cosines in p_setup.c:P_RemoveSlimeTrails();
+    fixed_t	r_x;
+    fixed_t	r_y;
+    boolean	moved;
 } vertex_t;
 
 struct line_s;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -157,12 +157,12 @@ typedef struct
     int lightlevel;
     int special;
     int minx, maxx;
-    unsigned short pad1;                  // leave pads for [minx-1]/[maxx+1]
-    unsigned short top[SCREENWIDTH];
-    unsigned short pad2;
-    unsigned short pad3;
-    unsigned short bottom[SCREENWIDTH];
-    unsigned short pad4;
+    unsigned int pad1;                    // [crispy] hires / 32-bit integer math
+    unsigned int top[SCREENWIDTH];        // [crispy] hires / 32-bit integer math
+    unsigned int pad2;                    // [crispy] hires / 32-bit integer math
+    unsigned int pad3;                    // [crispy] hires / 32-bit integer math
+    unsigned int bottom[SCREENWIDTH];     // [crispy] hires / 32-bit integer math
+    unsigned int pad4;                    // [crispy] hires / 32-bit integer math
 } visplane_t;
 
 typedef struct drawseg_s
@@ -174,9 +174,9 @@ typedef struct drawseg_s
     fixed_t bsilheight;         // don't clip sprites above this
     fixed_t tsilheight;         // don't clip sprites below this
 // pointers to lists for sprite clipping
-    short *sprtopclip;          // adjusted so [x1] is first value
-    short *sprbottomclip;       // adjusted so [x1] is first value
-    short *maskedtexturecol;    // adjusted so [x1] is first value
+    int *sprtopclip;            // [crispy] 32-bit integer math
+    int *sprbottomclip;         // [crispy] 32-bit integer math
+    int *maskedtexturecol;      // [crispy] 32-bit integer math
 } drawseg_t;
 
 #define	SIL_NONE	0
@@ -353,10 +353,10 @@ extern planefunction_t floorfunc, ceilingfunc;
 
 extern int skyflatnum;
 
-extern short openings[MAXOPENINGS], *lastopening;
+extern int *lastopening;    // [crispy] 32-bit integer math
 
-extern short floorclip[SCREENWIDTH];
-extern short ceilingclip[SCREENWIDTH];
+extern int floorclip[SCREENWIDTH];   // [crispy] 32-bit integer math
+extern int ceilingclip[SCREENWIDTH]; // [crispy] 32-bit integer math
 
 extern fixed_t yslope[SCREENHEIGHT];
 extern fixed_t distscale[SCREENWIDTH];
@@ -364,7 +364,7 @@ extern fixed_t distscale[SCREENWIDTH];
 void R_InitPlanes(void);
 void R_ClearPlanes(void);
 void R_MapPlane(int y, int x1, int x2);
-void R_MakeSpans(int x, int t1, int b1, int t2, int b2);
+void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsigned int b2); // [crispy] 32-bit integer math
 void R_DrawPlanes(void);
 
 visplane_t *R_FindPlane(fixed_t height, int picnum, int lightlevel,
@@ -407,12 +407,12 @@ extern vissprite_t *vissprites, *vissprite_p;
 extern vissprite_t vsprsortedhead;
 
 // constant arrays used for psprite clipping and initializing clipping
-extern short negonearray[SCREENWIDTH];
-extern short screenheightarray[SCREENWIDTH];
+extern int negonearray[SCREENWIDTH];       // [crispy] 32-bit integer math
+extern int screenheightarray[SCREENWIDTH]; // [crispy] 32-bit integer math
 
 // vars for R_DrawMaskedColumn
-extern short *mfloorclip;
-extern short *mceilingclip;
+extern int *mfloorclip;   // [crispy] 32-bit integer math
+extern int *mceilingclip; // [crispy] 32-bit integer math
 extern fixed_t spryscale;
 extern fixed_t sprtopscreen;
 extern fixed_t sprbotscreen;

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -39,15 +39,15 @@ visplane_t *visplanes = NULL, *lastvisplane;
 visplane_t *floorplane, *ceilingplane;
 static int numvisplanes;
 
-short openings[MAXOPENINGS], *lastopening;
+int openings[MAXOPENINGS], *lastopening; // [crispy] 32-bit integer math
 
 //
 // clip values are the solid pixel bounding the range
 // floorclip starts out SCREENHEIGHT
 // ceilingclip starts out -1
 //
-short floorclip[SCREENWIDTH];
-short ceilingclip[SCREENWIDTH];
+int floorclip[SCREENWIDTH];   // [crispy] 32-bit integer math
+int ceilingclip[SCREENWIDTH]; // [crispy] 32-bit integer math
 
 //
 // spanstart holds the start of a plane span
@@ -318,7 +318,7 @@ visplane_t *R_CheckPlane(visplane_t * pl, int start, int stop)
     }
 
     for (x = intrl; x <= intrh; x++)
-        if (pl->top[x] != 0xffff)
+        if (pl->top[x] != 0xffffffffu) // [crispy] hires / 32-bit integer math
             break;
 
     if (x > intrh)
@@ -355,7 +355,7 @@ visplane_t *R_CheckPlane(visplane_t * pl, int start, int stop)
 ================
 */
 
-void R_MakeSpans(int x, int t1, int b1, int t2, int b2)
+void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsigned int b2) // [crispy] 32-bit integer math
 {
     while (t1 < t2 && t1 <= b1)
     {
@@ -434,7 +434,7 @@ void R_DrawPlanes(void)
             {
                 dc_yl = pl->top[x];
                 dc_yh = pl->bottom[x];
-                if (dc_yl <= dc_yh)
+                if ((unsigned) dc_yl <= dc_yh) // [crispy] 32-bit integer math
                 {
                     angle = (viewangle + xtoviewangle[x]) >> ANGLETOSKYSHIFT;
                     dc_x = x;
@@ -523,8 +523,8 @@ void R_DrawPlanes(void)
             light = 0;
         planezlight = zlight[light];
 
-        pl->top[pl->maxx + 1] = 0xffff;
-        pl->top[pl->minx - 1] = 0xffff;
+        pl->top[pl->maxx + 1] = 0xffffffffu; // [crispy] hires / 32-bit integer math
+        pl->top[pl->minx - 1] = 0xffffffffu; // [crispy] hires / 32-bit integer math
 
         stop = pl->maxx + 1;
         for (x = pl->minx; x <= stop; x++)

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -63,7 +63,7 @@ fixed_t bottomfrac, bottomstep;
 
 lighttable_t **walllights;
 
-short *maskedtexturecol;
+int *maskedtexturecol;  // [crispy] 32-bit integer math
 
 /*
 ================
@@ -133,7 +133,7 @@ void R_RenderMaskedSegRange(drawseg_t * ds, int x1, int x2)
     for (dc_x = x1; dc_x <= x2; dc_x++)
     {
         // calculate lighting
-        if (maskedtexturecol[dc_x] != SHRT_MAX)
+        if (maskedtexturecol[dc_x] != INT_MAX) // [crispy] 32-bit integer math
         {
             if (!fixedcolormap)
             {
@@ -154,7 +154,7 @@ void R_RenderMaskedSegRange(drawseg_t * ds, int x1, int x2)
                                             maskedtexturecol[dc_x]) - 3);
 
             R_DrawMaskedColumn(col, -1);
-            maskedtexturecol[dc_x] = SHRT_MAX;
+            maskedtexturecol[dc_x] = INT_MAX; // [crispy] 32-bit integer math
         }
         spryscale += rw_scalestep;
     }
@@ -648,14 +648,14 @@ void R_StoreWallRange(int start, int stop)
 //
     if (((ds_p->silhouette & SIL_TOP) || maskedtexture) && !ds_p->sprtopclip)
     {
-        memcpy(lastopening, ceilingclip + start, 2 * (rw_stopx - start));
+        memcpy(lastopening, ceilingclip + start, sizeof(lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
         ds_p->sprtopclip = lastopening - start;
         lastopening += rw_stopx - start;
     }
     if (((ds_p->silhouette & SIL_BOTTOM) || maskedtexture)
         && !ds_p->sprbottomclip)
     {
-        memcpy(lastopening, floorclip + start, 2 * (rw_stopx - start));
+        memcpy(lastopening, floorclip + start, sizeof(lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
         ds_p->sprbottomclip = lastopening - start;
         lastopening += rw_stopx - start;
     }

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -45,8 +45,8 @@ fixed_t pspritescale, pspriteiscale;
 lighttable_t **spritelights;
 
 // constant arrays used for psprite clipping and initializing clipping
-short negonearray[SCREENWIDTH];
-short screenheightarray[SCREENWIDTH];
+int negonearray[SCREENWIDTH];       // [crispy] 32-bit integer math
+int screenheightarray[SCREENWIDTH]; // [crispy] 32-bit integer math
 
 /*
 ===============================================================================
@@ -335,8 +335,8 @@ vissprite_t *R_NewVisSprite(void)
 ================
 */
 
-short *mfloorclip;
-short *mceilingclip;
+int *mfloorclip;   // [crispy] 32-bit integer math
+int *mceilingclip; // [crispy] 32-bit integer math
 fixed_t spryscale;
 fixed_t sprtopscreen;
 fixed_t sprbotscreen;
@@ -898,7 +898,7 @@ void R_SortVisSprites(void)
 void R_DrawSprite(vissprite_t * spr)
 {
     drawseg_t *ds;
-    short clipbot[SCREENWIDTH], cliptop[SCREENWIDTH];
+    int clipbot[SCREENWIDTH], cliptop[SCREENWIDTH]; // [crispy] 32-bit integer math
     int x, r1, r2;
     fixed_t scale, lowscale;
     int silhouette;


### PR DESCRIPTION
Values are verified with current Crispy Doom.

Game/timedemos working fine. Coding style preserved (well, for 99%).
This will not change anything visually, but makes a green light for further limit removing changes.