### PR TITLE
Stop palette changes from happening when in help screen or crispness menu

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -62,6 +62,7 @@
 
 #include "v_trans.h" // [crispy] colored cheat messages
 
+extern boolean inhelpscreens; // [crispy] prevent palette changes
 extern int screenblocks; // [crispy] for the Crispy HUD
 
 //
@@ -1490,7 +1491,10 @@ void ST_doPaletteStuff(void)
     {
         palette = RADIATIONPAL;
     }
-
+    if (inhelpscreens)
+    {
+        palette = 0;
+    }
     if (palette != st_palette)
     {
 	st_palette = palette;


### PR DESCRIPTION
During a demo playback, this prevents the screen from flashing (like when the player picks up an item or gets hurt) when the help screen or crispness menu is open.

Edit: This applies to viewing the help screen or crispness menu when the game is paused too.