### PR TITLE
Make Hell Knights and Barons of Hell always face their targets when attacking

### DIFF
--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -996,7 +996,7 @@ void A_BruisAttack (mobj_t* actor)
 	return;
 		
     // [crispy] face the enemy
-//  A_FaceTarget (actor);
+    A_FaceTarget (actor);
     if (P_CheckMeleeRange (actor))
     {
 	S_StartSound (actor, sfx_claw);


### PR DESCRIPTION
Not sure why `A_FaceTarget (actor)` was commented out in the code because it doesn't seem to affect gameplay.