### PR TITLE
Fix resurrections of mirrored corpses staying mirrored

### DIFF
--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -1231,6 +1231,9 @@ void A_VileChase (mobj_t* actor)
 		    corpsehit->health = info->spawnhealth;
 		    corpsehit->target = NULL;
 
+		    // [crispy] unflip sprite
+		    corpsehit->flipsprite = 0;
+
 		    // [crispy] count resurrected monsters
 		    extrakills++;
 


### PR DESCRIPTION
When an Arch-Vile resurrects a mirrored corpse, the enemy stays mirrored, resulting in some funky-looking moonwalking.

This fix works and is simple, but the ideal fix would be to unflip the sprite after the resurrection animation completes.