### PR TITLE
Remove missing things check since the player start checks were added to Chocolate Doom

### DIFF
--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -502,12 +502,6 @@ void P_LoadThings (int lump)
     data = W_CacheLumpNum (lump,PU_STATIC);
     numthings = W_LumpLength (lump) / sizeof(mapthing_t);
 	
-    // [crispy] warn about missing thing
-    if (!data || !numthings)
-    {
-	I_Error("P_LoadThings: No things in map!");
-    }
-
     mt = (mapthing_t *)data;
     for (i=0 ; i<numthings ; i++, mt++)
     {


### PR DESCRIPTION
As of 3e21ed7.