### PR TITLE
Prevent idclev to nonexistent levels exiting the game

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -610,6 +610,7 @@ boolean
 ST_Responder (event_t* ev)
 {
   int		i;
+  char lumpname[9];
     
   // Filter automap on/off.
   if (ev->type == ev_keyup
@@ -1138,6 +1139,32 @@ ST_Responder (event_t* ev)
               return false;
           }
       }
+
+    // find map name
+    if ( gamemode == commercial)
+    {
+	if (map<10)
+	    DEH_snprintf(lumpname, 9, "map0%i", map);
+	else
+	    DEH_snprintf(lumpname, 9, "map%i", map);
+    }
+    else
+    {
+	lumpname[0] = 'E';
+	lumpname[1] = '0' + epsd;
+	lumpname[2] = 'M';
+	lumpname[3] = '0' + map;
+	lumpname[4] = 0;
+    }
+
+    // [crispy] special-casing for E1M10 "Sewers" support
+    if (crispy->havee1m10 && epsd == 1 && map == 10)
+	DEH_snprintf(lumpname, 9, "E1M10");
+
+    if (W_CheckNumForName(lumpname) < 0) {
+	    fprintf(stderr, "W_GetNumForName: %s not found!\n", lumpname);
+	    return false;
+    }
 
       // So be it.
       plyr->message = DEH_String(STSTR_CLEV);


### PR DESCRIPTION
The code was taken from p_setup.c. This could be refactored to a reusable function.