### PR TITLE
calculate the things' actual height from the spawnstate's first sprite

### DIFF
--- a/src/doom/info.h
+++ b/src/doom/info.h
@@ -1446,6 +1446,8 @@ typedef struct
     int	activesound;
     int	flags;
     int	raisestate;
+    // [crispy] height of the spawnstate's first sprite in pixels
+    int	actualheight;
 
 } mobjinfo_t;
 

--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -1016,6 +1016,7 @@ boolean PTR_ShootTraverse (intercept_t* in)
     fixed_t		dist;
     fixed_t		thingtopslope;
     fixed_t		thingbottomslope;
+    fixed_t		thingheight; // [crispy] mobj or actual sprite height
 		
     if (in->isaline)
     {
@@ -1143,7 +1144,9 @@ boolean PTR_ShootTraverse (intercept_t* in)
 		
     // check angles to see if the thing can be aimed at
     dist = FixedMul (attackrange, in->frac);
-    thingtopslope = FixedDiv (th->z+th->height - shootz , dist);
+    // [crispy] mobj or actual sprite height
+    thingheight = (critical->freeaim == FREEAIM_DIRECT) ? th->actualheight : th->height;
+    thingtopslope = FixedDiv (th->z+thingheight - shootz , dist);
 
     if (thingtopslope < aimslope)
 	return true;		// shot over the thing

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -637,6 +637,7 @@ P_SpawnMobjSafe
     mobj->height = info->height;
     mobj->flags = info->flags;
     mobj->health = info->spawnhealth;
+    mobj->actualheight = info->actualheight;
 
     if (gameskill != sk_nightmare)
 	mobj->reactiontime = info->reactiontime;

--- a/src/doom/p_mobj.h
+++ b/src/doom/p_mobj.h
@@ -293,6 +293,8 @@ typedef struct mobj_s
     fixed_t		oldz;
     angle_t		oldangle;
 
+    // [crispy] height of the spawnstate's first sprite in pixels
+    fixed_t		actualheight;
 } mobj_t;
 
 

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -1348,6 +1348,36 @@ P_SetupLevel
     }
 }
 
+// [crispy] height of the spawnstate's first sprite in pixels
+static void P_InitActualHeights (void)
+{
+	int i;
+
+	for (i = 0; i < NUMMOBJTYPES; i++)
+	{
+		state_t *state;
+		spritedef_t *sprdef;
+		spriteframe_t *sprframe;
+		int lump;
+		patch_t *patch;
+
+		state = &states[mobjinfo[i].spawnstate];
+		sprdef = &sprites[state->sprite];
+
+		if (!sprdef->numframes)
+		{
+			mobjinfo[i].actualheight = mobjinfo[i].height;
+			continue;
+		}
+
+		sprframe = &sprdef->spriteframes[state->frame & FF_FRAMEMASK];
+		lump = sprframe->lump[0];
+		patch = W_CacheLumpNum (lump + firstspritelump, PU_CACHE);
+
+		// [crispy] round to the next integer multiple of 8
+		mobjinfo[i].actualheight = ((patch->height + 7) & (~7)) << FRACBITS;
+	}
+}
 
 
 //
@@ -1358,6 +1388,7 @@ void P_Init (void)
     P_InitSwitchList ();
     P_InitPicAnims ();
     R_InitSprites (sprnames);
+    P_InitActualHeights();
 }
 
 


### PR DESCRIPTION
@Zodomaniac: This will help mitigate the issue you once reported when
both mouselook and direct aiming are enabled and you miss some obvious
targets, like e.g. Romero's head on a stick.

I am not merging this, yet, because I am still unsure in two questions:

- Should it be (critical->freeaim == FREEAIM_DIRECT) or
  (critical->freeaim == FREEAIM_BOTH), i.e. do we have to consider
  only the direct aiming case or also the mixed case with autoaiming?
- Should it get applies only to PTR_ShootTraverse() or also to
  PTR_AimTraverse(), i.e. do we have to consider only shooting (and
  laser aiming, that is) or also aiming. This is probably connected to
  the former question, though.