### PR TITLE
Add continue-recording functionality.

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -549,9 +549,6 @@ void D_DoomLoop (void)
                " may cause demos and network games to get out of sync.\n");
     }
 
-    if (demorecording)
-	G_BeginRecording ();
-
     main_loop_started = true;
 
     I_SetWindowTitle(gamedescription);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -139,8 +139,10 @@ boolean         longtics;               // cph's doom 1.91 longtics hack
 boolean         lowres_turn;            // low resolution turning for longtics
 boolean         demoplayback; 
 boolean		netdemo; 
-byte*		demobuffer;
-byte*		demo_p;
+byte*		demo_in_buffer;
+byte*		demo_out_buffer;
+byte*		demo_in_p;
+byte*		demo_out_p = NULL;
 byte*		demoend; 
 boolean         singledemo;            	// quit after playing a demo from cmdline 
  
@@ -2380,28 +2382,28 @@ int defdemotics = 0, deftotaldemotics;
 
 void G_ReadDemoTiccmd (ticcmd_t* cmd) 
 { 
-    if (*demo_p == DEMOMARKER) 
+    if (*demo_in_p == DEMOMARKER)
     {
-	// end of demo data stream 
-	G_CheckDemoStatus (); 
-	return; 
-    } 
-    cmd->forwardmove = ((signed char)*demo_p++); 
-    cmd->sidemove = ((signed char)*demo_p++); 
+	// end of demo data stream
+	G_CheckDemoStatus ();
+	return;
+    }
+    cmd->forwardmove = ((signed char)*demo_in_p++);
+    cmd->sidemove = ((signed char)*demo_in_p++);
 
     // If this is a longtics demo, read back in higher resolution
 
     if (longtics)
     {
-        cmd->angleturn = *demo_p++;
-        cmd->angleturn |= (*demo_p++) << 8;
+        cmd->angleturn = *demo_in_p++;
+        cmd->angleturn |= (*demo_in_p++) << 8;
     }
     else
     {
-        cmd->angleturn = ((unsigned char) *demo_p++)<<8; 
+        cmd->angleturn = ((unsigned char) *demo_in_p++)<<8;
     }
 
-    cmd->buttons = (unsigned char)*demo_p++; 
+    cmd->buttons = (unsigned char)*demo_in_p++;
 
     if (crispy->fliplevels)
     {
@@ -2426,30 +2428,33 @@ static void IncreaseDemoBuffer(void)
 
     // Find the current size
 
-    current_length = demoend - demobuffer;
+    current_length = demoend - demo_out_buffer;
     
     // Generate a new buffer twice the size
     new_length = current_length * 2;
     
     new_demobuffer = Z_Malloc(new_length, PU_STATIC, 0);
-    new_demop = new_demobuffer + (demo_p - demobuffer);
+    new_demop = new_demobuffer + (demo_out_p - demo_out_buffer);
 
     // Copy over the old data
 
-    memcpy(new_demobuffer, demobuffer, current_length);
+    memcpy(new_demobuffer, demo_out_buffer, current_length);
 
     // Free the old buffer and point the demo pointers at the new buffer.
 
-    Z_Free(demobuffer);
+    Z_Free(demo_out_buffer);
 
-    demobuffer = new_demobuffer;
-    demo_p = new_demop;
-    demoend = demobuffer + new_length;
+    demo_out_buffer = new_demobuffer;
+    demo_out_p = new_demop;
+    demoend = demo_out_buffer + new_length;
 }
 
 void G_WriteDemoTiccmd (ticcmd_t* cmd) 
-{ 
-    byte *demo_start;
+{
+    if (demo_out_p == NULL)
+    {
+        G_BeginRecording();
+    }
 
     if (crispy->fliplevels)
     {
@@ -2457,32 +2462,27 @@ void G_WriteDemoTiccmd (ticcmd_t* cmd)
 	cmd->angleturn *= (const short) -1;
     }
 
-    if (gamekeydown[key_demo_quit])           // press q to end demo recording 
-	G_CheckDemoStatus (); 
+    if (gamekeydown[key_demo_quit])           // press q to end demo recording
+	G_CheckDemoStatus ();
 
-    demo_start = demo_p;
-
-    *demo_p++ = cmd->forwardmove; 
-    *demo_p++ = cmd->sidemove; 
+    *demo_out_p++ = cmd->forwardmove;
+    *demo_out_p++ = cmd->sidemove;
 
     // If this is a longtics demo, record in higher resolution
  
     if (longtics)
     {
-        *demo_p++ = (cmd->angleturn & 0xff);
-        *demo_p++ = (cmd->angleturn >> 8) & 0xff;
+        *demo_out_p++ = (cmd->angleturn & 0xff);
+        *demo_out_p++ = (cmd->angleturn >> 8) & 0xff;
     }
     else
     {
-        *demo_p++ = cmd->angleturn >> 8; 
+        *demo_out_p++ = cmd->angleturn >> 8;
     }
 
-    *demo_p++ = cmd->buttons; 
+    *demo_out_p++ = cmd->buttons;
 
-    // reset demo pointer back
-    demo_p = demo_start;
-
-    if (demo_p > demoend - 16)
+    if (demo_out_p > demoend - 16)
     {
         // [crispy] unconditionally disable savegame and demo limits
         /*
@@ -2501,8 +2501,6 @@ void G_WriteDemoTiccmd (ticcmd_t* cmd)
             IncreaseDemoBuffer();
         }
     } 
-	
-    G_ReadDemoTiccmd (cmd);         // make SURE it is exactly the same 
 } 
  
  
@@ -2542,8 +2540,8 @@ void G_RecordDemo (char *name)
     i = M_CheckParmWithArgs("-maxdemo", 1);
     if (i)
 	maxsize = atoi(myargv[i+1])*1024;
-    demobuffer = Z_Malloc (maxsize,PU_STATIC,NULL); 
-    demoend = demobuffer + maxsize;
+    demo_out_buffer = Z_Malloc (maxsize,PU_STATIC,NULL);
+    demoend = demo_out_buffer + maxsize;
 	
     demorecording = true; 
 } 
@@ -2571,7 +2569,7 @@ void G_BeginRecording (void)
 { 
     int             i; 
 
-    demo_p = demobuffer;
+    demo_out_p = demo_out_buffer;
 
     //!
     // @category demo
@@ -2587,24 +2585,30 @@ void G_BeginRecording (void)
 
     if (longtics)
     {
-        *demo_p++ = DOOM_191_VERSION;
+        *demo_out_p++ = DOOM_191_VERSION;
     }
     else
     {
-        *demo_p++ = G_VanillaVersionCode();
+        *demo_out_p++ = G_VanillaVersionCode();
     }
 
-    *demo_p++ = gameskill; 
-    *demo_p++ = gameepisode; 
-    *demo_p++ = gamemap; 
-    *demo_p++ = deathmatch; 
-    *demo_p++ = respawnparm;
-    *demo_p++ = fastparm;
-    *demo_p++ = nomonsters;
-    *demo_p++ = consoleplayer;
-	 
+    *demo_out_p++ = gameskill;
+    *demo_out_p++ = gameepisode;
+    *demo_out_p++ = gamemap;
+    *demo_out_p++ = deathmatch;
+    *demo_out_p++ = respawnparm;
+    *demo_out_p++ = fastparm;
+    *demo_out_p++ = nomonsters;
+    *demo_out_p++ = consoleplayer;
+
     for (i=0 ; i<MAXPLAYERS ; i++) 
-	*demo_p++ = playeringame[i]; 		 
+	*demo_out_p++ = playeringame[i];
+
+    if (demoplayback)
+    {
+        singletics = true;
+        nodrawers = true;
+    }
 } 
  
 
@@ -2677,8 +2681,8 @@ void G_DoPlayDemo (void)
 
     lumpnum = W_GetNumForName(defdemoname);
     gameaction = ga_nothing;
-    demobuffer = W_CacheLumpNum(lumpnum, PU_STATIC);
-    demo_p = demobuffer;
+    demo_in_buffer = W_CacheLumpNum(lumpnum, PU_STATIC);
+    demo_in_p = demo_in_buffer;
 
     // [crispy] ignore empty demo lumps
     lumplength = W_LumpLength(lumpnum);
@@ -2689,7 +2693,7 @@ void G_DoPlayDemo (void)
 	return;
     }
 
-    demoversion = *demo_p++;
+    demoversion = *demo_in_p++;
 
     longtics = false;
 
@@ -2726,17 +2730,17 @@ void G_DoPlayDemo (void)
         }
     }
 
-    skill = *demo_p++; 
-    episode = *demo_p++; 
-    map = *demo_p++; 
-    deathmatch = *demo_p++;
-    respawnparm = *demo_p++;
-    fastparm = *demo_p++;
-    nomonsters = *demo_p++;
-    consoleplayer = *demo_p++;
+    skill = *demo_in_p++;
+    episode = *demo_in_p++;
+    map = *demo_in_p++;
+    deathmatch = *demo_in_p++;
+    respawnparm = *demo_in_p++;
+    fastparm = *demo_in_p++;
+    nomonsters = *demo_in_p++;
+    consoleplayer = *demo_in_p++;
 	
     for (i=0 ; i<MAXPLAYERS ; i++) 
-	playeringame[i] = *demo_p++; 
+	playeringame[i] = *demo_in_p++;
 
     if (playeringame[1] || M_CheckParm("-solo-net") > 0
                         || M_CheckParm("-netdemo") > 0)
@@ -2769,7 +2773,7 @@ void G_DoPlayDemo (void)
     // [crispy] demo progress bar
     {
 	int i, numplayersingame = 0;
-	byte *demo_ptr = demo_p;
+	byte *demo_ptr = demo_in_p;
 
 	for (i = 0; i < MAXPLAYERS; i++)
 	{
@@ -2781,7 +2785,8 @@ void G_DoPlayDemo (void)
 
 	deftotaldemotics = defdemotics = 0;
 
-	while (*demo_ptr != DEMOMARKER && (demo_ptr - demobuffer) < lumplength)
+	while (*demo_ptr != DEMOMARKER
+            && (demo_ptr - demo_in_buffer) < lumplength)
 	{
 	    demo_ptr += numplayersingame * (longtics ? 5 : 4);
 	    deftotaldemotics++;
@@ -2854,7 +2859,16 @@ boolean G_CheckDemoStatus (void)
 	fastparm = false;
 	nomonsters = false;
 	consoleplayer = 0;
-        
+
+        // If we're playing and recording (continuing) then end the sped-up
+        // playback flags we previously set, and begin normal play.
+        if (demorecording)
+        {
+            singletics = false;
+            nodrawers = false;
+            return true;
+        }
+
         if (singledemo) 
             I_Quit (); 
         else 
@@ -2865,9 +2879,9 @@ boolean G_CheckDemoStatus (void)
  
     if (demorecording) 
     { 
-	*demo_p++ = DEMOMARKER; 
-	M_WriteFile (demoname, demobuffer, demo_p - demobuffer); 
-	Z_Free (demobuffer); 
+	*demo_out_p++ = DEMOMARKER;
+	M_WriteFile (demoname, demo_out_buffer, demo_out_p - demo_out_buffer);
+	Z_Free (demo_out_buffer);
 	demorecording = false; 
 	I_Error ("Demo %s recorded",demoname); 
     } 


### PR DESCRIPTION
This allows -playdemo and -record to be used simultaneously, with the
input/playback and output/recording buffers stored separately. The user
can then continue a previously-recorded demo by using both simultaneously.