### PR TITLE
Allow joybjump to be assigned for Doom

### DIFF
--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1066,7 +1066,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
         AddJoystickControl(window, "Speed", &joybspeed);
     }
 
-    if (gamemission == hexen || gamemission == strife)
+    if (gamemission == doom || gamemission == hexen || gamemission == strife) // [crispy]
     {
         AddJoystickControl(window, "Jump", &joybjump);
     }


### PR DESCRIPTION
Since jumping can be enabled in Doom the joystick jump button should be assignable in the setup program.