### PR TITLE
in automap overlay mode, draw automap on top of everything

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -268,13 +268,6 @@ boolean D_Display (void)
 	R_FillBackScreen ();    // draw the pattern into the back screen
     }
 
-    // [crispy] in automap overlay mode,
-    // draw the automap beneath the bezel
-    if (automapactive && crispy->automapoverlay)
-    {
-	AM_Drawer ();
-    }
-
     // see if the border needs to be updated to the screen
     if (gamestate == GS_LEVEL && (!automapactive || crispy->automapoverlay) && scaledviewwidth != SCREENWIDTH)
     {
@@ -301,9 +294,10 @@ boolean D_Display (void)
     oldgamestate = wipegamestate = gamestate;
     
     // [crispy] in automap overlay mode,
-    // draw the HUD on top of everything else
+    // draw the automap and HUD on top of everything else
     if (automapactive && crispy->automapoverlay)
     {
+	AM_Drawer ();
 	HU_Drawer ();
 
 	// [crispy] force redraw of status bar and border


### PR DESCRIPTION
This reverts the following commit, which drew the automap beneath the
bezel for decreased screen sizes. I am not sure anymore why I would
have ever wanted it this way:

https://github.com/fabiangreffrath/crispy-doom/commit/8acfb0321592a32d031bf26b49f6403dc58696ca

Fixes #446.

Also, moving the call to `AM_Drawer()` past `R_DrawViewBorder()` fixes #340.