### PR TITLE
override savegame name if it already starts with a map identifier

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -990,6 +990,28 @@ static void SetDefaultSaveName(int slot)
     joypadSave = false;
 }
 
+// [crispy] override savegame name if it already starts with a map identifier
+static boolean StartsWithMapIdentifier (char *str)
+{
+    M_ForceUppercase(str);
+
+    if (strlen(str) >= 4 &&
+        str[0] == 'E' && isdigit(str[1]) &&
+        str[2] == 'M' && isdigit(str[3]))
+    {
+        return true;
+    }
+
+    if (strlen(str) >= 5 &&
+        str[0] == 'M' && str[1] == 'A' && str[2] == 'P' &&
+        isdigit(str[3]) && isdigit(str[4]))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 //
 // User wants to save. Start string input for M_Responder
 //
@@ -1010,7 +1032,9 @@ void M_SaveSelect(int choice)
 
     saveSlot = choice;
     M_StringCopy(saveOldString,savegamestrings[choice], SAVESTRINGSIZE);
-    if (!strcmp(savegamestrings[choice], EMPTYSTRING))
+    if (!strcmp(savegamestrings[choice], EMPTYSTRING) ||
+        // [crispy] override savegame name if it already starts with a map identifier
+        StartsWithMapIdentifier(savegamestrings[choice]))
     {
         savegamestrings[choice][0] = 0;
 


### PR DESCRIPTION
Fixes #467, thanks @zebzorb