### PR TITLE
remove shadowed menu and text drawing

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -318,7 +318,7 @@ boolean D_Display (void)
 	    y = 4;
 	else
 	    y = (viewwindowy >> crispy->hires)+4;
-	V_DrawPatchShadow2((viewwindowx >> crispy->hires) + ((scaledviewwidth >> crispy->hires) - 68) / 2, y,
+	V_DrawPatchDirect((viewwindowx >> crispy->hires) + ((scaledviewwidth >> crispy->hires) - 68) / 2, y,
                           W_CacheLumpName (DEH_String("M_PAUSE"), PU_CACHE));
     }
 

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -363,7 +363,7 @@ void F_TextWrite (void)
 	{
 	    break;
 	}
-	V_DrawPatchShadow1(cx, cy, hu_font[c]);
+	V_DrawPatch(cx, cy, hu_font[c]);
 	cx+=w;
     }
 	
@@ -834,7 +834,7 @@ void F_CastPrint (const char *text)
 	}
 		
 	w = SHORT (hu_font[c]->width);
-	V_DrawPatchShadow1(cx, 180, hu_font[c]);
+	V_DrawPatch(cx, 180, hu_font[c]);
 	cx+=w;
     }
 	

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -848,7 +848,7 @@ void M_DrawLoad(void)
 {
     int             i;
 	
-    V_DrawPatchShadow2(LoadDef_x, LoadDef_y,
+    V_DrawPatchDirect(LoadDef_x, LoadDef_y,
                       W_CacheLumpName(DEH_String("M_LOADG"), PU_CACHE));
 
     for (i = 0;i < load_end; i++)
@@ -934,7 +934,7 @@ void M_DrawSave(void)
 {
     int             i;
 	
-    V_DrawPatchShadow2(SaveDef_x, SaveDef_y, W_CacheLumpName(DEH_String("M_SAVEG"), PU_CACHE));
+    V_DrawPatchDirect(SaveDef_x, SaveDef_y, W_CacheLumpName(DEH_String("M_SAVEG"), PU_CACHE));
     for (i = 0;i < load_end; i++)
     {
 	M_DrawSaveLoadBorder(LoadDef.x,LoadDef.y+LINEHEIGHT*i);
@@ -1202,7 +1202,7 @@ void M_DrawReadThisCommercial(void)
 //
 void M_DrawSound(void)
 {
-    V_DrawPatchShadow2 (60, 38, W_CacheLumpName(DEH_String("M_SVOL"), PU_CACHE));
+    V_DrawPatchDirect (60, 38, W_CacheLumpName(DEH_String("M_SVOL"), PU_CACHE));
 
     M_DrawThermo(SoundDef.x,SoundDef.y+LINEHEIGHT*(sfx_vol+1),
 		 16,sfxVolume);
@@ -1270,8 +1270,8 @@ void M_DrawMainMenu(void)
 //
 void M_DrawNewGame(void)
 {
-    V_DrawPatchShadow2(96, 14, W_CacheLumpName(DEH_String("M_NEWG"), PU_CACHE));
-    V_DrawPatchShadow2(54, 38, W_CacheLumpName(DEH_String("M_SKILL"), PU_CACHE));
+    V_DrawPatchDirect(96, 14, W_CacheLumpName(DEH_String("M_NEWG"), PU_CACHE));
+    V_DrawPatchDirect(54, 38, W_CacheLumpName(DEH_String("M_SKILL"), PU_CACHE));
 }
 
 void M_NewGame(int choice)
@@ -1307,7 +1307,7 @@ int     epi;
 
 void M_DrawEpisode(void)
 {
-    V_DrawPatchShadow2(54, 38, W_CacheLumpName(DEH_String("M_EPISOD"), PU_CACHE));
+    V_DrawPatchDirect(54, 38, W_CacheLumpName(DEH_String("M_EPISOD"), PU_CACHE));
 }
 
 void M_VerifyNightmare(int key)
@@ -1363,7 +1363,7 @@ static const char *msgNames[2] = {"M_MSGOFF","M_MSGON"};
 
 void M_DrawOptions(void)
 {
-    V_DrawPatchShadow2(108, 15, W_CacheLumpName(DEH_String("M_OPTTTL"),
+    V_DrawPatchDirect(108, 15, W_CacheLumpName(DEH_String("M_OPTTTL"),
                                                PU_CACHE));
 	
 // [crispy] no patches are drawn in the Options menu anymore
@@ -1396,7 +1396,7 @@ static void M_DrawMouse(void)
 {
     char mouse_menu_text[48];
 
-    V_DrawPatchShadow2 (60, LoadDef_y, W_CacheLumpName(DEH_String("M_MSENS"), PU_CACHE));
+    V_DrawPatchDirect (60, LoadDef_y, W_CacheLumpName(DEH_String("M_MSENS"), PU_CACHE));
 
     M_WriteText(MouseDef.x, MouseDef.y + LINEHEIGHT * mouse_horiz + 6,
                 "HORIZONTAL: TURN");
@@ -2080,14 +2080,7 @@ M_WriteText
 	w = SHORT (hu_font[c]->width);
 	if (cx+w > ORIGWIDTH)
 	    break;
-	if (!messageToPrint && (currentMenu == &LoadDef || currentMenu == &SaveDef))
-	{
 	V_DrawPatchDirect(cx, cy, hu_font[c]);
-	}
-	else
-	{
-	    V_DrawPatchShadow1(cx, cy, hu_font[c]);
-	}
 	cx+=w;
     }
 }
@@ -2997,7 +2990,7 @@ void M_Drawer (void)
 		    M_WriteText(x, y+8-(M_StringHeight(alttext)/2), alttext);
 	    }
 	    else if (W_CheckNumForName(name) > 0) // [crispy] ...here
-	    V_DrawPatchShadow2 (x, y, W_CacheLumpName(name, PU_CACHE));
+	    V_DrawPatchDirect (x, y, W_CacheLumpName(name, PU_CACHE));
 
 	    dp_translation = NULL;
 	}

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1236,14 +1236,6 @@ void R_InitColormaps (void)
 
 	W_ReleaseLumpName("PLAYPAL");
     }
-
-#ifndef CRISPY_TRUECOLOR
-    // [crispy] initialize tinttable for V_DrawPatchShadow2
-    {
-	extern byte *tinttable;
-	tinttable = cr[CR_DARK];
-    }
-#endif
 }
 
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -199,7 +199,7 @@ static drawpatchpx_t *const drawpatchpx_a[2][2] = {{drawpatchpx11, drawpatchpx10
 
 static fixed_t dx, dxi, dy, dyi;
 
-static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
+void V_DrawPatch(int x, int y, patch_t *patch)
 { 
     int count;
     int col;
@@ -207,7 +207,6 @@ static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
     pixel_t *desttop;
     pixel_t *dest;
     byte *source;
-    pixel_t *desttop2, *dest2;
     int w;
 
     // [crispy] four different rendering functions
@@ -237,11 +236,10 @@ static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
 
     col = 0;
     desttop = dest_screen + ((y * dy) >> FRACBITS) * SCREENWIDTH + ((x * dx) >> FRACBITS);
-    desttop2 = dest_screen + (((y + r) * dy) >> FRACBITS) * SCREENWIDTH + (((x + r) * dx) >> FRACBITS);
 
     w = SHORT(patch->width);
 
-    for ( ; col<w << FRACBITS ; x++, col+=dxi, desttop++, desttop2++)
+    for ( ; col<w << FRACBITS ; x++, col+=dxi, desttop++)
     {
         int topdelta = -1;
 
@@ -275,7 +273,6 @@ static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
             top = ((y + topdelta) * dy) >> FRACBITS;
             source = (byte *)column + 3;
             dest = desttop + ((topdelta * dy) >> FRACBITS)*SCREENWIDTH;
-            dest2 = desttop2 + ((topdelta * dy) >> FRACBITS)*SCREENWIDTH;
             count = (column->length * dy) >> FRACBITS;
 
             // [crispy] too low / height
@@ -292,16 +289,6 @@ static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
 
             while (count--)
             {
-                if (r)
-                {
-#ifndef CRISPY_TRUECOLOR
-                    *dest2 = tinttable[*dest2];
-#else
-                    *dest2 = I_BlendDark(*dest2, 0x80);
-#endif
-                    dest2 += SCREENWIDTH;
-                }
-
                 // [crispy] too high
                 if (top++ >= 0)
                 {
@@ -313,21 +300,6 @@ static void V_DrawPatchCrispy(int x, int y, patch_t *patch, int r)
             column = (column_t *)((byte *)column + column->length + 4);
         }
     }
-}
-
-void V_DrawPatch(int x, int y, patch_t *patch)
-{
-    return V_DrawPatchCrispy(x, y, patch, 0);
-}
-
-void V_DrawPatchShadow1(int x, int y, patch_t *patch)
-{
-    return V_DrawPatchCrispy(x, y, patch, 1);
-}
-
-void V_DrawPatchShadow2(int x, int y, patch_t *patch)
-{
-    return V_DrawPatchCrispy(x, y, patch, 2);
 }
 
 void V_DrawPatchFullScreen(patch_t *patch, boolean flipped)

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -63,8 +63,6 @@ void V_DrawAltTLPatch(int x, int y, patch_t * patch);
 void V_DrawShadowedPatch(int x, int y, patch_t *patch);
 void V_DrawXlaPatch(int x, int y, patch_t * patch);     // villsa [STRIFE]
 void V_DrawPatchDirect(int x, int y, patch_t *patch);
-void V_DrawPatchShadow1(int x, int y, patch_t *patch);
-void V_DrawPatchShadow2(int x, int y, patch_t *patch);
 void V_DrawPatchFullScreen(patch_t *patch, boolean flipped);
 
 // Draw a linear block of pixels into the view buffer.


### PR DESCRIPTION
This makes Crispy resemble Vanilla more closely again, even without
minor cosmetic alterations that are nevertheless visible at first
sight. And since there won't be a menu switch for this...