### PR TITLE
Fix 16 bit audio files shifted by 8 bytes.

### DIFF
--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -788,7 +788,7 @@ static boolean CacheSFX(sfxinfo_t *sfxinfo)
         if (bits != 16 && bits != 8)
             return false;
 
-        data += 44;
+        data += 44 - 8;
     }
     // Check the header, and ensure this is a valid sound
     else if (lumplen >= 8 && data[0] == 0x03 && data[1] == 00)


### PR DESCRIPTION
Looks like there was a little bug in parsing 16-bit audio data, since I didn't notice the call to `ExpandSoundData()` in `CacheSFX()` shifts the address of `data` by 8 bytes before using it.

This fixes that.