### PR TITLE
Heretic: bind `crispy_smoothscaling`

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -748,6 +748,7 @@ void D_BindVariables(void)
     }
 
     // [crispy] bind "crispness" config variables
+    M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
     M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
     M_BindIntVariable("crispy_leveltime",       &crispy->leveltime);
     M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);


### PR DESCRIPTION
Bind `crispy_smoothscaling` which can be set in Crispness menu.