### PR TITLE
Condition extending the game scene

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1550,7 +1550,8 @@ void I_GetScreenDimensions (void)
 
 	if (crispy->widescreen)
 	{
-		SCREENWIDTH = w * ah / h;
+		if (aspect_ratio_correct) // don't extend the game scene in case of aspect_ratio_correct == 0, just stretch the framebuffer
+			SCREENWIDTH = w * ah / h;
 		// [crispy] make sure SCREENWIDTH is an integer multiple of 4 ...
 		SCREENWIDTH = (SCREENWIDTH + 3) & (int)~3;
 		// [crispy] ... but never exceeds MAXWIDTH (array size!)


### PR DESCRIPTION
for widescreen if `aspect_ratio_correction == 0` to make it behave different from `aspect_ratio_correction == 2`, as they behave different with widescreen disabled.