### PR TITLE
No aspect ratio correction-no widescreen rendering

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1501,7 +1501,7 @@ static void M_DrawCrispness1(void)
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
-    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, true);
+    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correction); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, true);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1501,7 +1501,7 @@ static void M_DrawCrispness1(void)
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
-    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correction >= 1); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
+    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correct); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, true);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1501,7 +1501,7 @@ static void M_DrawCrispness1(void)
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
-    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correct); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
+    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correct);
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, true);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1501,7 +1501,7 @@ static void M_DrawCrispness1(void)
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
-    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correction); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
+    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correction >= 1); // widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, true);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1538,8 +1538,11 @@ void I_GetScreenDimensions (void)
 
 	ah = (aspect_ratio_correct == 1) ? (6 * SCREENHEIGHT / 5) : SCREENHEIGHT;
 	
-	if (!aspect_ratio_correct)
-		crispy->widescreen = 0; // [crispy] widescreen rendering makes no sense without aspect ratio correction
+// [crispy] widescreen rendering makes no sense without aspect ratio correction
+if (!aspect_ratio_correct)
+{
+	crispy->widescreen = 0;
+}
 	
 	if (SDL_GetCurrentDisplayMode(video_display, &mode) == 0)
 	{

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1537,7 +1537,10 @@ void I_GetScreenDimensions (void)
 	HIRESWIDTH = SCREENWIDTH;
 
 	ah = (aspect_ratio_correct == 1) ? (6 * SCREENHEIGHT / 5) : SCREENHEIGHT;
-
+	
+	if (!aspect_ratio_correct)
+		crispy->widescreen = 0; // [crispy] widescreen rendering makes no sense without aspect ratio correction
+	
 	if (SDL_GetCurrentDisplayMode(video_display, &mode) == 0)
 	{
 		// [crispy] sanity check: really widescreen display?

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1538,12 +1538,6 @@ void I_GetScreenDimensions (void)
 
 	ah = (aspect_ratio_correct == 1) ? (6 * SCREENHEIGHT / 5) : SCREENHEIGHT;
 	
-// [crispy] widescreen rendering makes no sense without aspect ratio correction
-if (!aspect_ratio_correct)
-{
-	crispy->widescreen = 0;
-}
-	
 	if (SDL_GetCurrentDisplayMode(video_display, &mode) == 0)
 	{
 		// [crispy] sanity check: really widescreen display?
@@ -1554,6 +1548,12 @@ if (!aspect_ratio_correct)
 		}
 	}
 
+	// [crispy] widescreen rendering makes no sense without aspect ratio correction
+	if (!aspect_ratio_correct)
+	{
+		crispy->widescreen = 0;
+	}
+	
 	if (crispy->widescreen)
 	{
 		SCREENWIDTH = w * ah / h;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1537,7 +1537,7 @@ void I_GetScreenDimensions (void)
 	HIRESWIDTH = SCREENWIDTH;
 
 	ah = (aspect_ratio_correct == 1) ? (6 * SCREENHEIGHT / 5) : SCREENHEIGHT;
-	
+
 	if (SDL_GetCurrentDisplayMode(video_display, &mode) == 0)
 	{
 		// [crispy] sanity check: really widescreen display?


### PR DESCRIPTION
as widescreen rendering only makes sense if certain pixel aspect ratio is enforced, i.e. aspect ratio correction is enabled.