### PR TITLE
Remember widescreen setting

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1528,7 +1528,7 @@ static void SetVideoMode(void)
 void I_GetScreenDimensions (void)
 {
 	SDL_DisplayMode mode;
-	int w = 16, h = 9;
+	int w = 16, h = 9; // minimum aspect ratio considered widescreen
 	int ah;
 
 	SCREENWIDTH = ORIGWIDTH << crispy->hires;
@@ -1549,7 +1549,6 @@ void I_GetScreenDimensions (void)
 	}
 
 	// [crispy] widescreen rendering makes no sense without aspect ratio correction
-	// [crispy] this way widescreen setting is remembered when disabled by 'none' aspect ratio correction setting
 
 	if (crispy->widescreen && aspect_ratio_correct)
 	{

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1528,7 +1528,7 @@ static void SetVideoMode(void)
 void I_GetScreenDimensions (void)
 {
 	SDL_DisplayMode mode;
-	int w = 16, h = 9; // minimum aspect ratio considered widescreen
+	int w = 16, h = 9;
 	int ah;
 
 	SCREENWIDTH = ORIGWIDTH << crispy->hires;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1549,12 +1549,9 @@ void I_GetScreenDimensions (void)
 	}
 
 	// [crispy] widescreen rendering makes no sense without aspect ratio correction
-	if (!aspect_ratio_correct)
-	{
-		crispy->widescreen = 0;
-	}
-	
-	if (crispy->widescreen)
+	// [crispy] this way widescreen setting is remembered when disabled by 'none' aspect ratio correction setting
+
+	if (crispy->widescreen && aspect_ratio_correct)
 	{
 		SCREENWIDTH = w * ah / h;
 		// [crispy] make sure SCREENWIDTH is an integer multiple of 4 ...


### PR DESCRIPTION
after it gets forcefully disabled with aspect ratio correction set to 'none'