### PR TITLE
Explicitly write "crispy-doom" to extended savegame header

### DIFF
--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -441,7 +441,7 @@ typedef struct
 
 static const extsavegdata_t extsavegdata[] =
 {
-	{PACKAGE_TARNAME, P_WritePackageTarname, NULL, 0},
+	{"crispy-doom", P_WritePackageTarname, NULL, 0},
 	{"wadfilename", P_WriteWadFileName, P_ReadWadFileName, 0},
 	{"extrakills", P_WriteExtraKills, P_ReadExtraKills, 1},
 	{"totalleveltimes", P_WriteTotalLevelTimes, P_ReadTotalLevelTimes, 1},


### PR DESCRIPTION
to preserve savegame header compatibility across forks that might have different names, e.g. "so-doom"