### PR TITLE
Improved understanding of widescreen rendering

### DIFF
--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -131,8 +131,8 @@ multiitem_t multiitem_sndchannels[4] =
 multiitem_t multiitem_widescreen[NUM_WIDESCREEN] =
 {
     {WIDESCREEN_OFF, "off"},
-    {WIDESCREEN_WIDE, "wide"},
-    {WIDESCREEN_COMPACT, "compact"},
+    {WIDESCREEN_WIDE, "on (wide HUD)"},
+    {WIDESCREEN_COMPACT, "on (compact HUD)"},
 };
 
 multiitem_t multiitem_widgets[NUM_WIDGETS] =


### PR DESCRIPTION
The whole menu string should be read as a whole sentence making sense.
"Widescreen rendering: Compact" reads kinda: WIDE and COMPACT - WTF, mutually excluding paragraphs?!

So I propose Widescreen setting be Off or On, with HUD specifics in brackets, there's enough space for that.