### PR TITLE
Default widescreen resolution 2 b the narrowest

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1528,7 +1528,7 @@ static void SetVideoMode(void)
 void I_GetScreenDimensions (void)
 {
 	SDL_DisplayMode mode;
-	int w = 16, h = 9;
+	int w = 16, h = 10;
 	int ah;
 
 	SCREENWIDTH = ORIGWIDTH << crispy->hires;


### PR DESCRIPTION
as otherwise the messed-up HUD is shown during wipe screen on 16:10 displays.