### PR TITLE
Removed brackets from widescreen menu items

### DIFF
--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -131,8 +131,8 @@ multiitem_t multiitem_sndchannels[4] =
 multiitem_t multiitem_widescreen[NUM_WIDESCREEN] =
 {
     {WIDESCREEN_OFF, "off"},
-    {WIDESCREEN_WIDE, "on (wide HUD)"},
-    {WIDESCREEN_COMPACT, "on (compact HUD)"},
+    {WIDESCREEN_WIDE, "on, wide HUD"},
+    {WIDESCREEN_COMPACT, "on, compact HUD"},
 };
 
 multiitem_t multiitem_widgets[NUM_WIDGETS] =


### PR DESCRIPTION
as the closing one doesn't fit in the menu, and the opening one resembles C in (Compact HUD)