### PR TITLE
Patch to fix #533 by @fabiangreffrath

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1548,6 +1548,13 @@ void I_GetScreenDimensions (void)
 		}
 	}
 
+	else
+	if (!crispy->post_rendering_hook)
+	{
+		extern void ST_createWidgets(void);
+		crispy->post_rendering_hook = ST_createWidgets;
+	}
+	
 	// [crispy] widescreen rendering makes no sense without aspect ratio correction
 
 	if (crispy->widescreen && aspect_ratio_correct)


### PR DESCRIPTION
Create widgets if `SDL_GetCurrentDisplayMode` fails, e.g. when launching a map from command line on Windows.
@fabiangreffrath , you could've been busy and have forgotten about it, so here it is)