### PR TITLE
Add inv navigation mouse buttons

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -772,6 +772,59 @@ static void SetJoyButtons(unsigned int buttons_mask)
     }
 }
 
+static boolean InventoryMoveLeft()
+{
+    inventoryTics = 5 * 35;
+    if (!inventory)
+    {
+        inventory = true;
+        return false;
+    }
+    inv_ptr--;
+    if (inv_ptr < 0)
+    {
+        inv_ptr = 0;
+    }
+    else
+    {
+        curpos--;
+        if (curpos < 0)
+        {
+            curpos = 0;
+        }
+    }
+    return true;
+}
+
+static boolean InventoryMoveRight()
+{
+    player_t *plr;
+
+    plr = &players[consoleplayer];
+    inventoryTics = 5 * 35;
+    if (!inventory)
+    {
+        inventory = true;
+        return false;
+    }
+    inv_ptr++;
+    if (inv_ptr >= plr->inventorySlotNum)
+    {
+        inv_ptr--;
+        if (inv_ptr < 0)
+            inv_ptr = 0;
+    }
+    else
+    {
+        curpos++;
+        if (curpos > 6)
+        {
+            curpos = 6;
+        }
+    }
+    return true;
+}
+
 static void SetMouseButtons(unsigned int buttons_mask)
 {
     int i;
@@ -791,6 +844,14 @@ static void SetMouseButtons(unsigned int buttons_mask)
             else if (i == mousebnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == mousebinvleft)
+            {
+                InventoryMoveLeft();
+            }
+            else if (i == mousebinvright)
+            {
+                InventoryMoveRight();
             }
         }
 
@@ -874,51 +935,19 @@ boolean G_Responder(event_t * ev)
         case ev_keydown:
             if (ev->data1 == key_invleft)
             {
-                inventoryTics = 5 * 35;
-                if (!inventory)
+                if (InventoryMoveLeft())
                 {
-                    inventory = true;
-                    break;
+                    return (true);
                 }
-                inv_ptr--;
-                if (inv_ptr < 0)
-                {
-                    inv_ptr = 0;
-                }
-                else
-                {
-                    curpos--;
-                    if (curpos < 0)
-                    {
-                        curpos = 0;
-                    }
-                }
-                return (true);
+                break;
             }
             if (ev->data1 == key_invright)
             {
-                inventoryTics = 5 * 35;
-                if (!inventory)
+                if (InventoryMoveRight())
                 {
-                    inventory = true;
-                    break;
+                    return (true);
                 }
-                inv_ptr++;
-                if (inv_ptr >= plr->inventorySlotNum)
-                {
-                    inv_ptr--;
-                    if (inv_ptr < 0)
-                        inv_ptr = 0;
-                }
-                else
-                {
-                    curpos++;
-                    if (curpos > 6)
-                    {
-                        curpos = 6;
-                    }
-                }
-                return (true);
+                break;
             }
             if (ev->data1 == key_pause && !MenuActive)
             {

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1125,6 +1125,22 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(mouseb_nextweapon),
 
     //!
+    // @game heretic
+    //
+    // Mouse button to move to the left in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(mouseb_invleft),
+
+    //!
+    // @game heretic
+    //
+    // Mouse button to move to the right in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(mouseb_invright),
+
+    //!
     // If non-zero, double-clicking a mouse button acts like pressing
     // the "use" key to use an object in-game, eg. a door or switch.
     //

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -125,7 +125,8 @@ int mousebreverse = -1; // [crispy]
 
 int mousebprevweapon = 4; // [crispy]
 int mousebnextweapon = 3; // [crispy]
-
+int mousebinvleft = -1; // [crispy]
+int mousebinvright = -1; // [crispy]
 
 int key_message_refresh = KEY_ENTER;
 int key_pause = KEY_PAUSE;
@@ -296,6 +297,9 @@ void M_BindHereticControls(void)
     M_BindIntVariable("key_invleft",        &key_invleft);
     M_BindIntVariable("key_invright",       &key_invright);
     M_BindIntVariable("key_useartifact",    &key_useartifact);
+
+    M_BindIntVariable("mouseb_invleft", &mousebinvleft); // [crispy]
+    M_BindIntVariable("mouseb_invright", &mousebinvright); // [crispy]
 
     M_BindIntVariable("key_arti_quartz",        &key_arti_quartz);
     M_BindIntVariable("key_arti_urn",           &key_arti_urn);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -160,6 +160,8 @@ extern int mousebreverse;
 
 extern int mousebprevweapon;
 extern int mousebnextweapon;
+extern int mousebinvleft;
+extern int mousebinvright;
 
 extern int joybfire;
 extern int joybstrafe;

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -52,6 +52,8 @@ static int *all_mouse_buttons[] = {
     &mousebjump,
     &mousebprevweapon,
     &mousebnextweapon,
+    &mousebinvleft, // [crispy]
+    &mousebinvright, // [crispy]
     &mousebmouselook, // [crispy]
     &mousebreverse // [crispy]
 };
@@ -109,6 +111,12 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddMouseControl(buttons_table, "Previous weapon", &mousebprevweapon);
     AddMouseControl(buttons_table, "Strafe on", &mousebstrafe);
     AddMouseControl(buttons_table, "Next weapon", &mousebnextweapon);
+
+    if (gamemission == heretic)
+    {
+      AddMouseControl(buttons_table, "Inventory left", &mousebinvleft);
+      AddMouseControl(buttons_table, "Inventory right", &mousebinvright);
+    }
 
     if (gamemission == hexen || gamemission == strife)
     {


### PR DESCRIPTION
Hello :wave: 

Since I've started messing with crispy heretic I thought I would open PRs when I make adjustments that might be nice for others as well.

This PR adds mouse buttons for moving the inventory cursor. I find using keys is quite cumbersome, especially when going for speed, whereas the mouse wheel is perfect for this task. Maybe someone else agrees :wink: 

I extracted the inventory left / right code into separate functions so we don't duplicate the code for key and mouse. I tried to follow the general pattern I saw for other mouse buttons, so hopefully the implementation makes sense.