### PR TITLE
Add novert toggle to heretic

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -350,6 +350,10 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         novert = !novert;
 
+        P_SetMessage(&players[consoleplayer], novert ?
+                     "VERTICAL MOUSE MOVEMENT OFF" :
+                     "VERTICAL MOUSE MOVEMENT ON", false);
+
         S_StartSound(NULL, sfx_switch);
 
         gamekeydown[key_togglenovert] = false;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -345,6 +345,16 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         lspeed = 2;
     }
 
+    // [crispy] Toggle vertical mouse movement
+    if (gamekeydown[key_togglenovert])
+    {
+        novert = !novert;
+
+        S_StartSound(NULL, sfx_switch);
+
+        gamekeydown[key_togglenovert] = false;
+    }
+
 //
 // let movement keys cancel each other out
 //

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1852,7 +1852,7 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_toggleautorun),
 
     //!
-    // @game doom
+    // @game doom heretic
     // Toggle vertical mouse movement.
     //
 

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -226,7 +226,6 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         AddKeyControl(table, "Strafe Left (alt.)", &key_alt_strafeleft);
         AddKeyControl(table, "Strafe Right (alt.)", &key_alt_straferight);
         AddKeyControl(table, "Toggle always run", &key_toggleautorun);
-        AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
         AddKeyControl(table, "Quick Reverse", &key_reverse);
         }
         else
@@ -236,6 +235,11 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         AddKeyControl(table, "Look up", &key_lookup);
         AddKeyControl(table, "Look down", &key_lookdown);
         AddKeyControl(table, "Center view", &key_lookcenter);
+        }
+
+        if (gamemission == doom || gamemission == heretic)
+        {
+        AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
         }
 
         if (gamemission == heretic || gamemission == hexen)


### PR DESCRIPTION
Adds the novert toggle key to heretic.

I tried to get the hud message working with heretic, but I wasn't sure how to make it actually show up on the screen, although I was setting the player message field similarly to how it works in the doom file. It wasn't worth the effort to me to dig into it more, so I settled for just the sound to indicate the switch.

If the hud message is a requirement then probably someone with more understanding of the logic there would need to set it up.