### PR TITLE
Always Run + Run = Walk (heretic)

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -268,14 +268,6 @@ static int G_NextWeapon(int direction)
     return weapon_order_table[i].weapon_num;
 }
 
-// [crispy] holding down the "Run" key may trigger special behavior,
-// e.g. quick exit, clean screenshots, resurrection from savegames
-boolean speedkeydown (void)
-{
-    return (key_speed < NUMKEYS && gamekeydown[key_speed]) ||
-           (joybspeed < MAX_JOY_BUTTONS && joybuttons[joybspeed]);
-}
-
 /*
 ====================
 =
@@ -318,9 +310,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     // [crispy] when "always run" is active,
     // pressing the "run" key will result in walking
-    speed = key_speed >= NUMKEYS
-         || joybspeed >= MAX_JOY_BUTTONS;
-    speed ^= speedkeydown();
+    speed = (joybspeed >= MAX_JOY_BUTTONS)
+        ^ (gamekeydown[key_speed] || joybuttons[joybspeed]);
 
     // haleyjd: removed externdriver crap
     

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -268,6 +268,14 @@ static int G_NextWeapon(int direction)
     return weapon_order_table[i].weapon_num;
 }
 
+// [crispy] holding down the "Run" key may trigger special behavior,
+// e.g. quick exit, clean screenshots, resurrection from savegames
+boolean speedkeydown (void)
+{
+    return (key_speed < NUMKEYS && gamekeydown[key_speed]) ||
+           (joybspeed < MAX_JOY_BUTTONS && joybuttons[joybspeed]);
+}
+
 /*
 ====================
 =
@@ -307,9 +315,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     strafe = gamekeydown[key_strafe] || mousebuttons[mousebstrafe]
         || joybuttons[joybstrafe];
-    speed = joybspeed >= MAX_JOY_BUTTONS
-         || gamekeydown[key_speed]
-         || joybuttons[joybspeed];
+
+    // [crispy] when "always run" is active,
+    // pressing the "run" key will result in walking
+    speed = key_speed >= NUMKEYS
+         || joybspeed >= MAX_JOY_BUTTONS;
+    speed ^= speedkeydown();
 
     // haleyjd: removed externdriver crap
     


### PR DESCRIPTION
Copies over the run input handling from doom:

If "always run" is on, and the user holds down the run key, they will walk instead.

I will add the autorun toggle key support as well, but thought I'd get these aligned first.

I also didn't add the other uses for the `speedkeydown` method yet for heretic. If you'd rather I set that stuff up in a batch, let me know.