### PR TITLE
Add autorun toggle key to heretic

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -348,6 +348,30 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         lspeed = 2;
     }
 
+    // [crispy] toggle "always run"
+    if (gamekeydown[key_toggleautorun])
+    {
+        static int joybspeed_old = 2;
+
+        if (joybspeed >= MAX_JOY_BUTTONS)
+        {
+            joybspeed = joybspeed_old;
+        }
+        else
+        {
+            joybspeed_old = joybspeed;
+            joybspeed = 29;
+        }
+
+        P_SetMessage(&players[consoleplayer], (joybspeed >= MAX_JOY_BUTTONS) ?
+                     "ALWAYS RUN ON" :
+                     "ALWAYS RUN OFF", false);
+
+        S_StartSound(NULL, sfx_switch);
+
+        gamekeydown[key_toggleautorun] = false;
+    }
+
     // [crispy] Toggle vertical mouse movement
     if (gamekeydown[key_togglenovert])
     {

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -226,7 +226,20 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         AddKeyControl(table, "Strafe Left (alt.)", &key_alt_strafeleft);
         AddKeyControl(table, "Strafe Right (alt.)", &key_alt_straferight);
         AddKeyControl(table, "Toggle always run", &key_toggleautorun);
+        AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
         AddKeyControl(table, "Quick Reverse", &key_reverse);
+        }
+        else if (gamemission == heretic)
+        {
+        AddSectionLabel(table, "View", false);
+
+        AddKeyControl(table, "Look up", &key_lookup);
+        AddKeyControl(table, "Look down", &key_lookdown);
+        AddKeyControl(table, "Center view", &key_lookcenter);
+
+        AddSectionLabel(table, "Movement", true);
+        AddKeyControl(table, "Toggle always run", &key_toggleautorun);
+        AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
         }
         else
         {
@@ -235,11 +248,6 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         AddKeyControl(table, "Look up", &key_lookup);
         AddKeyControl(table, "Look down", &key_lookdown);
         AddKeyControl(table, "Center view", &key_lookcenter);
-        }
-
-        if (gamemission == doom || gamemission == heretic)
-        {
-        AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
         }
 
         if (gamemission == heretic || gamemission == hexen)


### PR DESCRIPTION
Adds the autorun toggle feature to heretic. Follows the same pattern as with the novert toggle key.

I rearranged the setup menu slightly. Previously I had moved novert out of the doom-specific list to a shared list with heretic, but I realized heretic didn't actually have the "movement" section so it looked a bit off. I moved the doom line back into its section and made a separate heretic one so it looks cleaner in the setup program.

This is also one of the tasks in the "various" list from https://github.com/fabiangreffrath/crispy-doom/issues/240, fyi @JNechaevsky 