### PR TITLE
Prevent heretic crispy settings from resetting in setup

### DIFF
--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -101,6 +101,16 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_weaponsquat",     &crispy->weaponsquat);
         M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);
     }
+    else if (gamemission == heretic)
+    {
+        M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
+        M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
+        M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
+        M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
+        M_BindIntVariable("crispy_leveltime",       &crispy->leveltime);
+        M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
+        M_BindIntVariable("crispy_secretmessage",   &crispy->secretmessage);
+    }
     else
     {
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -105,11 +105,11 @@ void BindCompatibilityVariables(void)
     {
         M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
         M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
-        M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
         M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
         M_BindIntVariable("crispy_leveltime",       &crispy->leveltime);
         M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
         M_BindIntVariable("crispy_secretmessage",   &crispy->secretmessage);
+        M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
     }
     else
     {


### PR DESCRIPTION
When you currently run "crispy-setup" for heretic, it resets all the crispy options to their defaults (stats, the new secret message, etc).

This patch binds those variables for heretic in `setup/compatibility` (it looks like this is what it does for doom, so I just duplicated that behaviour), which lets them keep their values when running the setup.