### PR TITLE
Crispy-Heretic: Always display seconds in intermission time

### DIFF
--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -934,6 +934,7 @@ void IN_DrawDMStats(void)
 //
 //========================================================================
 
+// [crispy] always draw seconds; don't 0-pad minutes with no hour
 void IN_DrawTime(int x, int y, int h, int m, int s)
 {
     if (h)
@@ -942,12 +943,15 @@ void IN_DrawTime(int x, int y, int h, int m, int s)
         IN_DrTextB(DEH_String(":"), x + 26, y);
     }
     x += 34;
-    if (m || h)
+    if (h || m > 9)
     {
         IN_DrawNumber(m, x, y, 2);
     }
+    else if (m)
+    {
+        IN_DrawNumber(m, x + 12, y, 1);
+    }
     x += 34;
-    if (s)
     {
         IN_DrTextB(DEH_String(":"), x - 8, y);
         IN_DrawNumber(s, x, y, 2);


### PR DESCRIPTION
And also don't pad the minutes with 0s if there's no hour, so an exit
time of one minute will display as "1:00". This is the same way Doom
displays the time.

(Also I wanted an easy commit to see if I could make PRs with both Crispy and Chocolate.)