### PR TITLE
Hexen: Make demoextend and shortticfix the default

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1972,10 +1972,11 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     //!
     // @category demo
     //
-    // Smooth out low resolution turning when recording a demo.
+    // Don't smooth out low resolution turning when recording a demo.
     //
 
-    shortticfix = M_ParmExists("-shortticfix");
+    shortticfix = (!M_ParmExists("-noshortticfix"));
+    //[crispy] make shortticfix the default
 
     G_InitNew(skill, episode, map);
     usergame = false;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -731,11 +731,12 @@ static void HandleArgs(void)
     //!
     // @category demo
     //
-    // Record or playback a demo without automatically quitting
+    // Record or playback a demo, automatically quitting
     // after either level exit or player respawn.
     //
 
-    demoextend = M_ParmExists("-demoextend");
+    demoextend = (!M_ParmExists("-nodemoextend"));
+    //[crispy] make demoextend the default
 
     if (M_ParmExists("-testcontrols"))
     {


### PR DESCRIPTION
Might as well be consistent to Hexen, even though Crispy Hexen isn't
really supported right now.