### PR TITLE
Enable Hexen and Strife build when using autotools

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,20 +1,20 @@
 
-SUBDIRS = doom heretic setup # hexen strife
+SUBDIRS = doom heretic setup hexen strife
 
 execgamesdir = ${bindir}
 
 execgames_PROGRAMS = @PROGRAM_PREFIX@doom     \
                      @PROGRAM_PREFIX@heretic  \
-                     @PROGRAM_PREFIX@server
-EXTRA_PROGRAMS =     @PROGRAM_PREFIX@hexen    \
+                     @PROGRAM_PREFIX@server   \
+                     @PROGRAM_PREFIX@hexen    \
                      @PROGRAM_PREFIX@strife
 
 noinst_PROGRAMS = @PROGRAM_PREFIX@setup
 
 SETUP_BINARIES = @PROGRAM_PREFIX@doom-setup$(EXEEXT)    \
-                 @PROGRAM_PREFIX@heretic-setup$(EXEEXT)
-#                @PROGRAM_PREFIX@hexen-setup$(EXEEXT)   \
-#                @PROGRAM_PREFIX@strife-setup$(EXEEXT)
+                 @PROGRAM_PREFIX@heretic-setup$(EXEEXT) \
+                 @PROGRAM_PREFIX@hexen-setup$(EXEEXT)   \
+                 @PROGRAM_PREFIX@strife-setup$(EXEEXT)
 
 execgames_SCRIPTS = $(SETUP_BINARIES)
 
@@ -225,9 +225,9 @@ EXTRA_DIST =                        \
 metainfodir = $(prefix)/share/metainfo
 metainfo_DATA =                             \
         @PACKAGE_RDNS@.Doom.metainfo.xml    \
-        @PACKAGE_RDNS@.Heretic.metainfo.xml
-#       @PACKAGE_RDNS@.Hexen.metainfo.xml   \
-#       @PACKAGE_RDNS@.Strife.metainfo.xml
+        @PACKAGE_RDNS@.Heretic.metainfo.xml \
+        @PACKAGE_RDNS@.Hexen.metainfo.xml   \
+        @PACKAGE_RDNS@.Strife.metainfo.xml
 
 @PACKAGE_RDNS@.Doom.metainfo.xml : Doom.metainfo.xml
 	cp Doom.metainfo.xml $@
@@ -242,11 +242,11 @@ metainfo_DATA =                             \
 	cp Strife.metainfo.xml $@
 
 appdir = $(prefix)/share/applications
-app_DATA =                                 \
+app_DATA =                                \
            @PACKAGE_RDNS@.Doom.desktop    \
-           @PACKAGE_RDNS@.Heretic.desktop
-#          @PACKAGE_RDNS@.Hexen.desktop   \
-#          @PACKAGE_RDNS@.Strife.desktop
+           @PACKAGE_RDNS@.Heretic.desktop \
+           @PACKAGE_RDNS@.Hexen.desktop   \
+           @PACKAGE_RDNS@.Strife.desktop
 
 @PACKAGE_RDNS@.Doom.desktop : Doom.desktop
 	cp Doom.desktop $@


### PR DESCRIPTION
They were disabled in crispy-doom-3.4.

I suppose they are disabled because they still don't support any crispy feature. But it's convenient to have them available as well. Hexen and Strife are built automatically when using cmake.