### PR TITLE
Heretic: clear centered message on intermission and finale screens

### DIFF
--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -56,6 +56,7 @@ void F_StartFinale(void)
     automapactive = false;
     players[consoleplayer].messageTics = 1;
     players[consoleplayer].message = NULL;
+    players[consoleplayer].centerMessage = NULL;
 
     switch (gameepisode)
     {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1236,6 +1236,7 @@ void G_PlayerFinishLevel(int player)
         p->chickenTics = 0;
     }
     p->messageTics = 0;
+    p->centerMessageTics = 0;
     p->lookdir = 0;
     p->mo->flags &= ~MF_SHADOW; // Remove invisibility
     p->extralight = 0;          // Remove weapon flashes


### PR DESCRIPTION
Fixes two cases:

* Intermission screen (`in_lude.c`) - [screenshot](https://user-images.githubusercontent.com/21193394/81106444-49e8b600-8f1e-11ea-9e22-01b635d58c0b.png)
* Finale screen (`f_finale.c`) - [screenshot](https://user-images.githubusercontent.com/21193394/81106495-62f16700-8f1e-11ea-9dda-87bd6d0855be.png)

These changes are small and I believe there is no need to add `// [crispy]` comments.



