### PR TITLE
Heretic: clear centered message from border and bezel

### DIFF
--- a/src/heretic/p_user.c
+++ b/src/heretic/p_user.c
@@ -582,7 +582,7 @@ void P_PlayerThink(player_t * player)
         if (!player->centerMessageTics)
         {
             // Refresh the screen when a message goes away
-            BorderTopRefresh = true;
+            BorderNeedRefresh = true;
         }
     }
 


### PR DESCRIPTION
Fixes remaining of centered message was not cleared from border and bezel ([screenshot](https://user-images.githubusercontent.com/21193394/81115701-cedacc00-8f2c-11ea-8fb4-e3eda634055b.png)).