### PR TITLE
Heretic & Hexen: fix top border refresh

### DIFF
--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -453,7 +453,7 @@ void R_DrawTopBorder(void)
     }
     dest = I_VideoBuffer;
 
-    for (y = 0; y < 30; y++)
+    for (y = 0; y < (30 << crispy->hires); y++)
     {
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -521,7 +521,7 @@ void R_DrawTopBorder(void)
     src = W_CacheLumpName("F_022", PU_CACHE);
     dest = I_VideoBuffer;
 
-    for (y = 0; y < 34; y++)
+    for (y = 0; y < (34 << crispy->hires); y++)
     {
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {


### PR DESCRIPTION
Properly refresh top border's background in hires mode. Fixes this ([screenshot](https://user-images.githubusercontent.com/21193394/81145162-6b798a00-8f7e-11ea-9639-60b10a1b462d.png)).