### PR TITLE
Add demo alert toggle

### DIFF
--- a/src/crispy.c
+++ b/src/crispy.c
@@ -23,6 +23,7 @@
 // [crispy] "regular" config variables
 static crispy_t crispy_s = {
 	0,
+	.demoalert = 1,
 	.extautomap = 1,
 	.extsaveg = 1,
 	.hires = 1,

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -49,6 +49,7 @@ typedef struct
 	int crosshairhealth;
 	int crosshairtarget;
 	int crosshairtype;
+	int demoalert;
 	int demotimer;
 	int demotimerdir;
 	int demobar;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -437,6 +437,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_crosshairhealth", &crispy->crosshairhealth);
     M_BindIntVariable("crispy_crosshairtarget", &crispy->crosshairtarget);
     M_BindIntVariable("crispy_crosshairtype",   &crispy->crosshairtype);
+    M_BindIntVariable("crispy_demoalert",       &crispy->demoalert);
     M_BindIntVariable("crispy_demobar",         &crispy->demobar);
     M_BindIntVariable("crispy_demotimer",       &crispy->demotimer);
     M_BindIntVariable("crispy_demotimerdir",    &crispy->demotimerdir);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3036,7 +3036,7 @@ boolean G_CheckDemoStatus (void)
 	Z_Free (demobuffer); 
 	demorecording = false; 
 	// [crispy] if a new game is started during demo recording, start a new demo
-	if (gameaction != ga_newgame)
+	if (gameaction != ga_newgame && crispy->demoalert)
 	{
 	I_Error ("Demo %s recorded",demoname); 
 	}

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -240,6 +240,12 @@ void M_CrispyToggleCrosshairtype(int choice)
     }
 }
 
+void M_CrispyToggleDemoAlert(int choice)
+{
+    choice = 0;
+    crispy->demoalert = !crispy->demoalert;
+}
+
 void M_CrispyToggleDemoBar(int choice)
 {
     choice = 0;

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -52,6 +52,7 @@ extern void M_CrispyToggleCrosshair(int choice);
 extern void M_CrispyToggleCrosshairHealth(int choice);
 extern void M_CrispyToggleCrosshairTarget(int choice);
 extern void M_CrispyToggleCrosshairtype(int choice);
+extern void M_CrispyToggleDemoAlert(int choice);
 extern void M_CrispyToggleDemoBar(int choice);
 extern void M_CrispyToggleDemoTimer(int choice);
 extern void M_CrispyToggleDemoTimerDir(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -604,6 +604,7 @@ enum
     crispness_demotimerdir,
     crispness_demobar,
     crispness_demousetimer,
+    crispness_demoalert,
     crispness_sep_demos_,
 
     crispness4_next,
@@ -625,6 +626,7 @@ static menuitem_t Crispness4Menu[]=
     {1,"",	M_CrispyToggleDemoTimerDir,'a'},
     {1,"",	M_CrispyToggleDemoBar,'w'},
     {1,"",	M_CrispyToggleDemoUseTimer,'u'},
+    {1,"",	M_CrispyToggleDemoAlert,'a'},
     {-1,"",0,'\0'},
     {1,"",	M_CrispnessNext,'n'},
     {1,"",	M_CrispnessPrev,'p'},
@@ -1574,6 +1576,7 @@ static void M_DrawCrispness4(void)
     M_DrawCrispnessMultiItem(crispness_demotimerdir, "Playback Timer Direction", multiitem_demotimerdir, crispy->demotimerdir + 1, crispy->demotimer & DEMOTIMER_PLAYBACK);
     M_DrawCrispnessItem(crispness_demobar, "Show Demo Progress Bar", crispy->demobar, true);
     M_DrawCrispnessItem(crispness_demousetimer, "\"Use\" Button Timer", crispy->btusetimer, true);
+    M_DrawCrispnessItem(crispness_demoalert, "Show Demo Recorded Alert", crispy->demoalert, true);
 
     M_DrawCrispnessGoto(crispness4_next, "First Page >");
     M_DrawCrispnessGoto(crispness4_prev, "< Prev Page");

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1992,6 +1992,14 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(crispy_crosshairtype),
+    
+    //!
+    // @game doom
+    //
+    // Show demo recorded alert.
+    //
+
+    CONFIG_VARIABLE_INT(crispy_demoalert),
 
     //!
     // @game doom

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -70,6 +70,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_crosshairhealth", &crispy->crosshairhealth);
         M_BindIntVariable("crispy_crosshairtarget", &crispy->crosshairtarget);
         M_BindIntVariable("crispy_crosshairtype",   &crispy->crosshairtype);
+        M_BindIntVariable("crispy_demoalert",       &crispy->demoalert);
         M_BindIntVariable("crispy_demobar",         &crispy->demobar);
         M_BindIntVariable("crispy_demotimer",       &crispy->demotimer);
         M_BindIntVariable("crispy_demotimerdir",    &crispy->demotimerdir);


### PR DESCRIPTION
By default there is an alert popup showing `Demo x.lmp recorded` when you finish recording a demo, despite this being the expected behaviour.

This PR adds a toggle to disable the popup (leaving it on by default).

Implementing in doom first - I will add this to heretic as well if it's approved.