### PR TITLE
Add "Dropped Item" support

### DIFF
--- a/src/doom/deh_thing.c
+++ b/src/doom/deh_thing.c
@@ -95,6 +95,8 @@ DEH_BEGIN_MAPPING(thing_mapping, mobjinfo_t)
   DEH_MAPPING("Action sound",        activesound)
   DEH_MAPPING("Bits",                flags)
   DEH_MAPPING("Respawn frame",       raisestate)
+  // [crispy] Thing id to drop after death
+  DEH_MAPPING("Dropped item",        droppeditem)
 DEH_END_MAPPING
 
 static void *DEH_ThingStart(deh_context_t *context, char *line)

--- a/src/doom/info.h
+++ b/src/doom/info.h
@@ -1249,6 +1249,7 @@ extern state_t	states[NUMSTATES];
 extern const char *sprnames[];
 
 typedef enum {
+    MT_NULL = -1, // [crispy] null/invalid mobj (zero is reserved for MT_PLAYER)
     MT_PLAYER,
     MT_POSSESSED,
     MT_SHOTGUY,
@@ -1448,6 +1449,8 @@ typedef struct
     int	raisestate;
     // [crispy] height of the spawnstate's first sprite in pixels
     int	actualheight;
+    // [crispy] mobj to drop after death
+    mobjtype_t droppeditem;
 
 } mobjinfo_t;
 

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -802,24 +802,12 @@ P_KillMobj
     // Drop stuff.
     // This determines the kind of object spawned
     // during the death frame of a thing.
-    switch (target->type)
+    if (target->info->droppeditem != MT_NULL) // [crispy] drop generalization
     {
-      case MT_WOLFSS:
-      case MT_POSSESSED:
-	item = MT_CLIP;
-	break;
-	
-      case MT_SHOTGUY:
-	item = MT_SHOTGUN;
-	break;
-	
-      case MT_CHAINGUY:
-	item = MT_CHAINGUN;
-	break;
-	
-      default:
-	return;
+        item = target->info->droppeditem;
     }
+    else
+        return;
 
     mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, item);
     mo->flags |= MF_DROPPED;	// special versions of items

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -1302,8 +1302,8 @@ P_SetupLevel
 
 }
 
-// [crispy] height of the spawnstate's first sprite in pixels
-static void P_InitActualHeights (void)
+// [crispy] initialize Thing extra properties (keeping vanilla props in info.c)
+static void P_InitThingProperties (void)
 {
 	int i;
 
@@ -1318,6 +1318,27 @@ static void P_InitActualHeights (void)
 		state = &states[mobjinfo[i].spawnstate];
 		sprdef = &sprites[state->sprite];
 
+		// [crispy] mobj id for item dropped on death
+		switch (i)
+		{
+			case MT_WOLFSS:
+			case MT_POSSESSED:
+			mobjinfo[i].droppeditem = MT_CLIP;
+			break;
+
+			case MT_SHOTGUY:
+			mobjinfo[i].droppeditem = MT_SHOTGUN;
+			break;
+
+			case MT_CHAINGUY:
+			mobjinfo[i].droppeditem = MT_CHAINGUN;
+			break;
+
+			default:
+			mobjinfo[i].droppeditem = MT_NULL;
+		}
+
+		// [crispy] height of the spawnstate's first sprite in pixels
 		if (!sprdef->numframes || !(mobjinfo[i].flags & (MF_SOLID|MF_SHOOTABLE)))
 		{
 			mobjinfo[i].actualheight = mobjinfo[i].height;
@@ -1342,7 +1363,7 @@ void P_Init (void)
     P_InitSwitchList ();
     P_InitPicAnims ();
     R_InitSprites (sprnames);
-    P_InitActualHeights();
+    P_InitThingProperties();
 }
 
 


### PR DESCRIPTION
Support the same dehacked Thing field as Doom Retro.
"Dropped item" will allow to specify the Thing Id to be spawned after
the Thing dies.

It's a generalization of the same behavior that in Doom vanilla is
hardcoded for MT_WOLFSS, MT_POSSESSED, MT_SHOTGUY and MT_CHAINGUY.

Thanks for the hint :P  
https://www.doomworld.com/forum/topic/115638-dehextra-discussion-split-from-pr-umapinfo-thread/?page=2&tab=comments#comment-2156303