### PR TITLE
Generalizations dehardcoding some vanilla behavior

### DIFF
--- a/src/doom/deh_thing.c
+++ b/src/doom/deh_thing.c
@@ -97,6 +97,12 @@ DEH_BEGIN_MAPPING(thing_mapping, mobjinfo_t)
   DEH_MAPPING("Respawn frame",       raisestate)
   // [crispy] Thing id to drop after death
   DEH_MAPPING("Dropped item",        droppeditem)
+  // [crispy] Distance to switch from missile to melee attack
+  DEH_MAPPING("Melee threshold",     meleethreshold)
+  // [crispy] Maximum distance range to start shooting (zero for unlimited)
+  DEH_MAPPING("Max target range",    maxattackrange)
+  // [crispy] Minimum chance for firing a missile
+  DEH_MAPPING("Min missile chance",  minmissilechance)
 DEH_END_MAPPING
 
 static void *DEH_ThingStart(deh_context_t *context, char *line)

--- a/src/doom/deh_thing.c
+++ b/src/doom/deh_thing.c
@@ -103,6 +103,8 @@ DEH_BEGIN_MAPPING(thing_mapping, mobjinfo_t)
   DEH_MAPPING("Max target range",    maxattackrange)
   // [crispy] Minimum chance for firing a missile
   DEH_MAPPING("Min missile chance",  minmissilechance)
+  // [crispy] Multiplies the chance of firing a missile (65536 = normal chance)
+  DEH_MAPPING("Missile chance multiplier",  missilechancemult)
 DEH_END_MAPPING
 
 static void *DEH_ThingStart(deh_context_t *context, char *line)

--- a/src/doom/info.h
+++ b/src/doom/info.h
@@ -1457,6 +1457,8 @@ typedef struct
     int maxattackrange;
     // [crispy] minimum likelihood of a missile attack (generaliz. for Cyberdemon)
     int minmissilechance;
+    // [crispy] multiplier for likelihood of a missile attack (generaliz. for various)
+    int missilechancemult;
 
 } mobjinfo_t;
 

--- a/src/doom/info.h
+++ b/src/doom/info.h
@@ -1451,6 +1451,12 @@ typedef struct
     int	actualheight;
     // [crispy] mobj to drop after death
     mobjtype_t droppeditem;
+    // [crispy] distance to switch from missile to melee attack (generaliz. for Revenant)
+    int meleethreshold;
+    // [crispy] maximum distance range to start shooting (generaliz. for Arch Vile)
+    int maxattackrange;
+    // [crispy] minimum likelihood of a missile attack (generaliz. for Cyberdemon)
+    int minmissilechance;
 
 } mobjinfo_t;
 

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -249,13 +249,10 @@ boolean P_CheckMissileRange (mobj_t* actor)
 	    return false;	// close for fist attack
     }
 	
-
-    if (actor->type == MT_CYBORG
-	|| actor->type == MT_SPIDER
-	|| actor->type == MT_UNDEAD // [crispy] keep Revenant double missile chance
-	|| actor->type == MT_SKULL)
+    // [crispy] generalize missile chance for Cyb, Spider, Revenant & Lost Soul
+    if (actor->info->missilechancemult != FRACUNIT)
     {
-	dist >>= 1;
+	dist = FixedMul(dist, actor->info->missilechancemult);
     }
     
     // [crispy] generalization of Min Missile Chance values hardcoded in vanilla

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -235,33 +235,32 @@ boolean P_CheckMissileRange (mobj_t* actor)
 
     dist >>= FRACBITS;
 
-    if (actor->type == MT_VILE)
+    // [crispy] generalization of the Arch Vile's different attack range
+    if (actor->info->maxattackrange > 0)
     {
-	if (dist > 14*64)	
+	if (dist > actor->info->maxattackrange)
 	    return false;	// too far away
     }
 	
-
-    if (actor->type == MT_UNDEAD)
+    // [crispy] generalization of the Revenant's different melee threshold
+    if (actor->info->meleethreshold > 0)
     {
-	if (dist < 196)	
+	if (dist < actor->info->meleethreshold)
 	    return false;	// close for fist attack
-	dist >>= 1;
     }
 	
 
     if (actor->type == MT_CYBORG
 	|| actor->type == MT_SPIDER
+	|| actor->type == MT_UNDEAD // [crispy] keep Revenant double missile chance
 	|| actor->type == MT_SKULL)
     {
 	dist >>= 1;
     }
     
-    if (dist > 200)
-	dist = 200;
-		
-    if (actor->type == MT_CYBORG && dist > 160)
-	dist = 160;
+    // [crispy] generalization of Min Missile Chance values hardcoded in vanilla
+    if (dist > actor->info->minmissilechance)
+      dist = actor->info->minmissilechance;
 		
     if (P_Random () < dist)
 	return false;

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -1356,6 +1356,15 @@ static void P_InitThingProperties (void)
 		else
 			mobjinfo[i].minmissilechance = 200;
 
+		// [crispy] multiplier for missile firing chance (generaliz. from vanilla)
+		if (i == MT_CYBORG
+		   || i == MT_SPIDER
+		   || i == MT_UNDEAD
+		   || i == MT_SKULL)
+			mobjinfo[i].missilechancemult = FRACUNIT/2;
+		else
+			mobjinfo[i].missilechancemult = FRACUNIT;
+
 		// [crispy] height of the spawnstate's first sprite in pixels
 		if (!sprdef->numframes || !(mobjinfo[i].flags & (MF_SOLID|MF_SHOOTABLE)))
 		{

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -1338,6 +1338,24 @@ static void P_InitThingProperties (void)
 			mobjinfo[i].droppeditem = MT_NULL;
 		}
 
+		// [crispy] distance to switch from missile to melee attack (generaliz. for Revenant)
+		if (i == MT_UNDEAD)
+			mobjinfo[i].meleethreshold = 196;
+		else
+			mobjinfo[i].meleethreshold = 0;
+
+		// [crispy] maximum distance range to start shooting (generaliz. for Arch Vile)
+		if (i == MT_VILE)
+			mobjinfo[i].maxattackrange = 14*64;
+		else
+			mobjinfo[i].maxattackrange = 0; // unlimited
+
+		// [crispy] minimum likelihood of a missile attack (generaliz. for Cyberdemon)
+		if (i == MT_CYBORG)
+			mobjinfo[i].minmissilechance = 160;
+		else
+			mobjinfo[i].minmissilechance = 200;
+
 		// [crispy] height of the spawnstate's first sprite in pixels
 		if (!sprdef->numframes || !(mobjinfo[i].flags & (MF_SOLID|MF_SHOOTABLE)))
 		{


### PR DESCRIPTION
This will add the following dehacked fields for Things:

* Melee threshold: distance to switch from missile to melee attack
* Max target range: Maximum distance range to start shooting (zero for unlimited)
* Min missile chance: Minimum chance for firing a missile

Based on old changes done in prboom-plus branch by Graf:
    https://github.com/coelckers/prboom-plus/commit/f5f8dea10bbb6ae20796c4459b39e68e8f4b6586

In addition the following field is added (as FRACUNIT-based scalar instead of being a flag):

* Missile chance multiplier: multiplier that factors the likelihood of shooting missiles. 65536 being the normal firing chance, lower values will proportionally increase the firing chance, while higher values will reduce it.

Discussed in Doomworld thread:
    https://www.doomworld.com/forum/topic/115638-dehextra-discussion-split-from-pr-umapinfo-thread/?page=2&tab=comments#comment-2156324