### PR TITLE
Make "Dropped item" 1-based in DEH, not 0-based

### DIFF
--- a/src/doom/deh_thing.c
+++ b/src/doom/deh_thing.c
@@ -165,6 +165,11 @@ static void DEH_ThingParseLine(deh_context_t *context, char *line, void *tag)
 		}
 	}
     }
+    // [crispy] Thing ids in dehacked are 1-based, convert dropped item to 0-based
+    if (!strcasecmp(variable_name, "dropped item"))
+    {
+        ivalue -= 1;
+    }
 
     // Set the field value
 


### PR DESCRIPTION
This was apparently an oversight that was recently corrected in Doom Retro by brad already, sorry.
 https://github.com/bradharding/doomretro/commit/cd62a1c2349e90bdbe7cde78dc5a193b95e24168
