### PR TITLE
Heretic: Allow ENGAGExy cheat (and some others) in Nightmare

### DIFF
--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1028,10 +1028,12 @@ static boolean HandleCheats(byte key)
     int i;
     boolean eat;
 
+    /* [crispy] check for nightmare/netgame per cheat, to allow "harmless" cheats
     if (netgame || gameskill == sk_nightmare)
     {                           // Can't cheat in a net-game, or in nightmare mode
         return (false);
     }
+    */
     if (players[consoleplayer].health <= 0)
     {                           // Dead players can't cheat
         return (false);
@@ -1054,8 +1056,12 @@ static boolean HandleCheats(byte key)
 //
 //--------------------------------------------------------------------------
 
+#define NIGHTMARE_NETGAME_CHECK if(netgame||gameskill==sk_nightmare){return;}
+#define NETGAME_CHECK if(netgame){return;}
+
 static void CheatGodFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     player->cheats ^= CF_GODMODE;
     if (player->cheats & CF_GODMODE)
     {
@@ -1070,6 +1076,7 @@ static void CheatGodFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatNoClipFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     player->cheats ^= CF_NOCLIP;
     if (player->cheats & CF_NOCLIP)
     {
@@ -1086,6 +1093,7 @@ static void CheatWeaponsFunc(player_t * player, Cheat_t * cheat)
     int i;
     //extern boolean *WeaponInShareware;
 
+    NIGHTMARE_NETGAME_CHECK;
     player->armorpoints = 200;
     player->armortype = 2;
     if (!player->backpack)
@@ -1115,6 +1123,7 @@ static void CheatWeaponsFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatPowerFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     if (player->powers[pw_weaponlevel2])
     {
         player->powers[pw_weaponlevel2] = 0;
@@ -1129,6 +1138,7 @@ static void CheatPowerFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatHealthFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     if (player->chickenTics)
     {
         player->health = player->mo->health = MAXCHICKENHEALTH;
@@ -1142,6 +1152,7 @@ static void CheatHealthFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatKeysFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     player->keys[key_yellow] = true;
     player->keys[key_green] = true;
     player->keys[key_blue] = true;
@@ -1151,6 +1162,7 @@ static void CheatKeysFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatSoundFunc(player_t * player, Cheat_t * cheat)
 {
+    NETGAME_CHECK;
     DebugSound = !DebugSound;
     if (DebugSound)
     {
@@ -1179,11 +1191,13 @@ static void CheatTickerFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatArtifact1Func(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     P_SetMessage(player, DEH_String(TXT_CHEATARTIFACTS1), false);
 }
 
 static void CheatArtifact2Func(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     P_SetMessage(player, DEH_String(TXT_CHEATARTIFACTS2), false);
 }
 
@@ -1195,6 +1209,7 @@ static void CheatArtifact3Func(player_t * player, Cheat_t * cheat)
     int type;
     int count;
 
+    NIGHTMARE_NETGAME_CHECK;
     cht_GetParam(cheat->seq, args);
     type = args[0] - 'a' + 1;
     count = args[1] - '0';
@@ -1241,6 +1256,7 @@ static void CheatWarpFunc(player_t * player, Cheat_t * cheat)
     int episode;
     int map;
 
+    NETGAME_CHECK;
     cht_GetParam(cheat->seq, args);
 
     episode = args[0] - '0';
@@ -1256,6 +1272,7 @@ static void CheatChickenFunc(player_t * player, Cheat_t * cheat)
 {
     extern boolean P_UndoPlayerChicken(player_t * player);
 
+    NIGHTMARE_NETGAME_CHECK;
     if (player->chickenTics)
     {
         if (P_UndoPlayerChicken(player))
@@ -1285,6 +1302,7 @@ static void CheatShowFpsFunc(player_t* player, Cheat_t* cheat)
 
 static void CheatMassacreFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     P_Massacre();
     P_SetMessage(player, DEH_String(TXT_CHEATMASSACRE), false);
 }
@@ -1292,6 +1310,8 @@ static void CheatMassacreFunc(player_t * player, Cheat_t * cheat)
 static void CheatIDKFAFunc(player_t * player, Cheat_t * cheat)
 {
     int i;
+
+    NIGHTMARE_NETGAME_CHECK;
     if (player->chickenTics)
     {
         return;
@@ -1306,6 +1326,7 @@ static void CheatIDKFAFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatIDDQDFunc(player_t * player, Cheat_t * cheat)
 {
+    NIGHTMARE_NETGAME_CHECK;
     P_DamageMobj(player->mo, NULL, player->mo, 10000);
     P_SetMessage(player, DEH_String(TXT_CHEATIDDQD), true);
 }


### PR DESCRIPTION
This restructures the cheat code handling to check for skill level and
netgames on a per-cheat basis. It's a little redundant but the least-
intrusive way I could think to do it.

Cheats enabled in Black Plague Possesses Thee (Heretic's Nightmare):
ENGAGExy: warp to level
NOISE: sound debug info

Cheats enabled in BPPT as well as netgames:
TICKER: show ticks-per-frame counter
SHOWFPS: show FPS counter (crispy specific cheat)

I don't see how the latter two could affect netgames at all, but it's
not something I've tested.

Partially resolves #634 