### PR TITLE
Add levelstat option (heretic)

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1568,6 +1568,7 @@ void G_DoCompleted(void)
     int i;
     static int afterSecret[5] = { 7, 5, 5, 5, 4 };
 
+    // [crispy] Write level statistics upon exit
     if (M_ParmExists("-levelstat"))
         G_WriteLevelStat();
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1525,7 +1525,9 @@ void G_WriteLevelStat(void)
     char levelTimeString[16];
     
     if (fstream == NULL)
+    {
         fstream = fopen("levelstat.txt", "w");
+    }
 
     exitTime = (float) leveltime / 35;
     exitHours = exitTime / 3600;
@@ -1570,7 +1572,9 @@ void G_DoCompleted(void)
 
     // [crispy] Write level statistics upon exit
     if (M_ParmExists("-levelstat"))
+    {
         G_WriteLevelStat();
+    }
 
     gameaction = ga_nothing;
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -54,6 +54,9 @@ void G_DoVictory(void);
 void G_DoWorldDone(void);
 void G_DoSaveGame(void);
 
+// [crispy] Write level statistics upon exit
+void G_WriteLevelStat(void);
+
 void D_PageTicker(void);
 void D_AdvanceDemo(void);
 
@@ -1510,10 +1513,63 @@ void G_SecretExitLevel(void)
     gameaction = ga_completed;
 }
 
+// [crispy] Write level statistics upon exit
+void G_WriteLevelStat(void)
+{
+    static FILE *fstream = NULL;
+
+    int i, playerKills = 0, playerItems = 0, playerSecrets = 0;
+    int exitHours, exitMinutes;
+    float exitTime, exitSeconds;
+
+    char levelTimeString[16];
+    
+    if (fstream == NULL)
+        fstream = fopen("levelstat.txt", "w");
+
+    exitTime = (float) leveltime / 35;
+    exitHours = exitTime / 3600;
+    exitTime -= exitHours * 3600;
+    exitMinutes = exitTime / 60;
+    exitTime -= exitMinutes * 60;
+    exitSeconds = exitTime;
+
+    if (exitHours)
+    {
+        M_snprintf(levelTimeString, sizeof(levelTimeString), "%d:%02d:%05.2f",
+                    exitHours, exitMinutes, exitSeconds);
+    }
+    else
+    {
+        M_snprintf(levelTimeString, sizeof(levelTimeString), "%01d:%05.2f", 
+                    exitMinutes, exitSeconds);
+    }
+
+    for (i = 0; i < MAXPLAYERS; i++)
+    {
+        if (playeringame[i])
+        {
+            playerKills += players[i].killcount;
+            playerItems += players[i].itemcount;
+            playerSecrets += players[i].secretcount;
+        }
+    }
+
+    // Duplicating prboom+ format for consistency
+    // Heretic isn't tracking total time (in parentheses) so it's 0 for now
+    fprintf(fstream, "E%dM%d%s - %s (0:00)  K: %d/%d  I: %d/%d  S: %d/%d\n",
+            gameepisode, gamemap, (secretexit ? "s" : ""),
+            levelTimeString, playerKills, totalkills, 
+            playerItems, totalitems, playerSecrets, totalsecret);
+}
+
 void G_DoCompleted(void)
 {
     int i;
     static int afterSecret[5] = { 7, 5, 5, 5, 4 };
+
+    if (M_ParmExists("-levelstat"))
+        G_WriteLevelStat();
 
     gameaction = ga_nothing;
 


### PR DESCRIPTION
PRBoom+ has a `-levelstat` option which causes some details about a map to be printed to `levelstat.txt` when the player gets to the exit. This data is printed for each map, so the levelstat file will have one line for each map completed.

Example: `E1M1 - 0:06.86 (0:06)  K: 4/22  I: 0/4  S: 1/4`

This file tracks kills / secrets for max validation, tracks times level by level for movie runs, and shows the map exit. In addition to general use by runners, this data helps with automation for DSDA.

This tooling is currently missing for heretic.

---

This PR adds the levelstat command line option and file for heretic. I'll be happy to add this for doom as well if it's approved. The format is identical to the one used by PRBoom+. One thing missing is, as far as I can tell, the total time across all levels isn't tracked yet for heretic (at least, I couldn't find it immediately). I left the total time in parentheses as "0:00" for now.

---

This code is adapted from a patch PVS made, so thanks to him for that!