### PR TITLE
Add levelstat to doom

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Many additional less user-visible features have been implemented, e.g. fixed eng
  * `-playdemo demoname1 -record demoname2` plays back fast-forward until the end of demoname1 and continues recording as demoname2 (new in 5.5).
  * `-fliplevels` loads mirrored versions of the maps (this was the default on April 1st up to version 5.0).
  * `-flipweapons` flips the player's weapons (new in 5.3).
+ * `-levelstat` prints a levelstat.txt file with statistics for each completed level (new in dev).
 
 ### New cheat codes
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -93,7 +93,7 @@ void	G_DoCompleted (void);
 void	G_DoVictory (void); 
 void	G_DoWorldDone (void); 
 void	G_DoSaveGame (void); 
-
+ 
 // Gamestate the last time G_Ticker was called.
 
 gamestate_t     oldgamestate; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -93,10 +93,6 @@ void	G_DoCompleted (void);
 void	G_DoVictory (void); 
 void	G_DoWorldDone (void); 
 void	G_DoSaveGame (void); 
- 
-// [crispy] Write level statistics upon exit
-void G_WriteLevelStat(void);
-void G_FormatLevelStatTime(char *str, int tics);
 
 // Gamestate the last time G_Ticker was called.
 
@@ -1655,7 +1651,7 @@ void G_SecretExitLevel (void)
 } 
 
 // [crispy] format time for level statistics
-void G_FormatLevelStatTime(char *str, int tics)
+static void G_FormatLevelStatTime(char *str, int tics)
 {
     int exitHours, exitMinutes;
     float exitTime, exitSeconds;
@@ -1679,7 +1675,7 @@ void G_FormatLevelStatTime(char *str, int tics)
 }
 
 // [crispy] Write level statistics upon exit
-void G_WriteLevelStat(void)
+static void G_WriteLevelStat(void)
 {
     static FILE *fstream = NULL;
 
@@ -1693,6 +1689,12 @@ void G_WriteLevelStat(void)
     if (fstream == NULL)
     {
         fstream = fopen("levelstat.txt", "w");
+
+        if (fstream == NULL)
+        {
+            fprintf(stderr, "Unable to open levelstat.txt for writing!\n");
+            return;
+        }
     }
     
     if (gamemode == commercial)
@@ -1710,7 +1712,10 @@ void G_WriteLevelStat(void)
 
     // Total time ignores centiseconds
     decimal = strchr(totalTimeString, '.');
-    *decimal = '\0';
+    if (decimal != NULL)
+    {
+        *decimal = '\0';
+    }
 
     for (i = 0; i < MAXPLAYERS; i++)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -94,6 +94,10 @@ void	G_DoVictory (void);
 void	G_DoWorldDone (void); 
 void	G_DoSaveGame (void); 
  
+// [crispy] Write level statistics upon exit
+void G_WriteLevelStat(void);
+void G_FormatLevelStatTime(char *str, int tics);
+
 // Gamestate the last time G_Ticker was called.
 
 gamestate_t     oldgamestate; 
@@ -1649,10 +1653,90 @@ void G_SecretExitLevel (void)
     G_ClearSavename();
     gameaction = ga_completed; 
 } 
+
+// [crispy] format time for level statistics
+void G_FormatLevelStatTime(char *str, int tics)
+{
+    int exitHours, exitMinutes;
+    float exitTime, exitSeconds;
+
+    exitTime = (float) tics / 35;
+    exitHours = exitTime / 3600;
+    exitTime -= exitHours * 3600;
+    exitMinutes = exitTime / 60;
+    exitTime -= exitMinutes * 60;
+    exitSeconds = exitTime;
+
+    if (exitHours)
+    {
+        M_snprintf(str, sizeof(str), "%d:%02d:%05.2f",
+                    exitHours, exitMinutes, exitSeconds);
+    }
+    else
+    {
+        M_snprintf(str, sizeof(str), "%01d:%05.2f", exitMinutes, exitSeconds);
+    }
+}
+
+// [crispy] Write level statistics upon exit
+void G_WriteLevelStat(void)
+{
+    static FILE *fstream = NULL;
+
+    int i, playerKills = 0, playerItems = 0, playerSecrets = 0;
+
+    char levelString[8];
+    char levelTimeString[16];
+    char totalTimeString[16];
+    char *decimal;
+
+    if (fstream == NULL)
+    {
+        fstream = fopen("levelstat.txt", "w");
+    }
+    
+    if (gamemode == commercial)
+    {
+        M_snprintf(levelString, sizeof(levelString), "MAP%02d", gamemap);
+    }
+    else
+    {
+        M_snprintf(levelString, sizeof(levelString), "E%dM%d",
+                    gameepisode, gamemap);
+    }
+
+    G_FormatLevelStatTime(levelTimeString, leveltime);
+    G_FormatLevelStatTime(totalTimeString, totalleveltimes + leveltime);
+
+    // Total time ignores centiseconds
+    decimal = strchr(totalTimeString, '.');
+    *decimal = '\0';
+
+    for (i = 0; i < MAXPLAYERS; i++)
+    {
+        if (playeringame[i])
+        {
+            playerKills += players[i].killcount;
+            playerItems += players[i].itemcount;
+            playerSecrets += players[i].secretcount;
+        }
+    }
+
+    fprintf(fstream, "%s%s - %s (%s)  K: %d/%d  I: %d/%d  S: %d/%d\n",
+            levelString, (secretexit ? "s" : ""),
+            levelTimeString, totalTimeString, playerKills, totalkills, 
+            playerItems, totalitems, playerSecrets, totalsecret);
+}
  
 void G_DoCompleted (void) 
 { 
     int             i; 
+
+    // [crispy] Write level statistics upon exit
+    if (M_ParmExists("-levelstat"))
+    {
+        G_WriteLevelStat();
+    }
 	 
     gameaction = ga_nothing; 
  


### PR DESCRIPTION
See https://github.com/fabiangreffrath/crispy-doom/pull/643 for context (heretic).

This is the same thing for doom.
We have access to the total time now, so handling has been added for that.
Additionally we need to handle the case of doom 2 style (MAP15) vs doom 1 style (E1M1) level names.