### PR TITLE
Track heretic total time for levelstat

### DIFF
--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -563,6 +563,7 @@ extern int prevmap;
 extern int totalkills, totalitems, totalsecret; // for intermission
 extern int levelstarttic;       // gametic at level start
 extern int leveltime;           // tics in game play for par
+extern int totalleveltimes; // [crispy] total time for all completed levels
 
 extern ticcmd_t *netcmds;
 


### PR DESCRIPTION
Adds total time tracking for heretic and incorporates the full implementation of levelstat from the doom PR (https://github.com/fabiangreffrath/crispy-doom/pull/644).