### PR TITLE
Add total time to heretic intermission

### DIFF
--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -781,6 +781,7 @@ void IN_DrawSingleStats(void)
     {
         IN_DrTextB(DEH_String("TIME"), 85, 150);
         IN_DrawTime(155, 150, hours, minutes, seconds);
+
         // [crispy] Show total time on intermission
         IN_DrTextB(DEH_String("TOTAL"), 85, 170);
         IN_DrawTime(155, 170, totalHours, totalMinutes, totalSeconds);
@@ -790,9 +791,11 @@ void IN_DrawSingleStats(void)
         // [crispy] show the level time for Ep.4 and up
         IN_DrTextB(DEH_String("TIME"), 85, 120);
         IN_DrawTime(155, 120, hours, minutes, seconds);
+
         // [crispy] Show total time on intermission
         IN_DrTextB(DEH_String("TOTAL"), 85, 140);
         IN_DrawTime(155, 140, totalHours, totalMinutes, totalSeconds);
+
         x = 160 - MN_TextAWidth(DEH_String("NOW ENTERING:")) / 2;
         MN_DrTextA(DEH_String("NOW ENTERING:"), x, 160);
         x = 160 - MN_TextBWidth(next_level_name) / 2;

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -72,6 +72,11 @@ static int hours;
 static int minutes;
 static int seconds;
 
+// [crispy] Show total time on intermission
+static int totalHours;
+static int totalMinutes;
+static int totalSeconds;
+
 static int slaughterboy;        // in DM, the player with the most kills
 
 static int killPercent[MAXPLAYERS];
@@ -229,6 +234,14 @@ void IN_InitStats(void)
         minutes = count / 60;
         count -= minutes * 60;
         seconds = count;
+
+        // [crispy] Show total time on intermission
+        count = totalleveltimes / 35;
+        totalHours = count / 3600;
+        count -= totalHours * 3600;
+        totalMinutes = count / 60;
+        count -= totalMinutes * 60;
+        totalSeconds = count;
     }
     else if (netgame && !deathmatch)
     {
@@ -766,14 +779,20 @@ void IN_DrawSingleStats(void)
 
     if (gamemode != retail || gameepisode <= 3)
     {
-        IN_DrTextB(DEH_String("TIME"), 85, 160);
-        IN_DrawTime(155, 160, hours, minutes, seconds);
+        IN_DrTextB(DEH_String("TIME"), 85, 150);
+        IN_DrawTime(155, 150, hours, minutes, seconds);
+        // [crispy] Show total time on intermission
+        IN_DrTextB(DEH_String("TOTAL"), 85, 170);
+        IN_DrawTime(155, 170, totalHours, totalMinutes, totalSeconds);
     }
     else
     {
         // [crispy] show the level time for Ep.4 and up
-        IN_DrTextB(DEH_String("TIME"), 85, 130);
-        IN_DrawTime(155, 130, hours, minutes, seconds);
+        IN_DrTextB(DEH_String("TIME"), 85, 120);
+        IN_DrawTime(155, 120, hours, minutes, seconds);
+        // [crispy] Show total time on intermission
+        IN_DrTextB(DEH_String("TOTAL"), 85, 140);
+        IN_DrawTime(155, 140, totalHours, totalMinutes, totalSeconds);
         x = 160 - MN_TextAWidth(DEH_String("NOW ENTERING:")) / 2;
         MN_DrTextA(DEH_String("NOW ENTERING:"), x, 160);
         x = 160 - MN_TextBWidth(next_level_name) / 2;


### PR DESCRIPTION
Adds total elapsed time to the intermission screen for heretic. I had to adjust the positioning of the current time to make some room.

![e1-intermission](https://user-images.githubusercontent.com/25529060/89664675-cef5b980-d8d7-11ea-8082-5dee6121b1cb.png)

From e4 onwards, heretic has a "now entering" text underneath the time, which doesn't leave much room. It fits but I don't know if we want to adjust any of the other text on the screen vertically to give more space between things.
![e4-intermission](https://user-images.githubusercontent.com/25529060/89664678-cf8e5000-d8d7-11ea-933e-eaf13c58fb1f.png)
