### PR TITLE
Add final intermission to heretic episodes

### DIFF
--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -565,6 +565,8 @@ extern int levelstarttic;       // gametic at level start
 extern int leveltime;           // tics in game play for par
 extern int totalleveltimes; // [crispy] total time for all completed levels
 
+extern boolean finalintermission; // [crispy] track intermission at end of episode
+
 extern ticcmd_t *netcmds;
 
 #define SAVEGAMESIZE 0x30000*16

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -108,6 +108,8 @@ int levelstarttic;              // gametic at level start
 int totalkills, totalitems, totalsecret;        // for intermission
 int totalleveltimes; // [crispy] total time for all completed levels
 
+boolean finalintermission; // [crispy] track intermission at end of episode
+
 int mouseSensitivity;
 
 char demoname[32];
@@ -1619,8 +1621,8 @@ void G_DoCompleted(void)
     }
     else if (gamemap == 8)
     {
-        gameaction = ga_victory;
-        return;
+        // [crispy] track intermission at end of episode
+        finalintermission = true;
     }
     else
     {
@@ -1643,6 +1645,12 @@ void G_DoCompleted(void)
 void G_WorldDone(void)
 {
     gameaction = ga_worlddone;
+
+    // [crispy] track intermission at end of episode
+    if (finalintermission)
+    {
+        gameaction = ga_victory;
+    }
 }
 
 //============================================================================
@@ -1829,6 +1837,9 @@ void G_InitNew(skill_t skill, int episode, int map)
 
     // [crispy] total time for all completed levels
     totalleveltimes = 0;
+
+    // [crispy] track intermission at end of episode
+    finalintermission = false;
 
     // Set the sky map
     if (episode > 5)

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -421,6 +421,15 @@ void IN_Ticker(void)
     if (oldintertime < intertime)
     {
         interstate++;
+
+        // [crispy] skip "now entering" if it's the final intermission
+        if (interstate >= 1 && finalintermission)
+        {
+            IN_Stop();
+            G_WorldDone();
+            return;
+        }
+
         if (gameepisode > 3 && interstate >= 1)
         {                       // Extended Wad levels:  skip directly to the next level
             interstate = 3;
@@ -453,6 +462,13 @@ void IN_Ticker(void)
         {
             intertime = 150;
             skipintermission = false;
+            return;
+        }
+        // [crispy] skip "now entering" if it's the final intermission
+        else if (finalintermission)
+        {
+            IN_Stop();
+            G_WorldDone();
             return;
         }
         else if (interstate < 2 && gameepisode < 4)
@@ -777,7 +793,8 @@ void IN_DrawSingleStats(void)
         sounds++;
     }
 
-    if (gamemode != retail || gameepisode <= 3)
+    // [crispy] ignore "now entering" if it's the final intermission
+    if (gamemode != retail || gameepisode <= 3 || finalintermission)
     {
         IN_DrTextB(DEH_String("TIME"), 85, 150);
         IN_DrawTime(155, 150, hours, minutes, seconds);


### PR DESCRIPTION
Took a bit of trial and error in the intermission logic but this seems to work fine. Checked waiting for the tallies at the intermission screen as well as skipping through it, and checked e1 and e4 (since they have different intermission formats).