### PR TITLE
Add pistol/wand start command line option

### DIFF
--- a/src/crispy.h
+++ b/src/crispy.h
@@ -95,6 +95,7 @@ typedef struct
 	boolean havee1m10;
 	boolean havemap33;
 	boolean havessg;
+	boolean pistolstart;
 	boolean singleplayer;
 	boolean stretchsky;
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1680,9 +1680,10 @@ void D_DoomMain (void)
     // Automatic pistol start when advancing from one level to the next. At the
     // beginning of each level, the player's health is reset to 100, their
     // armor to 0 and their inventory is reduced to the following: pistol,
-    // fists and 50 bullets. This option has no effect when recording a demo,
+    // fists and 50 bullets. This option is not allowed when recording a demo,
     // playing back a demo or when starting a network game.
     //
+
     crispy->pistolstart = M_ParmExists("-pistolstart");
 
     //!
@@ -1824,6 +1825,7 @@ void D_DoomMain (void)
     if (p)
     {
         char *uc_filename = strdup(myargv[p + 1]);
+
         M_ForceUppercase(uc_filename);
 
         // With Vanilla you have to specify the file without extension,

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1825,7 +1825,6 @@ void D_DoomMain (void)
     if (p)
     {
         char *uc_filename = strdup(myargv[p + 1]);
-
         M_ForceUppercase(uc_filename);
 
         // With Vanilla you have to specify the file without extension,

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1674,6 +1674,18 @@ void D_DoomMain (void)
     }
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Automatic pistol start when advancing from one level to the next. At the
+    // beginning of each level, the player's health is reset to 100, their
+    // armor to 0 and their inventory is reduced to the following: pistol,
+    // fists and 50 bullets. This option has no effect when recording a demo,
+    // playing back a demo or when starting a network game.
+    //
+    crispy->pistolstart = M_ParmExists("-pistolstart");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad and .deh files.

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -852,7 +852,7 @@ void G_DoLoadLevel (void)
     R_InitSkyMap();
 
     // [crispy] pistol start
-    if (crispy->pistolstart && !demorecording && !demoplayback && !netgame)
+    if (crispy->pistolstart && crispy->singleplayer)
     {
         G_PlayerReborn(0);
     }

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -851,12 +851,6 @@ void G_DoLoadLevel (void)
     // [crispy] sky texture scales
     R_InitSkyMap();
 
-    // [crispy] pistol start
-    if (crispy->pistolstart && crispy->singleplayer)
-    {
-        G_PlayerReborn(0);
-    }
-
     levelstarttic = gametic;        // for time calculation
     
     if (wipegamestate == GS_LEVEL) 
@@ -874,6 +868,28 @@ void G_DoLoadLevel (void)
 		 
     // [crispy] update the "singleplayer" variable
     CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
+
+    // [crispy] pistol start
+    if (crispy->pistolstart)
+    {
+        if (crispy->singleplayer)
+        {
+            G_PlayerReborn(0);
+        }
+        else if (demoplayback && !singledemo)
+        {
+            // no-op - silently ignore pistolstart when playing demo from the
+            // demo reel
+        }
+        else
+        {
+            const char message[] = "The -pistolstart option is not suppported"
+                                   " for demos and\n"
+                                   " network play.";
+            I_Error(message);
+        }
+    }
+
     P_SetupLevel (gameepisode, gamemap, 0, gameskill);    
     displayplayer = consoleplayer;		// view the guy you are playing    
     gameaction = ga_nothing; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -851,6 +851,12 @@ void G_DoLoadLevel (void)
     // [crispy] sky texture scales
     R_InitSkyMap();
 
+    // [crispy] pistol start
+    if (crispy->pistolstart && !demorecording && !demoplayback && !netgame)
+    {
+        G_PlayerReborn(0);
+    }
+
     levelstarttic = gametic;        // for time calculation
     
     if (wipegamestate == GS_LEVEL) 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1019,6 +1019,18 @@ void D_DoomMain(void)
     W_CheckCorrectIWAD(heretic);
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Automatic wand start when advancing from one level to the next. At the
+    // beginning of each level, the player's health is reset to 100, their
+    // armor to 0 and their inventory is reduced to the following: wand, staff
+    // and 50 ammo for the wand. This option has no effect when recording a
+    // demo, playing back a demo or when starting a network game.
+    //
+    crispy->pistolstart = M_ParmExists("-wandstart");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1025,9 +1025,10 @@ void D_DoomMain(void)
     // Automatic wand start when advancing from one level to the next. At the
     // beginning of each level, the player's health is reset to 100, their
     // armor to 0 and their inventory is reduced to the following: wand, staff
-    // and 50 ammo for the wand. This option has no effect when recording a
+    // and 50 ammo for the wand. This option is not allowed when recording a
     // demo, playing back a demo or when starting a network game.
     //
+
     crispy->pistolstart = M_ParmExists("-wandstart");
 
     //!

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -762,6 +762,12 @@ void G_DoLoadLevel(void)
 {
     int i;
 
+    // [crispy] pistol start
+    if (crispy->pistolstart && !demorecording && !demoplayback && !netgame)
+    {
+        G_PlayerReborn(0);
+    }
+
     levelstarttic = gametic;    // for time calculation
     gamestate = GS_LEVEL;
     for (i = 0; i < MAXPLAYERS; i++)

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -763,7 +763,7 @@ void G_DoLoadLevel(void)
     int i;
 
     // [crispy] pistol start
-    if (crispy->pistolstart && !demorecording && !demoplayback && !netgame)
+    if (crispy->pistolstart && crispy->singleplayer)
     {
         G_PlayerReborn(0);
     }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -762,12 +762,6 @@ void G_DoLoadLevel(void)
 {
     int i;
 
-    // [crispy] pistol start
-    if (crispy->pistolstart && crispy->singleplayer)
-    {
-        G_PlayerReborn(0);
-    }
-
     levelstarttic = gametic;    // for time calculation
     gamestate = GS_LEVEL;
     for (i = 0; i < MAXPLAYERS; i++)
@@ -775,6 +769,30 @@ void G_DoLoadLevel(void)
         if (playeringame[i] && players[i].playerstate == PST_DEAD)
             players[i].playerstate = PST_REBORN;
         memset(players[i].frags, 0, sizeof(players[i].frags));
+    }
+
+    // [crispy] update the "singleplayer" variable
+    CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
+
+    // [crispy] wand start
+    if (crispy->pistolstart)
+    {
+        if (crispy->singleplayer)
+        {
+            G_PlayerReborn(0);
+        }
+        else if (demoplayback && !singledemo)
+        {
+            // no-op - silently ignore pistolstart when playing demo from
+            // the demo reel
+        }
+        else
+        {
+            const char message[] = "The -wandstart option is not supported"
+                                   " for demos and\n"
+                                   " network play.";
+            I_Error(message);
+        }
     }
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);


### PR DESCRIPTION
Per #654, submitting this PR which implements a basic "pistol start" command line option. When this option has been specified, the player's health and inventory are reset to game start or resurrection values. This option is disabled when recording a demo, playing back a demo or when in a network game.

These changes seem too simple (probably missing some edge cases!) so I am interested in any suggestions on how to make this more robust and worthwhile. 