### PR TITLE
Only load Sigil when gameversion is Ultimate Doom

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1852,7 +1852,7 @@ void D_DoomMain (void)
     // [crispy] allow overriding of special-casing
     if (!M_ParmExists("-noautoload") && gamemode != shareware)
     {
-	if (gamemode == retail)
+	if (gamemode == retail && gameversion == exe_ultimate)
 	{
 		D_LoadSigilWad();
 	}


### PR DESCRIPTION
Fixes errors caused by Sigil being loaded playing Chex Quest.