### PR TITLE
Support widescreen assets.

### DIFF
--- a/src/crispy.h
+++ b/src/crispy.h
@@ -222,4 +222,14 @@ enum
     NUM_WIDGETS
 };
 
+enum
+{
+    RATIO_4_3,
+    RATIO_MATCH_SCREEN,
+    RATIO_16_10,
+    RATIO_16_9,
+    RATIO_21_9,
+    NUM_RATIOS
+};
+
 #endif

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -933,9 +933,9 @@ void F_BunnyScroll (void)
     p1 = W_CacheLumpName (DEH_String("PFUB2"), PU_LEVEL);
     p2 = W_CacheLumpName (DEH_String("PFUB1"), PU_LEVEL);
 
+    // [crispy] fill pillarboxes in widescreen mode
     pillar_width = (SCREENWIDTH - (p1->width << FRACBITS) / dxi) / 2;
 
-    // [crispy] fill pillarboxes in widescreen mode
     if (pillar_width > 0)
     {
         V_DrawFilledBox(0, 0, pillar_width, SCREENHEIGHT, 0);
@@ -946,18 +946,20 @@ void F_BunnyScroll (void)
         pillar_width = 0;
     }
 
-    if (p1->width != p2->width)
+    // Calculate the portion of PFUB2 that would be offscreen at original res.
+    p1offset = (ORIGWIDTH - p1->width) / 2;
+
+    if (p2->width == ORIGWIDTH)
     {
-        // Unity PFUBs, no overlap.
-        p2offset = p2->width - (ORIGWIDTH - p1->width) / 2;
-        p1offset = p2offset - p1->width;
+        // Unity or original PFUBs.
+        // PFUB1 only contains the pixels that scroll off.
+        p2offset = ORIGWIDTH - p1offset;
     }
     else
     {
-        // Widescreen mod PFUBs, overlap.
-        // Also original PFUBs, in which case these reduce to defaults.
-        p2offset = ORIGWIDTH + (ORIGWIDTH - p2->width) / 2;
-        p1offset = (ORIGWIDTH - p1->width) / 2;
+        // Widescreen mod PFUBs.
+        // Right side of PFUB2 and left side of PFUB1 are identical.
+        p2offset = ORIGWIDTH + p1offset;
     }
 
     V_MarkRect (0, 0, SCREENWIDTH, SCREENHEIGHT);

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -890,8 +890,8 @@ F_DrawPatchCol
     pixel_t*	desttop;
     int		count;
 	
-    column = (column_t *)((byte *)patch + LONG(patch->columnofs[col >> FRACBITS]));
-    desttop = I_VideoBuffer + x + (WIDESCREENDELTA << crispy->hires);
+    column = (column_t *)((byte *)patch + LONG(patch->columnofs[col]));
+    desttop = I_VideoBuffer + x;
 
     // step through the posts in a column
     while (column->topdelta != 0xff )
@@ -924,19 +924,41 @@ void F_BunnyScroll (void)
     char	name[10];
     int		stage;
     static int	laststage;
+    int         p2offset, p1offset, pillar_width;
 		
     dxi = (ORIGWIDTH << FRACBITS) / NONWIDEWIDTH;
     dy = (SCREENHEIGHT << FRACBITS) / ORIGHEIGHT;
     dyi = (ORIGHEIGHT << FRACBITS) / SCREENHEIGHT;
 
-    // [crispy] fill pillarboxes in widescreen mode
-    if (SCREENWIDTH != NONWIDEWIDTH)
-    {
-	V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
-    }
-
     p1 = W_CacheLumpName (DEH_String("PFUB2"), PU_LEVEL);
     p2 = W_CacheLumpName (DEH_String("PFUB1"), PU_LEVEL);
+
+    pillar_width = (SCREENWIDTH - (p1->width << FRACBITS) / dxi) / 2;
+
+    // [crispy] fill pillarboxes in widescreen mode
+    if (pillar_width > 0)
+    {
+        V_DrawFilledBox(0, 0, pillar_width, SCREENHEIGHT, 0);
+        V_DrawFilledBox(SCREENWIDTH - pillar_width, 0, pillar_width, SCREENHEIGHT, 0);
+    }
+    else
+    {
+        pillar_width = 0;
+    }
+
+    if (p1->width != p2->width)
+    {
+        // Unity PFUBs, no overlap.
+        p2offset = p2->width - (ORIGWIDTH - p1->width) / 2;
+        p1offset = p2offset - p1->width;
+    }
+    else
+    {
+        // Widescreen mod PFUBs, overlap.
+        // Also original PFUBs, in which case these reduce to defaults.
+        p2offset = ORIGWIDTH + (ORIGWIDTH - p2->width) / 2;
+        p1offset = (ORIGWIDTH - p1->width) / 2;
+    }
 
     V_MarkRect (0, 0, SCREENWIDTH, SCREENHEIGHT);
 	
@@ -945,14 +967,15 @@ void F_BunnyScroll (void)
 	scrolled = ORIGWIDTH;
     if (scrolled < 0)
 	scrolled = 0;
-    scrolled <<= FRACBITS;
-		
-    for ( x=0 ; x<ORIGWIDTH << FRACBITS; x+=dxi)
+
+    for (x = pillar_width; x < SCREENWIDTH - pillar_width; x++)
     {
-	if (x+scrolled < ORIGWIDTH << FRACBITS)
-	    F_DrawPatchCol (x/dxi, p1, x+scrolled);
-	else
-	    F_DrawPatchCol (x/dxi, p2, x+scrolled - (ORIGWIDTH << FRACBITS));
+        int x2 = ((x * dxi) >> FRACBITS) - WIDESCREENDELTA + scrolled;
+
+        if (x2 < p2offset)
+            F_DrawPatchCol (x, p1, x2 - p1offset);
+        else
+            F_DrawPatchCol (x, p2, x2 - p2offset);
     }
 	
     if (finalecount < 1130)

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -135,6 +135,15 @@ multiitem_t multiitem_widgets[NUM_WIDGETS] =
     {WIDGETS_ALWAYS, "always"},
 };
 
+multiitem_t multiitem_widescreen[NUM_RATIOS] =
+{
+    {RATIO_4_3, "4:3"},
+    {RATIO_MATCH_SCREEN, "Match screen"},
+    {RATIO_16_10, "16:10"},
+    {RATIO_16_9, "16:9"},
+    {RATIO_21_9, "21:9"},
+};
+
 extern void AM_LevelInit (boolean reinit);
 extern void EnableLoadingDisk (void);
 extern void P_SegLengths (boolean contrast_only);
@@ -537,7 +546,7 @@ void M_CrispyToggleWeaponSquat(int choice)
 
 static void M_CrispyToggleWidescreenHook (void)
 {
-    crispy->widescreen = !crispy->widescreen;
+    crispy->widescreen = (crispy->widescreen + 1) % NUM_RATIOS;
 
     // [crispy] no need to re-init when switching from wide to compact
     {

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -41,6 +41,7 @@ extern multiitem_t multiitem_sndchannels[4];
 extern multiitem_t multiitem_secretmessage[NUM_SECRETMESSAGE];
 extern multiitem_t multiitem_translucency[NUM_TRANSLUCENCY];
 extern multiitem_t multiitem_widgets[NUM_WIDGETS];
+extern multiitem_t multiitem_widescreen[NUM_RATIOS];
 
 extern void M_CrispyToggleAutomapstats(int choice);
 extern void M_CrispyToggleBobfactor(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1480,7 +1480,7 @@ static void M_DrawCrispness1(void)
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
-    M_DrawCrispnessItem(crispness_widescreen, "Widescreen Rendering", crispy->widescreen, aspect_ratio_correct);
+    M_DrawCrispnessMultiItem(crispness_widescreen, "Widescreen Aspect Ratio", multiitem_widescreen, crispy->widescreen, aspect_ratio_correct);
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, true);

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -502,15 +502,15 @@ void ST_refreshBackground(boolean force)
 		}
 	}
 
-        if (sbar->width > ORIGWIDTH && sbar->leftoffset == 0)
-        {
-            // Unity wide status bar, center on screen
-            V_DrawPatch(ST_X + (ORIGWIDTH - sbar->width) / 2, 0, sbar);
-        }
-        else
-        {
-            V_DrawPatch(ST_X, 0, sbar);
-        }
+	// [crispy] center unity rerelease wide status bar
+	if (sbar->width > ORIGWIDTH && sbar->leftoffset == 0)
+	{
+	    V_DrawPatch(ST_X + (ORIGWIDTH - sbar->width) / 2, 0, sbar);
+	}
+	else
+	{
+	    V_DrawPatch(ST_X, 0, sbar);
+	}
 
 	// draw right side of bar if needed (Doom 1.0)
 	if (sbarr)

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -502,7 +502,15 @@ void ST_refreshBackground(boolean force)
 		}
 	}
 
-	V_DrawPatch(ST_X, 0, sbar);
+        if (sbar->width > ORIGWIDTH && sbar->leftoffset == 0)
+        {
+            // Unity wide status bar, center on screen
+            V_DrawPatch(ST_X + (ORIGWIDTH - sbar->width) / 2, 0, sbar);
+        }
+        else
+        {
+            V_DrawPatch(ST_X, 0, sbar);
+        }
 
 	// draw right side of bar if needed (Doom 1.0)
 	if (sbarr)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -315,16 +315,7 @@ static void AdjustWindowSize(void)
 {
     if (aspect_ratio_correct || integer_scaling)
     {
-        if (window_width * actualheight <= window_height * SCREENWIDTH)
-        {
-            // We round up window_height if the ratio is not exact; this leaves
-            // the result stable.
-            window_height = (window_width * actualheight + SCREENWIDTH - 1) / SCREENWIDTH;
-        }
-        else
-        {
-            window_width = window_height * SCREENWIDTH / actualheight;
-        }
+        window_width = window_height * SCREENWIDTH / actualheight;
     }
 }
 
@@ -1551,6 +1542,24 @@ void I_GetScreenDimensions (void)
 	// [crispy] widescreen rendering makes no sense without aspect ratio correction
 	if (crispy->widescreen && aspect_ratio_correct)
 	{
+		switch(crispy->widescreen)
+		{
+			case RATIO_16_10:
+				w = 16;
+				h = 10;
+				break;
+			case RATIO_16_9:
+				w = 16;
+				h = 9;
+				break;
+			case RATIO_21_9:
+				w = 21;
+				h = 9;
+				break;
+			default:
+				break;
+		}
+
 		SCREENWIDTH = w * ah / h;
 		// [crispy] make sure SCREENWIDTH is an integer multiple of 4 ...
 		SCREENWIDTH = (SCREENWIDTH + 3) & (int)~3;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -317,7 +317,7 @@ static void AdjustWindowSize(void)
     {
         // [crispy] always adjust window width only, otherwise repeatedly
         // changing widescreen settings causes the window to shrink.
-        if (window_width * actualheight <= window_height * SCREENWIDTH && FALSE)
+        if (window_width * actualheight <= window_height * SCREENWIDTH && false)
         {
             // We round up window_height if the ratio is not exact; this leaves
             // the result stable.

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -315,7 +315,18 @@ static void AdjustWindowSize(void)
 {
     if (aspect_ratio_correct || integer_scaling)
     {
-        window_width = window_height * SCREENWIDTH / actualheight;
+        // [crispy] always adjust window width only, otherwise repeatedly
+        // changing widescreen settings causes the window to shrink.
+        if (window_width * actualheight <= window_height * SCREENWIDTH && FALSE)
+        {
+            // We round up window_height if the ratio is not exact; this leaves
+            // the result stable.
+            window_height = (window_width * actualheight + SCREENWIDTH - 1) / SCREENWIDTH;
+        }
+        else
+        {
+            window_width = window_height * SCREENWIDTH / actualheight;
+        }
     }
 }
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -236,19 +236,22 @@ void V_DrawPatch(int x, int y, patch_t *patch)
     V_MarkRect(x, y, SHORT(patch->width), SHORT(patch->height));
 
     col = 0;
+    if (x < 0)
+    {
+	col += dxi * ((-x * dx) >> FRACBITS);
+	x = 0;
+    }
+
     desttop = dest_screen + ((y * dy) >> FRACBITS) * SCREENWIDTH + ((x * dx) >> FRACBITS);
 
     w = SHORT(patch->width);
 
+    // convert x to screen position
+    x = (x * dx) >> FRACBITS;
+
     for ( ; col<w << FRACBITS ; x++, col+=dxi, desttop++)
     {
         int topdelta = -1;
-
-        // [crispy] too far left
-        if (x < 0)
-        {
-            continue;
-        }
 
         // [crispy] too far right / width
         if (x >= SCREENWIDTH)
@@ -305,13 +308,7 @@ void V_DrawPatch(int x, int y, patch_t *patch)
 
 void V_DrawPatchFullScreen(patch_t *patch, boolean flipped)
 {
-    const short width = SHORT(patch->width);
-    const short height = SHORT(patch->height);
-
-    dx = (NONWIDEWIDTH << FRACBITS) / ORIGWIDTH;
-    dxi = (width << FRACBITS) / NONWIDEWIDTH;
-    dy = (SCREENHEIGHT << FRACBITS) / height;
-    dyi = (height << FRACBITS) / SCREENHEIGHT;
+    int x = ((SCREENWIDTH >> crispy->hires) - patch->width) / 2 - WIDESCREENDELTA;
 
     patch->leftoffset = 0;
     patch->topoffset = 0;
@@ -324,17 +321,12 @@ void V_DrawPatchFullScreen(patch_t *patch, boolean flipped)
 
     if (flipped)
     {
-        V_DrawPatchFlipped(0, 0, patch);
+        V_DrawPatchFlipped(x, 0, patch);
     }
     else
     {
-        V_DrawPatch(0, 0, patch);
+        V_DrawPatch(x, 0, patch);
     }
-
-    dx = (NONWIDEWIDTH << FRACBITS) / ORIGWIDTH;
-    dxi = (ORIGWIDTH << FRACBITS) / NONWIDEWIDTH;
-    dy = (SCREENHEIGHT << FRACBITS) / ORIGHEIGHT;
-    dyi = (ORIGHEIGHT << FRACBITS) / SCREENHEIGHT;
 }
 
 //
@@ -377,9 +369,18 @@ void V_DrawPatchFlipped(int x, int y, patch_t *patch)
     V_MarkRect (x, y, SHORT(patch->width), SHORT(patch->height));
 
     col = 0;
+    if (x < 0)
+    {
+	col += dxi * ((-x * dx) >> FRACBITS);
+	x = 0;
+    }
+
     desttop = dest_screen + ((y * dy) >> FRACBITS) * SCREENWIDTH + ((x * dx) >> FRACBITS);
 
     w = SHORT(patch->width);
+
+    // convert x to screen position
+    x = (x * dx) >> FRACBITS;
 
     for ( ; col<w << FRACBITS ; x++, col+=dxi, desttop++)
     {


### PR DESCRIPTION
Here's a crispy version of https://github.com/chocolate-doom/chocolate-doom/pull/1317 .

This version adds support for widescreen huds from https://forum.zdoom.org/viewtopic.php?f=19&t=37960 , and the Doom widescreen modding assets from https://bethesda.net/en/game/doom-widescreen-mods , as long as they're placed in a pwad and converted to native Doom graphics format.