### PR TITLE
Add configurable status bar color thresholds in config file

### DIFF
--- a/src/crispy.c
+++ b/src/crispy.c
@@ -29,6 +29,17 @@ static crispy_t crispy_s = {
 	.smoothscaling = 1,
 	.soundfix = 1,
 	.vsync = 1,
+	.redhealth = 25,
+	.yellowhealth = 50,
+	.greenhealth = 100,
+	.redarmor = 25,
+	.yellowarmor = 50,
+	.greenarmor = 100,
+	.redammo = 25,
+	.yellowammo = 50,
+	.greenammo = 100,
+	.graypercent = 1,
+	.armorcolorbytype = 1,
 };
 crispy_t *const crispy = &crispy_s;
 

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -82,6 +82,18 @@ typedef struct
 	int weaponsquat;
 	int widescreen;
 
+	int redhealth;
+	int yellowhealth;
+	int greenhealth;
+	int redarmor;
+	int yellowarmor;
+	int greenarmor;
+	int redammo;
+	int yellowammo;
+	int greenammo;
+	int graypercent;
+	int armorcolorbytype;
+
 	// [crispy] in-game switches and variables
 	int screenshotmsg;
 	int cleanscreenshot;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -469,6 +469,17 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);
     M_BindIntVariable("crispy_weaponsquat",     &crispy->weaponsquat);
     M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);
+    M_BindIntVariable("crispy_redhealth",       &crispy->redhealth);
+    M_BindIntVariable("crispy_yellowhealth",    &crispy->yellowhealth);
+    M_BindIntVariable("crispy_greenhealth",     &crispy->greenhealth);
+    M_BindIntVariable("crispy_redarmor",        &crispy->redarmor);
+    M_BindIntVariable("crispy_yellowarmor",     &crispy->yellowarmor);
+    M_BindIntVariable("crispy_greenarmor",      &crispy->greenarmor);
+    M_BindIntVariable("crispy_redammo",         &crispy->redammo);
+    M_BindIntVariable("crispy_yellowammo",      &crispy->yellowammo);
+    M_BindIntVariable("crispy_greenammo",       &crispy->greenammo);
+    M_BindIntVariable("crispy_graypercent",     &crispy->graypercent);
+    M_BindIntVariable("crispy_armorcolorbytype",&crispy->armorcolorbytype);
 }
 
 //

--- a/src/doom/st_lib.c
+++ b/src/doom/st_lib.c
@@ -198,7 +198,7 @@ STlib_updatePercent
 
     STlib_updateNum(&per->n, refresh); // [crispy] moved here
 
-    if (crispy->coloredhud & COLOREDHUD_BAR)
+    if (crispy->graypercent && crispy->coloredhud & COLOREDHUD_BAR)
         dp_translation = cr[CR_GRAY];
 
     if (refresh && *per->n.on)

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -1762,11 +1762,13 @@ static byte* ST_WidgetColor(int i)
                 int ammo =  plyr->ammo[weaponinfo[plyr->readyweapon].ammo];
                 int fullammo = maxammo[weaponinfo[plyr->readyweapon].ammo];
 
-                if (ammo < fullammo/4)
+		int ammopercent = 100 * ammo / fullammo;
+
+                if (ammopercent < crispy->redammo)
                     return cr[CR_RED];
-                else if (ammo < fullammo/2)
+                else if (ammopercent < crispy->yellowammo)
                     return cr[CR_GOLD];
-                else if (ammo <= fullammo)
+                else if (ammopercent < crispy->greenammo)
                     return cr[CR_GREEN];
                 else
                     return cr[CR_BLUE];
@@ -1781,11 +1783,11 @@ static byte* ST_WidgetColor(int i)
             if (plyr->cheats & CF_GODMODE ||
                 plyr->powers[pw_invulnerability])
                 return cr[CR_GRAY];
-            else if (health < 25)
+            else if (health < crispy->redhealth)
                 return cr[CR_RED];
-            else if (health < 50)
+            else if (health < crispy->yellowhealth)
                 return cr[CR_GOLD];
-            else if (health <= 100)
+            else if (health <= crispy->greenhealth)
                 return cr[CR_GREEN];
             else
                 return cr[CR_BLUE];
@@ -1811,26 +1813,29 @@ static byte* ST_WidgetColor(int i)
 	    if (plyr->cheats & CF_GODMODE ||
                 plyr->powers[pw_invulnerability])
                 return cr[CR_GRAY];
-	    // [crispy] color by armor type
-	    else if (plyr->armortype >= 2)
-                return cr[CR_BLUE];
-	    else if (plyr->armortype == 1)
-                return cr[CR_GREEN];
-	    else if (plyr->armortype == 0)
-                return cr[CR_RED];
-/*
-            // [crispy] alternatively, color by armor points
-            int armor = plyr->armorpoints;
 
-            if (armor < 25)
-                return cr[CR_RED];
-            else if (armor < 50)
-                return cr[CR_GOLD];
-            else if (armor <= 100)
-                return cr[CR_GREEN];
-            else
-                return cr[CR_BLUE];
-*/
+	    if (crispy->armorcolorbytype) {
+	        // [crispy] color by armor type
+	        if (plyr->armortype >= 2)
+                    return cr[CR_BLUE];
+	        else if (plyr->armortype == 1)
+                    return cr[CR_GREEN];
+	        else if (plyr->armortype == 0)
+                    return cr[CR_RED];
+	    } else {
+                // [crispy] alternatively, color by armor points
+                int armor = plyr->armorpoints;
+
+                if (armor < crispy->redarmor)
+                    return cr[CR_RED];
+                else if (armor < crispy->yellowarmor)
+                    return cr[CR_GOLD];
+                else if (armor <= crispy->greenarmor)
+                    return cr[CR_GREEN];
+                else
+                    return cr[CR_BLUE];
+	    }
+
             break;
         }
     }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2234,6 +2234,18 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(crispy_widescreen),
+
+    CONFIG_VARIABLE_INT(crispy_redhealth),
+    CONFIG_VARIABLE_INT(crispy_yellowhealth),
+    CONFIG_VARIABLE_INT(crispy_greenhealth),
+    CONFIG_VARIABLE_INT(crispy_redarmor),
+    CONFIG_VARIABLE_INT(crispy_yellowarmor),
+    CONFIG_VARIABLE_INT(crispy_greenarmor),
+    CONFIG_VARIABLE_INT(crispy_redammo),
+    CONFIG_VARIABLE_INT(crispy_yellowammo),
+    CONFIG_VARIABLE_INT(crispy_greenammo),
+    CONFIG_VARIABLE_INT(crispy_graypercent),
+    CONFIG_VARIABLE_INT(crispy_armorcolorbytype),
 };
 
 static default_collection_t extra_defaults =

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -102,6 +102,17 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_vsync",           &crispy->vsync);
         M_BindIntVariable("crispy_weaponsquat",     &crispy->weaponsquat);
         M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);
+        M_BindIntVariable("crispy_redhealth",       &crispy->redhealth);
+        M_BindIntVariable("crispy_yellowhealth",    &crispy->yellowhealth);
+        M_BindIntVariable("crispy_greenhealth",     &crispy->greenhealth);
+        M_BindIntVariable("crispy_redarmor",        &crispy->redarmor);
+        M_BindIntVariable("crispy_yellowarmor",     &crispy->yellowarmor);
+        M_BindIntVariable("crispy_greenarmor",      &crispy->greenarmor);
+        M_BindIntVariable("crispy_redammo",         &crispy->redammo);
+        M_BindIntVariable("crispy_yellowammo",      &crispy->yellowammo);
+        M_BindIntVariable("crispy_greenammo",       &crispy->greenammo);
+        M_BindIntVariable("crispy_graypercent",     &crispy->graypercent);
+        M_BindIntVariable("crispy_armorcolorbytype",&crispy->armorcolorbytype);
     }
     else if (gamemission == heretic)
     {


### PR DESCRIPTION
One feature I loved from PrBoom is the ability to set the status bar color thresholds to your preferences, so I have added config file options to set these. The ingame crispness menu has been unchanged to avoid cluttering it.

The following options have been added in crispy-doom.cfg:
|Config file option|Description|Default value
|-|-|-|
|crispy_redhealth|If health gets below this threshold, the health value becomes red|25|
|crispy_yellowhealth|If health gets below this threshold, the health value becomes yellow|50|
|crispy_greenhealth|If health gets below or equal this threshold, the health value becomes green, otherwise blue|100|
|crispy_redarmor|If armor gets below this threshold, the armor value becomes red|25|
|crispy_yellowarmor|If armor gets below this threshold, the armor value becomes yellow|50|
|crispy_greenarmor|If armor gets below or equal this threshold, the armor value becomes green, otherwise blue|100|
|crispy_redammo|If the ammo percentage gets below this threshold, the ammo value becomes red|25|
|crispy_yellowammo|If the ammo percentage gets below this threshold, the ammo value becomes yellow|50|
|crispy_greenammo|If the ammo percentage gets below this threshold, the ammo value becomes green, otherwise blue|100|
|crispy_graypercent|If this option is set to 1, then the percent signs are colored gray, otherwise it matches the color of the value|1|
|crispy_armorcolorbytype|If this option is set to 1, then the armor value becomes red if the player has no armor present, green if the player wears a green armor and blue if the player wears a blue armor. If this option is set to 0, then the armor color thresholds above apply|1|


