### PR TITLE
apply special treatment for NRFTL and Masterlevels - even during demos

### DIFF
--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -148,15 +148,6 @@ void F_StartFinale (void)
             screen->level = 5;
         }
 
-        // [crispy] During demo recording/playback or network games
-        // these two packs behave like any other ordinary PWAD
-        if (!crispy->singleplayer &&
-            (gamemission == pack_nerve || gamemission == pack_master)
-            && screen->mission == doom2)
-        {
-            screen->mission = gamemission;
-        }
-
         if (logical_gamemission == screen->mission
          && (logical_gamemission != doom || gameepisode == screen->episode)
          && gamemap == screen->level)
@@ -212,10 +203,10 @@ void F_Ticker (void)
 				
       if (i < MAXPLAYERS)
       {	
-	if (gamemission == pack_nerve && crispy->singleplayer && gamemap == 8)
+	if (gamemission == pack_nerve && gamemap == 8)
 	  F_StartCast ();
 	else
-	if (gamemission == pack_master && crispy->singleplayer && (gamemap == 20 || gamemap == 21))
+	if (gamemission == pack_master && (gamemap == 20 || gamemap == 21))
 	  F_StartCast ();
 	else
 	if (gamemap == 30)

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1836,7 +1836,7 @@ void G_DoCompleted (void)
     wminfo.last = gamemap -1;
     
     // wminfo.next is 0 biased, unlike gamemap
-    if ( gamemission == pack_nerve && gamemap <= 9 && crispy->singleplayer )
+    if ( gamemission == pack_nerve && gamemap <= 9 )
     {
 	if (secretexit)
 	    switch(gamemap)
@@ -1851,7 +1851,7 @@ void G_DoCompleted (void)
 	    }
     }
     else
-    if ( gamemission == pack_master && gamemap <= 21 && crispy->singleplayer )
+    if ( gamemission == pack_master && gamemap <= 21 )
     {
 	wminfo.next = gamemap;
     }
@@ -1938,8 +1938,8 @@ void G_DoCompleted (void)
         {
             wminfo.partime = TICRATE*bex_cpars[gamemap-1];
         }
-        // [crispy] single player par times for NRFTL
-        else if (gamemission == pack_nerve && crispy->singleplayer)
+        // [crispy] par times for NRFTL
+        else if (gamemission == pack_nerve)
         {
             wminfo.partime = TICRATE*npars[gamemap-1];
         }
@@ -2016,7 +2016,7 @@ void G_WorldDone (void)
       if (!crispy->havee1m10 || gameepisode != 1 || gamemap != 1)
 	players[consoleplayer].didsecret = true; 
 
-    if ( gamemission == pack_nerve && crispy->singleplayer )
+    if ( gamemission == pack_nerve )
     {
 	switch (gamemap)
 	{
@@ -2026,7 +2026,7 @@ void G_WorldDone (void)
 	}
     }
     else
-    if ( gamemission == pack_master && crispy->singleplayer )
+    if ( gamemission == pack_master )
     {
 	switch (gamemap)
 	{

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -1730,7 +1730,7 @@ void A_BossDeath (mobj_t* mo)
     {
 	if (gamemap != 7 &&
 	// [crispy] Master Levels in PC slot 7
-	!(crispy->singleplayer && gamemission == pack_master && (gamemap == 14 || gamemap == 15 || gamemap == 16)))
+	!(gamemission == pack_master && (gamemap == 14 || gamemap == 15 || gamemap == 16)))
 	    return;
 		
 	if ((mo->type != MT_FATSO)
@@ -1775,7 +1775,7 @@ void A_BossDeath (mobj_t* mo)
     {
 	if (gamemap == 7 ||
 	// [crispy] Master Levels in PC slot 7
-	(crispy->singleplayer && gamemission == pack_master && (gamemap == 14 || gamemap == 15 || gamemap == 16)))
+	(gamemission == pack_master && (gamemap == 14 || gamemap == 15 || gamemap == 16)))
 	{
 	    if (mo->type == MT_FATSO)
 	    {

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -868,10 +868,9 @@ void WI_drawShowNextLoc(void)
 	    WI_drawOnLnode(wbs->next, yah); 
     }
 
-    if (crispy->singleplayer && (
-        (gamemission == pack_nerve && wbs->last == 7) ||
+    if ((gamemission == pack_nerve && wbs->last == 7) ||
         (gamemission == pack_master && wbs->last == 19 && !secretexit) ||
-        (gamemission == pack_master && wbs->last == 20)))
+        (gamemission == pack_master && wbs->last == 20))
         return;
 
     // draws which level you are entering..
@@ -1517,8 +1516,8 @@ static boolean WI_drawParTime (void)
 			result = false;
 		}
 
-		// [crispy] PWAD: NRFTL has par times (for singleplayer games)
-		if (gamemission == pack_nerve && crispy->singleplayer)
+		// [crispy] PWAD: NRFTL has par times
+		if (gamemission == pack_nerve)
 		{
 			result = true;
 		}


### PR DESCRIPTION
With this change, both NRFTL and The Masterlevels get full special
treatment - even during network games, demo recording and playback.
This includes level transitions to the secret maps and back, finale
text screens, par times etc.

Users who insist on the pure Vanilla experience that was applied in
previous releases or who need it to properly play back demos recorded
with a previous release may want to simply rename their NERVE.WAD PWAD
file and explicitly load it on the command line.

Thanks Coincident and Keyboard_Doomer for input from the DSDA
community!