### PR TITLE
Fix bezel crash.

### DIFF
--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -933,7 +933,6 @@ void R_ExecuteSetViewSize (void)
 
     // [crispy] forcefully initialize the status bar backing screen
     ST_refreshBackground(true);
-    ST_drawWidgets(true);
 }
 
 

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -539,8 +539,15 @@ void ST_refreshBackground(boolean force)
 
 	// [crispy] copy entire SCREENWIDTH, to preserve the pattern
 	// to the left and right of the status bar in widescren mode
-	if (st_classicstatusbar)
-	V_CopyRect(ST_X, 0, st_backing_screen, SCREENWIDTH >> crispy->hires, ST_HEIGHT, ST_X, ST_Y);
+	if (!force)
+	{
+	    V_CopyRect(ST_X, 0, st_backing_screen, SCREENWIDTH >> crispy->hires, ST_HEIGHT, ST_X, ST_Y);
+	}
+	else if (WIDESCREENDELTA > 0)
+	{
+	    V_CopyRect(0, 0, st_backing_screen, WIDESCREENDELTA, ST_HEIGHT, 0, ST_Y);
+	    V_CopyRect(ORIGWIDTH + WIDESCREENDELTA, 0, st_backing_screen, WIDESCREENDELTA, ST_HEIGHT, ORIGWIDTH + WIDESCREENDELTA, ST_Y);
+	}
     }
 
 }

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -58,7 +58,6 @@ void ST_Init (void);
 
 // [crispy] forcefully initialize the status bar backing screen
 extern void ST_refreshBackground(boolean force);
-extern void ST_drawWidgets(boolean refresh);
 
 
 // States for status bar code.


### PR DESCRIPTION
Just fixing a bug I saw reported at https://www.doomworld.com/forum/topic/67168-crispy-doom-592-update-sep-22-2020/?do=findComment&comment=2207398 .