### PR TITLE
d_net: allow up to 8 players in deathmatch

### DIFF
--- a/src/doom/d_englsh.h
+++ b/src/doom/d_englsh.h
@@ -365,6 +365,11 @@
 #define HUSTR_KEYINDIGO	'i'
 #define HUSTR_KEYBROWN	'b'
 #define HUSTR_KEYRED	'r'
+#define HUSTR_KEYPLAYER5	'j'
+#define HUSTR_KEYPLAYER6	'y'
+#define HUSTR_KEYPLAYER7	'h'
+#define HUSTR_KEYPLAYER8	'l'
+
 
 //
 //	AM_map.C

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -394,6 +394,10 @@ void D_BindVariables(void)
     key_multi_msgplayer[1] = HUSTR_KEYINDIGO;
     key_multi_msgplayer[2] = HUSTR_KEYBROWN;
     key_multi_msgplayer[3] = HUSTR_KEYRED;
+    key_multi_msgplayer[4] = HUSTR_KEYPLAYER5;
+    key_multi_msgplayer[5] = HUSTR_KEYPLAYER6;
+    key_multi_msgplayer[6] = HUSTR_KEYPLAYER7;
+    key_multi_msgplayer[7] = HUSTR_KEYPLAYER8;
 
     NET_BindVariables();
 
@@ -2006,9 +2010,6 @@ void D_DoomMain (void)
     printf ("NET_Init: Init network subsystem.\n");
     NET_Init ();
 
-    // Initial netgame startup. Connect to server etc.
-    D_ConnectNetGame();
-
     // get skill / episode / map from parms
     startskill = sk_medium;
     startepisode = 1;
@@ -2190,9 +2191,6 @@ void D_DoomMain (void)
     DEH_printf("S_Init: Setting up sound.\n");
     S_Init (sfxVolume * 8, musicVolume * 8);
 
-    DEH_printf("D_CheckNetGame: Checking network game status.\n");
-    D_CheckNetGame ();
-
     PrintGameVersion();
 
     DEH_printf("HU_Init: Setting up heads up display.\n");
@@ -2252,6 +2250,18 @@ void D_DoomMain (void)
 	G_LoadGame(file);
     }
 	
+    if (gameaction != ga_loadgame )
+    {
+	if (autostart || netgame)
+            G_InitNew (startskill, startepisode, startmap);
+    }
+
+    // Initial netgame startup. Connect to server etc.
+    D_ConnectNetGame();
+
+    DEH_printf("D_CheckNetGame: Checking network game status.\n");
+    D_CheckNetGame ();
+
     if (gameaction != ga_loadgame )
     {
 	if (autostart || netgame)

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -161,7 +161,11 @@ static void InitConnectData(net_connect_data_t *connect_data)
 {
     boolean shorttics;
 
-    connect_data->max_players = MAXPLAYERS;
+    if (deathmatch)
+      connect_data->max_players = MAX(MIN(deathmatch_p - deathmatchstarts, MAXPLAYERS), MINPLAYERS);
+    else
+      connect_data->max_players = 4;
+
     connect_data->drone = false;
 
     //!

--- a/src/doom/doomdef.h
+++ b/src/doom/doomdef.h
@@ -41,8 +41,11 @@
 // most parameter validation debugging code will not be compiled
 #define RANGECHECK
 
+// The manimum number of players, multiplayer/networking.
+#define MINPLAYERS 4
+
 // The maximum number of players, multiplayer/networking.
-#define MAXPLAYERS 4
+#define MAXPLAYERS 8
 
 // The current state of the game: whether we are
 // playing, gazing at the intermission screen,

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1529,8 +1529,8 @@ void G_DeathMatchSpawnPlayer (int playernum)
     int				selections; 
 	 
     selections = deathmatch_p - deathmatchstarts; 
-    if (selections < 4) 
-	I_Error ("Only %i deathmatch spots, 4 required", selections); 
+    if (selections < MINPLAYERS) 
+	I_Error ("Only %i deathmatch spots, %i required", selections, MINPLAYERS); 
  
     for (j=0 ; j<20 ; j++) 
     { 

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -1842,11 +1842,11 @@ static void WI_loadUnloadData(load_callback_t callback)
     for (i=0 ; i<MAXPLAYERS ; i++)
     {
 	// "1,2,3,4"
-	DEH_snprintf(name, 9, "STPB%d", i);
+	DEH_snprintf(name, 9, "STPB%d", i%4);
         callback(name, &p[i]);
 
 	// "1,2,3,4"
-	DEH_snprintf(name, 9, "WIBP%d", i+1);
+	DEH_snprintf(name, 9, "WIBP%d", i%4+1);
         callback(name, &bp[i]);
     }
 


### PR DESCRIPTION
Please don't merge as-is.

This commit adds dynamic behavior in d_net.c where the amount of allowed player slots are dependent on the number of deathmatch starts present in the selected map. That said, subsequent maploads of course may load maps with less multiplayer starts than present in the starting map, potentially leading to automatic telefrags later on?

This does however depend on a chicken/egg type situation as G_InitNew needs to be run before D_ConnectNetGame which needs to be run before G_InitNew, the current approach works by running G_InitNew twice works, but is obviously not the way to go.

A much simpler approach would be to just raise MAXPLAYERS to 8 (and the %4's in wi_stuff) and let players discover the map limits via telefrags to start with...