### PR TITLE
Show weapon pickup messages in cooperative multiplayer and implement additional cheat codes

### DIFF
--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -491,6 +491,7 @@ typedef struct player_s
 #define	CF_GODMODE		2
 #define	CF_NOMOMENTUM	4       // not really a cheat, just a debug aid
 #define CF_SHOWFPS      8       // [crispy]
+#define CF_NOTARGET     16      // [crispy]
 
 #define	SBARHEIGHT	(42 << crispy->hires)      // status bar height at bottom of screen
 

--- a/src/heretic/dstrings.h
+++ b/src/heretic/dstrings.h
@@ -102,11 +102,24 @@
 #define TXT_CHEATSCREENSHOT		"SCREENSHOT"
 #define TXT_CHEATCHICKENON		"CHICKEN ON"
 #define TXT_CHEATCHICKENOFF		"CHICKEN OFF"
-#define TXT_SHOWFPSON			"SHOW FPS ON"	// [crispy]
-#define TXT_SHOWFPSOFF			"SHOW FPS OFF"	// [crispy]
 #define TXT_CHEATMASSACRE		"MASSACRE"
 #define TXT_CHEATIDDQD			"TRYING TO CHEAT, EH?  NOW YOU DIE!"
 #define TXT_CHEATIDKFA			"CHEATER - YOU DON'T DESERVE WEAPONS"
+
+// [crispy] strings for new cheats
+#define TXT_SHOWFPSON			"SHOW FPS ON"
+#define TXT_SHOWFPSOFF			"SHOW FPS OFF"
+#define TXT_CHEATNOTARGETON             "NOTARGET MODE ON"
+#define TXT_CHEATNOTARGETOFF            "NOTARGET MODE OFF"
+#define TXT_CHEATWEAPREMOVEALL          "ALL WEAPONS REMOVED"
+#define TXT_CHEATWEAPBAD                "WEAPON NOT AVAILABLE"
+#define TXT_CHEATWEAPADD                "WEAPON %i ADDED"
+#define TXT_CHEATWEAPREMOVE             "WEAPON %i REMOVED"
+#define TXT_CHEATSPECHIT                "%i SPECIAL LINE%s TRIGGERED"
+#define TXT_CHEATNOMOMON                "NO MOMENTUM MODE ON"
+#define TXT_CHEATNOMOMOFF               "NO MOMENTUM MODE OFF"
+#define TXT_HOMDETECTON                 "HOM DETECTION ON"
+#define TXT_HOMDETECTOFF                "HOM DETECTION OFF"
 
 //---------------------------------------------------------------------------
 //

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -142,6 +142,12 @@ void P_RecursiveSound(sector_t * sec, int soundblocks)
 
 void P_NoiseAlert(mobj_t * target, mobj_t * emmiter)
 {
+    // [crispy] monsters are deaf with NOTARGET cheat
+    if (target && target->player && (target->player->cheats & CF_NOTARGET))
+    {
+        return;
+    }
+
     soundtarget = target;
     validcount++;
     P_RecursiveSound(emmiter->subsector->sector, 0);
@@ -546,6 +552,11 @@ boolean P_LookForPlayers(mobj_t * actor, boolean allaround)
             return false;       // done looking
 
         player = &players[actor->lastlook];
+
+        // [crispy] monsters don't look for players with NOTARGET cheat
+        if (player->cheats & CF_NOTARGET)
+            continue;
+
         if (player->health <= 0)
             continue;           // dead
         if (!P_CheckSight(actor, player->mo))

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -233,6 +233,20 @@ boolean P_GiveAmmo(player_t * player, ammotype_t ammo, int count)
 //
 //--------------------------------------------------------------------------
 
+// [crispy] show weapon pickup messages in multiplayer games
+const char *const WeaponPickupMessages[NUMWEAPONS] =
+{
+    NULL, // wp_staff
+    NULL, // wp_goldwand
+    TXT_WPNCROSSBOW,
+    TXT_WPNBLASTER,
+    TXT_WPNSKULLROD,
+    TXT_WPNPHOENIXROD,
+    TXT_WPNMACE,
+    TXT_WPNGAUNTLETS,
+    NULL // wp_beak
+};
+
 boolean P_GiveWeapon(player_t * player, weapontype_t weapon)
 {
     boolean gaveAmmo;
@@ -248,6 +262,10 @@ boolean P_GiveWeapon(player_t * player, weapontype_t weapon)
         player->weaponowned[weapon] = true;
         P_GiveAmmo(player, wpnlev1info[weapon].ammo, GetWeaponAmmo[weapon]);
         player->pendingweapon = weapon;
+	
+        // [crispy] show weapon pickup messages in multiplayer games
+        P_SetMessage(player, DEH_String(WeaponPickupMessages[weapon]), false);
+
         if (player == &players[consoleplayer])
         {
             S_StartSound(NULL, sfx_wpnup);

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -21,6 +21,7 @@
 #include "m_bbox.h"
 #include "r_local.h"
 #include "tables.h"
+#include "v_video.h" // [crispy] V_DrawFilledBox for HOM detector
 
 int viewangleoffset;
 

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -856,6 +856,15 @@ void R_RenderPlayerView(player_t * player)
     R_ClearDrawSegs();
     R_ClearPlanes();
     R_ClearSprites();
+
+    // [crispy] flashing HOM indicator
+    if (crispy->flashinghom)
+    {
+        V_DrawFilledBox(viewwindowx, viewwindowy,
+            scaledviewwidth, viewheight,
+            160 - (gametic % 16));
+    }
+
     NetUpdate();                // check for new console commands
     R_InterpolateTextureOffsets(); // [crispy] smooth texture scrolling
     R_RenderBSPNode(numnodes - 1);      // the head node is the last node output

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1498,10 +1498,12 @@ static void CheatSpecHitFunc(player_t *player, Cheat_t *cheat)
         if (lines[i].special)
         {
             // do not trigger level exits or teleports
-            // 39 = teleport, 97 = retrig teleport,
-            // 52 = regular exit, 105 = secret exit
+            // 39 = teleport, 97 = retrig teleport
+            // 52 = regular walk exit, 105 = secret walk exit
+            // 11 = regular switch exit, 51 = secret switch exit
             if (lines[i].special == 39 || lines[i].special == 97 ||
-                lines[i].special == 52 || lines[i].special == 105)
+                lines[i].special == 52 || lines[i].special == 105 ||
+                lines[i].special == 11 || lines[i].special == 51)
             {
                 continue;
             }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1477,7 +1477,7 @@ static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat)
 }
 
 // [crispy] trigger all special lines available on the map
-#define NO_INDEX ((unsigned short)-1)
+#define NO_INDEX (-1)
 static void CheatSpecHitFunc(player_t *player, Cheat_t *cheat)
 {
     int i, speciallines = 0;

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1359,7 +1359,6 @@ static void CheatShowFpsFunc(player_t* player, Cheat_t* cheat)
 // [crispy] implement boom-style "tntweap?" cheat
 extern boolean P_GiveWeapon(player_t * player, weapontype_t weapon);
 extern const char *const WeaponPickupMessages[NUMWEAPONS];
-extern boolean P_CheckAmmo(player_t * player);
 
 static boolean WeaponAvailable (int w)
 {
@@ -1374,6 +1373,27 @@ static boolean WeaponAvailable (int w)
     }
 
     return true;
+}
+
+// same order of preference as in p_inter.c:WeaponValue
+static weapontype_t PickBestWeapon(player_t *player)
+{
+    int i;
+
+    for (i = wp_mace; i >= wp_goldwand; i--)
+    {
+        if (player->weaponowned[i])
+        {
+            return i;
+        }
+    }
+
+    if (player->weaponowned[wp_gauntlets])
+    {
+        return wp_gauntlets;
+    }
+
+    return wp_staff;
 }
 
 static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat)
@@ -1435,8 +1455,8 @@ static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat)
     setmsg = 0;
 
     // do not give registered only weapons if in shareware mode
-    // or the chicken beak
-    if (!WeaponAvailable(w))
+    // or touch the chicken beak, never remove staff
+    if (!WeaponAvailable(w) || w == wp_staff)
     {
         return;
     }
@@ -1463,7 +1483,7 @@ static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat)
         // if current weapon was removed, select another one
         if (w == player->readyweapon)
         {
-            P_CheckAmmo(player);
+            player->pendingweapon = PickBestWeapon(player);
         }
     }
 

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -60,10 +60,17 @@ static void CheatArtifact2Func(player_t * player, Cheat_t * cheat);
 static void CheatArtifact3Func(player_t * player, Cheat_t * cheat);
 static void CheatWarpFunc(player_t * player, Cheat_t * cheat);
 static void CheatChickenFunc(player_t * player, Cheat_t * cheat);
-static void CheatShowFpsFunc(player_t* player, Cheat_t* cheat); // [crispy]
 static void CheatMassacreFunc(player_t * player, Cheat_t * cheat);
 static void CheatIDKFAFunc(player_t * player, Cheat_t * cheat);
 static void CheatIDDQDFunc(player_t * player, Cheat_t * cheat);
+
+// [crispy] new cheat functions
+static void CheatShowFpsFunc(player_t *player, Cheat_t *cheat);
+static void CheatNoTargetFunc(player_t *player, Cheat_t *cheat);
+static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat);
+static void CheatSpecHitFunc(player_t *player, Cheat_t *cheat);
+static void CheatNoMomentumFunc(player_t *player, Cheat_t *cheat);
+static void CheatHomDetectFunc(player_t *player, Cheat_t *cheat);
 
 // Public Data
 
@@ -154,14 +161,19 @@ cheatseq_t CheatWarpSeq = CHEAT("engage", 2);
 // Save a screenshot
 cheatseq_t CheatChickenSeq = CHEAT("cockadoodledoo", 0);
 
-// [crispy] Show FPS
-cheatseq_t CheatShowFpsSeq = CHEAT("showfps", 0);
-
 // Kill all monsters
 cheatseq_t CheatMassacreSeq = CHEAT("massacre", 0);
 
 cheatseq_t CheatIDKFASeq = CHEAT("idkfa", 0);
 cheatseq_t CheatIDDQDSeq = CHEAT("iddqd", 0);
+
+// [crispy] new cheat sequences
+cheatseq_t CheatShowFpsSeq = CHEAT("showfps", 0);         // Show FPS
+cheatseq_t CheatNoTargetSeq = CHEAT("notarget", 0);       // Monsters don't target player
+cheatseq_t CheatAddRemoveWpnSeq = CHEAT("weap", 1);       // Add/remove single weapon, or bag
+cheatseq_t CheatSpecHitSeq = CHEAT("spechits", 0);        // Trigger all special lines in map
+cheatseq_t CheatNoMomentumSeq = CHEAT("nomomentum", 0);   // No momentum mode
+cheatseq_t CheatHomDetectSeq = CHEAT("homdet", 0);        // Flash unrendered areas red
 
 static Cheat_t Cheats[] = {
     {CheatGodFunc,       &CheatGodSeq},
@@ -177,11 +189,19 @@ static Cheat_t Cheats[] = {
     {CheatArtifact3Func, &CheatArtifact3Seq},
     {CheatWarpFunc,      &CheatWarpSeq},
     {CheatChickenFunc,   &CheatChickenSeq},
-    {CheatShowFpsFunc,   &CheatShowFpsSeq},
     {CheatMassacreFunc,  &CheatMassacreSeq},
     {CheatIDKFAFunc,     &CheatIDKFASeq},
     {CheatIDDQDFunc,     &CheatIDDQDSeq},
-    {NULL,               NULL} 
+
+    // [crispy] new cheats
+    {CheatShowFpsFunc,      &CheatShowFpsSeq},
+    {CheatNoTargetFunc,     &CheatNoTargetSeq},
+    {CheatAddRemoveWpnFunc, &CheatAddRemoveWpnSeq},
+    {CheatSpecHitFunc,      &CheatSpecHitSeq},
+    {CheatNoMomentumFunc,   &CheatNoMomentumSeq},
+    {CheatHomDetectFunc,    &CheatHomDetectSeq},
+
+    {NULL,               NULL}
 };
 
 //---------------------------------------------------------------------------
@@ -1286,20 +1306,6 @@ static void CheatChickenFunc(player_t * player, Cheat_t * cheat)
     }
 }
 
-// [crispy] "Cheat" to show FPS
-static void CheatShowFpsFunc(player_t* player, Cheat_t* cheat)
-{
-    player->cheats ^= CF_SHOWFPS;
-    if (player->cheats & CF_SHOWFPS)
-    {
-        P_SetMessage(player, DEH_String(TXT_SHOWFPSON), false);
-    }
-    else
-    {
-        P_SetMessage(player, DEH_String(TXT_SHOWFPSOFF), false);
-    }
-}
-
 static void CheatMassacreFunc(player_t * player, Cheat_t * cheat)
 {
     NIGHTMARE_NETGAME_CHECK;
@@ -1329,4 +1335,304 @@ static void CheatIDDQDFunc(player_t * player, Cheat_t * cheat)
     NIGHTMARE_NETGAME_CHECK;
     P_DamageMobj(player->mo, NULL, player->mo, 10000);
     P_SetMessage(player, DEH_String(TXT_CHEATIDDQD), true);
+}
+
+// [crispy] used by some of the new cheats, the buffer cannot be local
+//          to the cheat functions because the message string data is
+//          still accessed elsewhere after the function returns!
+static char msgbuf[64];
+
+// [crispy] "Cheat" to show FPS
+static void CheatShowFpsFunc(player_t* player, Cheat_t* cheat)
+{
+    player->cheats ^= CF_SHOWFPS;
+    if (player->cheats & CF_SHOWFPS)
+    {
+        P_SetMessage(player, DEH_String(TXT_SHOWFPSON), false);
+    }
+    else
+    {
+        P_SetMessage(player, DEH_String(TXT_SHOWFPSOFF), false);
+    }
+}
+
+// [crispy] implement boom-style "tntweap?" cheat
+extern boolean P_GiveWeapon(player_t * player, weapontype_t weapon);
+extern const char *const WeaponPickupMessages[NUMWEAPONS];
+extern boolean P_CheckAmmo(player_t * player);
+
+static boolean WeaponAvailable (int w)
+{
+    if (w < 0 || w == wp_beak || w >= NUMWEAPONS)
+    {
+        return false;
+    }
+
+    if (shareware && (w >= wp_skullrod && w != wp_gauntlets))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static void CheatAddRemoveWpnFunc(player_t *player, Cheat_t *cheat)
+{
+    int i, w, setmsg;
+    char arg;
+
+    NIGHTMARE_NETGAME_CHECK;
+
+    // don't do anything if currently chicken
+    if (player->chickenTics)
+    {
+        return;
+    }
+
+    cht_GetParam(cheat->seq, &arg);
+    w = arg-'1';
+
+    // WEAP0 takes away all weapons and ammo except for the elvenwand
+    // and 50 crystal ammo
+    if (w == -1)
+    {
+        // remove backpack if the player has it
+        if (player->backpack)
+        {
+            player->backpack = false;
+            for (i = 0; i < NUMAMMO; i++)
+            {
+                player->maxammo[i] /= 2;
+            }
+        }
+
+        // remove Tome of Power if active
+        player->powers[pw_weaponlevel2] = 0;
+
+        for (i = 0; i < NUMWEAPONS; i++)
+        {
+            player->weaponowned[i] = false;
+        }
+        player->weaponowned[wp_staff] = true;
+        player->weaponowned[wp_goldwand] = true;
+
+        for (i = 0; i < NUMAMMO; i++)
+        {
+            player->ammo[i] = 0;
+        }
+        player->ammo[am_goldwand] = 50; // not HHE modifiable?
+
+        if (player->readyweapon > wp_goldwand)
+        {
+            player->pendingweapon = wp_goldwand;
+        }
+
+        P_SetMessage(player, DEH_String(TXT_CHEATWEAPREMOVEALL), false);
+
+        return;
+    }
+
+    setmsg = 0;
+
+    // do not give registered only weapons if in shareware mode
+    // or the chicken beak
+    if (!WeaponAvailable(w))
+    {
+        return;
+    }
+
+    if (!player->weaponowned[w])
+    {
+        P_GiveWeapon(player, w);
+        S_StartSound(NULL, sfx_wpnup);
+
+        // no pickup message for staff or wand
+        if (w > 1)
+        {
+            P_SetMessage(player, DEH_String(WeaponPickupMessages[w]), false);
+            setmsg = 1;
+        }
+
+        // trigger palette flash
+        player->bonuscount += 6; // same as BONUSADD
+    }
+    else
+    {
+        player->weaponowned[w] = false;
+
+        // if current weapon was removed, select another one
+        if (w == player->readyweapon)
+        {
+            P_CheckAmmo(player);
+        }
+    }
+
+    if (!setmsg)
+    {
+        DEH_snprintf(msgbuf, sizeof(msgbuf),
+         player->weaponowned[w] ? TXT_CHEATWEAPADD : TXT_CHEATWEAPREMOVE,
+         w+1);
+        P_SetMessage(player, msgbuf, false);
+    }
+}
+
+// [crispy] trigger all special lines available on the map
+#define NO_INDEX ((unsigned short)-1)
+static void CheatSpecHitFunc(player_t *player, Cheat_t *cheat)
+{
+    int i, speciallines = 0;
+    boolean origkeys[NUMKEYS];
+    line_t dummy;
+
+    NIGHTMARE_NETGAME_CHECK;
+
+    // temporarily give all keys
+    for (i = 0; i < NUMKEYS; i++)
+    {
+        origkeys[i] = player->keys[i];
+        player->keys[i] = true;
+    }
+
+    for (i = 0; i < numlines; i++)
+    {
+        if (lines[i].special)
+        {
+            // do not trigger level exits or teleports
+            // 39 = teleport, 97 = retrig teleport,
+            // 52 = regular exit, 105 = secret exit
+            if (lines[i].special == 39 || lines[i].special == 97 ||
+                lines[i].special == 52 || lines[i].special == 105)
+            {
+                continue;
+            }
+
+            // special without tag --> DR linedef type, don't
+            // change door direction if it is already moving
+            if (lines[i].tag == 0 && lines[i].sidenum[1] != NO_INDEX &&
+                sides[lines[i].sidenum[1]].sector->specialdata)
+            {
+                continue;
+            }
+
+            P_CrossSpecialLine(i, 0, player->mo);
+            P_ShootSpecialLine(player->mo, &lines[i]);
+            P_UseSpecialLine(player->mo, &lines[i]);
+
+            speciallines++;
+        }
+    }
+
+    // restore original keys
+    for (i = 0; i < NUMKEYS; i++)
+    {
+        player->keys[i] = origkeys[i];
+    }
+
+    // trigger special tag 666 events
+    dummy.tag = 666;
+    speciallines += EV_DoFloor(&dummy, lowerFloor);
+
+    DEH_snprintf(msgbuf, sizeof(msgbuf), TXT_CHEATSPECHIT,
+                 speciallines,speciallines != 1 ? "S" : "");
+    P_SetMessage(player, msgbuf, false);
+}
+
+// [crispy] nomomentum mode, pretty useless
+static void CheatNoMomentumFunc(player_t *player, Cheat_t *cheat)
+{
+    NIGHTMARE_NETGAME_CHECK;
+
+    player->cheats ^= CF_NOMOMENTUM;
+
+    if (player->cheats & CF_NOMOMENTUM)
+    {
+        P_SetMessage(player, DEH_String(TXT_CHEATNOMOMON), false);
+    }
+    else
+    {
+        P_SetMessage(player, DEH_String(TXT_CHEATNOMOMOFF), false);
+    }
+
+    return;
+}
+
+// [crispy] toggle flashing HOM indicator, see also:
+//          r_main.c:R_RenderPlayerView
+static void CheatHomDetectFunc(player_t *player, Cheat_t *cheat)
+{
+    crispy->flashinghom = !crispy->flashinghom;
+
+    if (crispy->flashinghom)
+    {
+        P_SetMessage(player, DEH_String(TXT_HOMDETECTON), false);
+    }
+    else
+    {
+        P_SetMessage(player, DEH_String(TXT_HOMDETECTOFF), false);
+    }
+
+    return;
+}
+
+
+// [crispy] toggle notarget mode: monsters don't target player, and also
+//          forget their target if they're currently targeting the player
+//          when this mode is toggled on
+static void CheatNoTargetFunc(player_t *player, Cheat_t *cheat)
+{
+    int i;
+
+    NIGHTMARE_NETGAME_CHECK;
+
+    player->cheats ^= CF_NOTARGET;
+
+    if (player->cheats & CF_NOTARGET)
+    {
+        int i;
+        thinker_t *th;
+
+        // [crispy] let monsters and tracers forget their target
+        for (th = thinkercap.next; th != &thinkercap; th = th->next)
+        {
+            if (th->function == P_MobjThinker)
+            {
+                mobj_t *const mo = (mobj_t *)th;
+
+                if (mo->target && mo->target->player)
+                {
+                    mo->target = NULL;
+                }
+
+                // MT_HORNRODFX2 is the powered up Hellstaff projectile which
+                // can also home on a target stored in special1, but it should
+                // never be homing on the player in single player mode, and
+                // HHE patches cannot make monsters fire those properly since
+                // it is only spaned by a pspr action function
+                if (mo->type == MT_MUMMYFX1 || mo->type == MT_WHIRLWIND)
+                {
+                    if (mo->special1.m && mo->special1.m->player)
+                    {
+                        mo->special1.m = NULL;
+                    }
+                }
+            }
+        }
+    }
+
+    // [crispy] let sectors forget their soundtarget
+    for (i = 0; i < numsectors; i++)
+    {
+        sector_t *const sector = &sectors[i];
+
+        sector->soundtarget = NULL;
+    }
+
+    if (player->cheats & CF_NOTARGET)
+    {
+        P_SetMessage(player, DEH_String(TXT_CHEATNOTARGETON), false);
+    }
+    else
+    {
+        P_SetMessage(player, DEH_String(TXT_CHEATNOTARGETOFF), false);
+    }
 }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1588,7 +1588,6 @@ static void CheatNoTargetFunc(player_t *player, Cheat_t *cheat)
 
     if (player->cheats & CF_NOTARGET)
     {
-        int i;
         thinker_t *th;
 
         // [crispy] let monsters and tracers forget their target
@@ -1607,7 +1606,7 @@ static void CheatNoTargetFunc(player_t *player, Cheat_t *cheat)
                 // can also home on a target stored in special1, but it should
                 // never be homing on the player in single player mode, and
                 // HHE patches cannot make monsters fire those properly since
-                // it is only spaned by a pspr action function
+                // it is only spawned by a pspr action function
                 if (mo->type == MT_MUMMYFX1 || mo->type == MT_WHIRLWIND)
                 {
                     if (mo->special1.m && mo->special1.m->player)


### PR DESCRIPTION
- show weapon pickup messages even in cooperative multiplayer (where weapons stay)
- implement additional cheat codes (ported from Crispy Doom), one of which requires the weapon pickup string table added for the above

Why in the same pull request? I didn't realize that the pull request gets automatically updated if I merge changes from another branch to the master in _my own fork_ of the repo, first time using github after all as mentioned on DW. Apologies.