### PR TITLE
Implemented workaround for the blockmap bug

### DIFF
--- a/src/crispy.h
+++ b/src/crispy.h
@@ -39,6 +39,7 @@ typedef struct
 	int automapoverlay;
 	int automaprotate;
 	int automapstats;
+	int blockmapfix;
 	int bobfactor;
 	int brightmaps;
 	int btusetimer;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -427,6 +427,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_automapoverlay",  &crispy->automapoverlay);
     M_BindIntVariable("crispy_automaprotate",   &crispy->automaprotate);
     M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
+    M_BindIntVariable("crispy_blockmapfix",     &crispy->blockmapfix);
     M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
     M_BindIntVariable("crispy_btusetimer",      &crispy->btusetimer);
     M_BindIntVariable("crispy_brightmaps",      &crispy->brightmaps);

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -569,3 +569,10 @@ void M_CrispyToggleWidescreen(int choice)
 
     crispy->post_rendering_hook = M_CrispyToggleWidescreenHook;
 }
+
+void M_CrispyToggleBlockmapfix(int choice)
+{
+    choice = 0;
+
+    crispy->blockmapfix = !crispy->blockmapfix;
+}

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -44,6 +44,7 @@ extern multiitem_t multiitem_widgets[NUM_WIDGETS];
 extern multiitem_t multiitem_widescreen[NUM_RATIOS];
 
 extern void M_CrispyToggleAutomapstats(int choice);
+extern void M_CrispyToggleBlockmapfix(int choice);
 extern void M_CrispyToggleBobfactor(int choice);
 extern void M_CrispyToggleBrightmaps(int choice);
 extern void M_CrispyToggleCenterweapon(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -597,6 +597,7 @@ enum
     crispness_jumping,
     crispness_overunder,
     crispness_recoil,
+    crispness_blockmapfix,
     crispness_sep_physical_,
 
     crispness_sep_demos,
@@ -619,6 +620,7 @@ static menuitem_t Crispness4Menu[]=
     {1,"",	M_CrispyToggleJumping,'a'},
     {1,"",	M_CrispyToggleOverunder,'w'},
     {1,"",	M_CrispyToggleRecoil,'w'},
+    {1,"",	M_CrispyToggleBlockmapfix,'b'},
     {-1,"",0,'\0'},
     {-1,"",0,'\0'},
     {1,"",	M_CrispyToggleDemoTimer,'v'},
@@ -1553,6 +1555,7 @@ static void M_DrawCrispness4(void)
     M_DrawCrispnessMultiItem(crispness_jumping, "Allow Jumping", multiitem_jump, crispy->jump, crispy->singleplayer);
     M_DrawCrispnessItem(crispness_overunder, "Walk over/under Monsters", crispy->overunder, crispy->singleplayer);
     M_DrawCrispnessItem(crispness_recoil, "Weapon Recoil Thrust", crispy->recoil, crispy->singleplayer);
+    M_DrawCrispnessItem(crispness_blockmapfix, "Fix Blockmap Bug", crispy->blockmapfix, crispy->singleplayer);
 
     M_DrawCrispnessSeparator(crispness_sep_demos, "Demos");
 

--- a/src/doom/p_maputl.c
+++ b/src/doom/p_maputl.c
@@ -529,6 +529,121 @@ P_BlockThingsIterator
 	if (!func( mobj ) )
 	    return false;
     }
+
+    // [crispy] Blockmap bug fix - add other mobjs from
+    // surrounding blocks that overlap this one
+    if (crispy->blockmapfix)
+    {
+	// Unwrapped for least number of bounding box checks
+	// (-1, -1)
+	if (x > 0 && y > 0)
+	{
+	    for (mobj = blocklinks[(y-1)*bmapwidth+(x-1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x + mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		int yy = (mobj->y + mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (xx == x && yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (0, -1)
+	if (y > 0)
+	{
+	    for (mobj = blocklinks[(y-1)*bmapwidth+x] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int yy = (mobj->y + mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (1, -1)
+	if (x < (bmapwidth-1) && y > 0)
+	{
+	    for (mobj = blocklinks[(y-1)*bmapwidth+(x+1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x - mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		int yy = (mobj->y + mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (xx == x && yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (1, 0)
+	if (x < (bmapwidth-1))
+	{
+	    for (mobj = blocklinks[y*bmapwidth+(x+1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x - mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		if (xx == x)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (1, 1)
+	if (x < (bmapwidth-1) && y < (bmapheight-1))
+	{
+	    for (mobj = blocklinks[(y+1)*bmapwidth+(x+1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x - mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		int yy = (mobj->y - mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (xx == x && yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (0, 1)
+	if (y < (bmapheight-1))
+	{
+	    for (mobj = blocklinks[(y+1)*bmapwidth+x] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int yy = (mobj->y - mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (-1, 1)
+	if (x > 0 && y < (bmapheight-1))
+	{
+	    for (mobj = blocklinks[(y+1)*bmapwidth+(x-1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x + mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		int yy = (mobj->y - mobj->radius - bmaporgy)>>MAPBLOCKSHIFT;
+		if (xx == x && yy == y)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+	// (-1, 0)
+	if (x > 0)
+	{
+	    for (mobj = blocklinks[y*bmapwidth+(x-1)] ;
+		 mobj ;
+		 mobj = mobj->bnext)
+	    {
+		int xx = (mobj->x + mobj->radius - bmaporgx)>>MAPBLOCKSHIFT;
+		if (xx == x)
+		    if (!func( mobj ) )
+			return false;
+	    }
+	}
+    }
     return true;
 }
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1916,6 +1916,14 @@ static default_t extra_defaults_list[] =
     //!
     // @game doom
     //
+    // Fix the blockmap bug.
+    //
+
+    CONFIG_VARIABLE_INT(crispy_blockmapfix),
+
+    //!
+    // @game doom
+    //
     // Variable player view bob.
     //
 

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -60,6 +60,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_automapoverlay",  &crispy->automapoverlay);
         M_BindIntVariable("crispy_automaprotate",   &crispy->automaprotate);
         M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
+        M_BindIntVariable("crispy_blockmapfix",     &crispy->blockmapfix);
         M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
         M_BindIntVariable("crispy_btusetimer",      &crispy->btusetimer);
         M_BindIntVariable("crispy_brightmaps",      &crispy->brightmaps);


### PR DESCRIPTION
Hi all!

I was inspired by Coincident's video on the blockmap bug and decided to take a stab at fixing it. Crispy Doom is my favorite source port and I felt like some players (such as myself 😉) might like to play it with an option to fix the bug.

Here's my workaround:

In `P_BlockThingsIterator`, after iterating through the block in question, ALSO iterate through all surrounding blocks. For each thing in the surrounding blocks, first check if it partially overlaps this block. I do this by adding/subtracting `mobj->radius` from the thing's x and/or y coordinates to get a new point on the edge or corner of that thing. If that new point is inside the block, then run `func` on that thing as well.

I decided to minimize the number calculations that needed to be made, I added the code inline or "unwrapped" as in there are 8 similar versions of this code, once for each neighboring block. For each of these, I could manually decide whether or not to check both a modified x AND y coordinate (if it's a corner neighboring block), or just one coordinate (if it's an orthogonal neighboring block).

Since that might seem really confusing (I confused myself writing that paragraph), this image should hopefully describe what I'm talking about. Here I am highlighting the blocks that are neighboring the current block. In each of those blocks, I've drawn one thing, where the x is the thing's center. The green dot is where it will check if it's inside the new block. This should cover all cases where a thing in another block partially overlaps this block.

![CrispyDoomBlockmapWorkaround](https://user-images.githubusercontent.com/7307599/111415179-ca884f00-86b7-11eb-8b28-4354d9f0d04d.png)

A few more considerations:

* I am not sure I fully handled the configuration correctly - since this is a "physical" change, it should be disabled for demos/multiplayer games. I couldn't find code to ensure that, so will this work correctly in those cases?
* I realized the contribution guidelines say to use spaces rather than tabs, etc. In my changes, I generally copied the format of the function that it was inside (mixed indentation, spaces inside parentheses sometimes) so that it matches. Should I have not done that?
* This method of working around the bug seems quite wasteful, each time it iterates over a block, it's actually iterating over 9. It may be better if we can adjust the way `blocklinks` are stored, so that the same mobj can actually be stored in multiple lists (not possible right now since each mobj acts as its own linked list node)

My testing:

So far, this seems to work pretty well. I've done some playtesting with the setting turned on and I haven't encountered any weird bugs or crashes yet. I downloaded barrel2.wad and was able to confirm that toggling the setting on and off DID fix the error in the corridor that is often used as an example for the bug.

I tried testing the difference with one-shotting the spider mastermind with the BFG. It does seem more consistent with the patch turned on, which is expected, but I also noticed that it seems you cannot get as close to the spider mastermind when the blockmap fix is turned on. Is this an unintended side effect of my running doing this with the blockmap iterator, or is this revealing what is really the "true" collisions after all? Not too sure

Anyways I wrote way more than I probably needed to so I'll stop. Please feel free to comment!