### PR TITLE
Clear overlaid automap remainings

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -638,6 +638,7 @@ void D_DoAdvanceDemo (void)
 void D_StartTitle (void)
 {
     gameaction = ga_nothing;
+    automapactive = false; // [crispy] clear overlaid automap remainings
     demosequence = -1;
     D_AdvanceDemo ();
 }


### PR DESCRIPTION
This fixes automap remainings after ending the game in overlaid automap mode:

![image](https://user-images.githubusercontent.com/21193394/113503244-49470e00-9539-11eb-880b-91d0a815e95a.png)

Initial discussion: https://github.com/JNechaevsky/russian-doom/issues/225