### PR TITLE
Activate VSYNC on textscreen, fixing too fast screen updates.

### DIFF
--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -253,7 +253,7 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
+    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
 
     // Special handling for OS X retina display. If we successfully set the
     // highdpi flag, check the output size for the screen renderer. If we get


### PR DESCRIPTION
This is needed so screen updates look right on some SDL2 backends.
For example, on KMSDRM, buffer swaps occur immediately (no X11 server), so not having VSYNC ON causes screen to be refreshed so fast on the text menu that it seems to be slow!

Also, no need to force the software renderer. HW renderer (or whatever SDL2 uses internally in each platform) is fine. 