### PR TITLE
Implement smooth automap rotation

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1681,12 +1681,12 @@ static void AM_rotatePoint (mpoint_t *pt)
     pt->x -= mapcenter.x;
     pt->y -= mapcenter.y;
 
-    tmpx = (int64_t)FixedMul(pt->x, finecosine[mapangle>>ANGLETOFINESHIFT])
-         - (int64_t)FixedMul(pt->y, finesine[mapangle>>ANGLETOFINESHIFT])
+    tmpx = (int64_t)FixedMul(pt->x, finecosine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
+         - (int64_t)FixedMul(pt->y, finesine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
          + mapcenter.x;
 
-    pt->y = (int64_t)FixedMul(pt->x, finesine[mapangle>>ANGLETOFINESHIFT])
-          + (int64_t)FixedMul(pt->y, finecosine[mapangle>>ANGLETOFINESHIFT])
+    pt->y = (int64_t)FixedMul(pt->x, finesine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
+          + (int64_t)FixedMul(pt->y, finecosine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
           + mapcenter.y;
 
     pt->x = tmpx;

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1677,16 +1677,17 @@ AM_rotate
 static void AM_rotatePoint (mpoint_t *pt)
 {
     int64_t tmpx;
+    const angle_t actualangle = ANG90 - viewangle;
 
     pt->x -= mapcenter.x;
     pt->y -= mapcenter.y;
 
-    tmpx = (int64_t)FixedMul(pt->x, finecosine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
-         - (int64_t)FixedMul(pt->y, finesine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
+    tmpx = (int64_t)FixedMul(pt->x, finecosine[actualangle>>ANGLETOFINESHIFT])
+         - (int64_t)FixedMul(pt->y, finesine[actualangle>>ANGLETOFINESHIFT])
          + mapcenter.x;
 
-    pt->y = (int64_t)FixedMul(pt->x, finesine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
-          + (int64_t)FixedMul(pt->y, finecosine[(ANG90 - viewangle)>>ANGLETOFINESHIFT])
+    pt->y = (int64_t)FixedMul(pt->x, finesine[actualangle>>ANGLETOFINESHIFT])
+          + (int64_t)FixedMul(pt->y, finecosine[actualangle>>ANGLETOFINESHIFT])
           + mapcenter.y;
 
     pt->x = tmpx;


### PR DESCRIPTION
This PR implements smooth rotation in automap rotate mode. 
Tested with capped framerate as well as with `-fliplevels`, everything fine.