### PR TITLE
Allow use of custom translucency maps (again).

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -13,8 +13,8 @@
 // GNU General Public License for more details.
 //
 // DESCRIPTION:
-//  Preparation of data for rendering,
-//  generation of lookups, caching, retrieval by name.
+//	Preparation of data for rendering,
+//	generation of lookups, caching, retrieval by name.
 //
 
 #include <stdio.h>
@@ -61,11 +61,11 @@
 //
 typedef PACKED_STRUCT (
 {
-    short   originx;
-    short   originy;
-    short   patch;
-    short   stepdir;
-    short   colormap;
+    short	originx;
+    short	originy;
+    short	patch;
+    short	stepdir;
+    short	colormap;
 }) mappatch_t;
 
 
@@ -76,13 +76,13 @@ typedef PACKED_STRUCT (
 //
 typedef PACKED_STRUCT (
 {
-    char        name[8];
-    int         masked; 
-    short       width;
-    short       height;
+    char		name[8];
+    int			masked;	
+    short		width;
+    short		height;
     int                 obsolete;
-    short       patchcount;
-    mappatch_t  patches[1];
+    short		patchcount;
+    mappatch_t	patches[1];
 }) maptexture_t;
 
 
@@ -94,9 +94,9 @@ typedef struct
     // Block origin (allways UL),
     // which has allready accounted
     // for the internal origin of the patch.
-    short   originx;    
-    short   originy;
-    int     patch;
+    short	originx;	
+    short	originy;
+    int		patch;
 } texpatch_t;
 
 
@@ -109,9 +109,9 @@ typedef struct texture_s texture_t;
 struct texture_s
 {
     // Keep name for switch changing, etc.
-    char    name[8];        
-    short   width;
-    short   height;
+    char	name[8];		
+    short	width;
+    short	height;
 
     // Index in textures list
 
@@ -123,51 +123,51 @@ struct texture_s
     
     // All the patches[patchcount]
     //  are drawn back to front into the cached texture.
-    short   patchcount;
-    texpatch_t  patches[1];     
+    short	patchcount;
+    texpatch_t	patches[1];		
 };
 
 
 
-int     firstflat;
-int     lastflat;
-int     numflats;
+int		firstflat;
+int		lastflat;
+int		numflats;
 
-int     firstpatch;
-int     lastpatch;
-int     numpatches;
+int		firstpatch;
+int		lastpatch;
+int		numpatches;
 
-int     firstspritelump;
-int     lastspritelump;
-int     numspritelumps;
+int		firstspritelump;
+int		lastspritelump;
+int		numspritelumps;
 
-int     numtextures;
-texture_t** textures;
+int		numtextures;
+texture_t**	textures;
 texture_t**     textures_hashtable;
 
 
-int*            texturewidthmask;
-int*            texturewidth; // [crispy] texture width for wrapping column getter function
+int*			texturewidthmask;
+int*			texturewidth; // [crispy] texture width for wrapping column getter function
 // needed for texture pegging
-fixed_t*        textureheight; // [crispy] texture height for Tutti-Frutti fix
-int*            texturecompositesize;
-short**         texturecolumnlump;
-unsigned**      texturecolumnofs; // [crispy] column offsets for composited translucent mid-textures on 2S walls
-unsigned**      texturecolumnofs2; // [crispy] column offsets for composited opaque textures
-byte**          texturecomposite; // [crispy] composited translucent mid-textures on 2S walls
-byte**          texturecomposite2; // [crispy] composited opaque textures
-byte**          texturebrightmap; // [crispy] brightmaps
+fixed_t*		textureheight; // [crispy] texture height for Tutti-Frutti fix
+int*			texturecompositesize;
+short**			texturecolumnlump;
+unsigned**		texturecolumnofs; // [crispy] column offsets for composited translucent mid-textures on 2S walls
+unsigned**		texturecolumnofs2; // [crispy] column offsets for composited opaque textures
+byte**			texturecomposite; // [crispy] composited translucent mid-textures on 2S walls
+byte**			texturecomposite2; // [crispy] composited opaque textures
+byte**			texturebrightmap; // [crispy] brightmaps
 
 // for global animation
-int*        flattranslation;
-int*        texturetranslation;
+int*		flattranslation;
+int*		texturetranslation;
 
 // needed for pre rendering
-fixed_t*    spritewidth;    
-fixed_t*    spriteoffset;
-fixed_t*    spritetopoffset;
+fixed_t*	spritewidth;	
+fixed_t*	spriteoffset;
+fixed_t*	spritetopoffset;
 
-lighttable_t    *colormaps;
+lighttable_t	*colormaps;
 
 
 //
@@ -197,53 +197,53 @@ lighttable_t    *colormaps;
 
 void
 R_DrawColumnInCache
-( column_t* patch,
-  byte*     cache,
-  int       originy,
-  int       cacheheight,
-  byte*     marks )
+( column_t*	patch,
+  byte*		cache,
+  int		originy,
+  int		cacheheight,
+  byte*		marks )
 {
-    int     count;
-    int     position;
-    byte*   source;
-    int     top = -1;
+    int		count;
+    int		position;
+    byte*	source;
+    int		top = -1;
 
     while (patch->topdelta != 0xff)
     {
-    // [crispy] support for DeePsea tall patches
-    if (patch->topdelta <= top)
-    {
-        top += patch->topdelta;
-    }
-    else
-    {
-        top = patch->topdelta;
-    }
-    source = (byte *)patch + 3;
-    count = patch->length;
-    position = originy + top;
+	// [crispy] support for DeePsea tall patches
+	if (patch->topdelta <= top)
+	{
+		top += patch->topdelta;
+	}
+	else
+	{
+		top = patch->topdelta;
+	}
+	source = (byte *)patch + 3;
+	count = patch->length;
+	position = originy + top;
 
-    if (position < 0)
-    {
-        count += position;
-        position = 0;
-    }
+	if (position < 0)
+	{
+	    count += position;
+	    position = 0;
+	}
 
-    if (position + count > cacheheight)
-        count = cacheheight - position;
+	if (position + count > cacheheight)
+	    count = cacheheight - position;
 
-    if (count > 0)
-    {
-        memcpy (cache + position, source, count);
+	if (count > 0)
+	{
+	    memcpy (cache + position, source, count);
 
-        // killough 4/9/98: remember which cells in column have been drawn,
-        // so that column can later be converted into a series of posts, to
-        // fix the Medusa bug.
+	    // killough 4/9/98: remember which cells in column have been drawn,
+	    // so that column can later be converted into a series of posts, to
+	    // fix the Medusa bug.
 
-        memset (marks + position, 0xff, count);
-    }
-        
-    patch = (column_t *)(  (byte *)patch + patch->length + 4); 
+	    memset (marks + position, 0xff, count);
+	}
+		
+	patch = (column_t *)(  (byte *)patch + patch->length + 4); 
     }
 }
 
@@ -259,29 +259,29 @@ R_DrawColumnInCache
 
 void R_GenerateComposite (int texnum)
 {
-    byte*       block, *block2;
-    texture_t*      texture;
-    texpatch_t*     patch;  
-    patch_t*        realpatch;
-    int         x;
-    int         x1;
-    int         x2;
-    int         i;
-    column_t*       patchcol;
-    short*      collump;
-    unsigned*       colofs, *colofs2; // killough 4/9/98: make 32-bit
-    byte*       marks; // killough 4/9/98: transparency marks
-    byte*       source; // killough 4/9/98: temporary column
-    
+    byte*		block, *block2;
+    texture_t*		texture;
+    texpatch_t*		patch;	
+    patch_t*		realpatch;
+    int			x;
+    int			x1;
+    int			x2;
+    int			i;
+    column_t*		patchcol;
+    short*		collump;
+    unsigned*		colofs, *colofs2; // killough 4/9/98: make 32-bit
+    byte*		marks; // killough 4/9/98: transparency marks
+    byte*		source; // killough 4/9/98: temporary column
+	
     texture = textures[texnum];
 
     block = Z_Malloc (texturecompositesize[texnum],
-              PU_STATIC, 
-              &texturecomposite[texnum]);   
+		      PU_STATIC, 
+		      &texturecomposite[texnum]);	
     // [crispy] memory block for opaque textures
     block2 = Z_Malloc (texture->width * texture->height,
-              PU_STATIC,
-              &texturecomposite2[texnum]);
+		      PU_STATIC,
+		      &texturecomposite2[texnum]);
 
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
@@ -295,41 +295,41 @@ void R_GenerateComposite (int texnum)
 
     // Composite the columns together.
     for (i=0 , patch = texture->patches;
-     i<texture->patchcount;
-     i++, patch++)
+	 i<texture->patchcount;
+	 i++, patch++)
     {
-    realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
-    x1 = patch->originx;
-    x2 = x1 + SHORT(realpatch->width);
+	realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
+	x1 = patch->originx;
+	x2 = x1 + SHORT(realpatch->width);
 
-    if (x1<0)
-        x = 0;
-    else
-        x = x1;
-    
-    if (x2 > texture->width)
-        x2 = texture->width;
+	if (x1<0)
+	    x = 0;
+	else
+	    x = x1;
+	
+	if (x2 > texture->width)
+	    x2 = texture->width;
 
-    for ( ; x<x2 ; x++)
-    {
-        // Column does not have multiple patches?
-        // [crispy] generate composites for single-patched columns as well
-        /*
-        if (collump[x] >= 0)
-        continue;
-        */
-        
-        patchcol = (column_t *)((byte *)realpatch
-                    + LONG(realpatch->columnofs[x-x1]));
-        R_DrawColumnInCache (patchcol,
-                 block + colofs[x],
-                 // [crispy] single-patched columns are normally not composited
-                 // but directly read from the patch lump ignoring their originy
-                 collump[x] >= 0 ? 0 : patch->originy,
-                 texture->height,
-                 marks + x * texture->height);
-    }
-                        
+	for ( ; x<x2 ; x++)
+	{
+	    // Column does not have multiple patches?
+	    // [crispy] generate composites for single-patched columns as well
+	    /*
+	    if (collump[x] >= 0)
+		continue;
+	    */
+	    
+	    patchcol = (column_t *)((byte *)realpatch
+				    + LONG(realpatch->columnofs[x-x1]));
+	    R_DrawColumnInCache (patchcol,
+				 block + colofs[x],
+				 // [crispy] single-patched columns are normally not composited
+				 // but directly read from the patch lump ignoring their originy
+				 collump[x] >= 0 ? 0 : patch->originy,
+				 texture->height,
+				 marks + x * texture->height);
+	}
+						
     }
 
     // killough 4/9/98: Next, convert multipatched columns into true columns,
@@ -338,57 +338,57 @@ void R_GenerateComposite (int texnum)
     source = I_Realloc(NULL, texture->height); // temporary column
     for (i = 0; i < texture->width; i++)
     {
-    // [crispy] generate composites for all columns
-//  if (collump[i] == -1) // process only multipatched columns
-    {
-        column_t *col = (column_t *)(block + colofs[i] - 3); // cached column
-        const byte *mark = marks + i * texture->height;
-        int j = 0;
-        // [crispy] absolut topdelta for first 254 pixels, then relative
-        int abstop, reltop = 0;
-        boolean relative = false;
+	// [crispy] generate composites for all columns
+//	if (collump[i] == -1) // process only multipatched columns
+	{
+	    column_t *col = (column_t *)(block + colofs[i] - 3); // cached column
+	    const byte *mark = marks + i * texture->height;
+	    int j = 0;
+	    // [crispy] absolut topdelta for first 254 pixels, then relative
+	    int abstop, reltop = 0;
+	    boolean relative = false;
 
-        // save column in temporary so we can shuffle it around
-        memcpy(source, (byte *) col + 3, texture->height);
-        // [crispy] copy composited columns to opaque texture
-        memcpy(block2 + colofs2[i], source, texture->height);
+	    // save column in temporary so we can shuffle it around
+	    memcpy(source, (byte *) col + 3, texture->height);
+	    // [crispy] copy composited columns to opaque texture
+	    memcpy(block2 + colofs2[i], source, texture->height);
 
-        for ( ; ; ) // reconstruct the column by scanning transparency marks
-        {
-        unsigned len; // killough 12/98
+	    for ( ; ; ) // reconstruct the column by scanning transparency marks
+	    {
+		unsigned len; // killough 12/98
 
-        while (j < texture->height && reltop < 254 && !mark[j]) // skip transparent cells
-            j++, reltop++;
+		while (j < texture->height && reltop < 254 && !mark[j]) // skip transparent cells
+		    j++, reltop++;
 
-        if (j >= texture->height) // if at end of column
-        {
-            col->topdelta = -1; // end-of-column marker
-            break;
-        }
+		if (j >= texture->height) // if at end of column
+		{
+		    col->topdelta = -1; // end-of-column marker
+		    break;
+		}
 
-        // [crispy] absolut topdelta for first 254 pixels, then relative
-        col->topdelta = relative ? reltop : j; // starting offset of post
+		// [crispy] absolut topdelta for first 254 pixels, then relative
+		col->topdelta = relative ? reltop : j; // starting offset of post
 
-        // [crispy] once we pass the 254 boundary, topdelta becomes relative
-        if ((abstop = j) >= 254)
-        {
-            relative = true;
-            reltop = 0;
-        }
+		// [crispy] once we pass the 254 boundary, topdelta becomes relative
+		if ((abstop = j) >= 254)
+		{
+			relative = true;
+			reltop = 0;
+		}
 
-        // killough 12/98:
-        // Use 32-bit len counter, to support tall 1s multipatched textures
+		// killough 12/98:
+		// Use 32-bit len counter, to support tall 1s multipatched textures
 
-        for (len = 0; j < texture->height && reltop < 254 && mark[j]; j++, reltop++)
-            len++; // count opaque cells
+		for (len = 0; j < texture->height && reltop < 254 && mark[j]; j++, reltop++)
+		    len++; // count opaque cells
 
-        col->length = len; // killough 12/98: intentionally truncate length
+		col->length = len; // killough 12/98: intentionally truncate length
 
-        // copy opaque cells from the temporary back into the column
-        memcpy((byte *) col + 3, source + abstop, len);
-        col = (column_t *)((byte *) col + len + 4); // next post
-        }
-    }
+		// copy opaque cells from the temporary back into the column
+		memcpy((byte *) col + 3, source + abstop, len);
+		col = (column_t *)((byte *) col + len + 4); // next post
+	    }
+	}
     }
 
     free(source); // free temporary column
@@ -410,20 +410,20 @@ void R_GenerateComposite (int texnum)
 
 void R_GenerateLookup (int texnum)
 {
-    texture_t*      texture;
-    byte*       patchcount; // patchcount[texture->width]
-    byte*       postcount; // killough 4/9/98: keep count of posts in addition to patches.
-    texpatch_t*     patch;  
-    patch_t*        realpatch;
-    int         x;
-    int         x1;
-    int         x2;
-    int         i;
-    short*      collump;
-    unsigned*       colofs, *colofs2; // killough 4/9/98: make 32-bit
-    int         csize = 0; // killough 10/98
-    int         err = 0; // killough 10/98
-    
+    texture_t*		texture;
+    byte*		patchcount;	// patchcount[texture->width]
+    byte*		postcount; // killough 4/9/98: keep count of posts in addition to patches.
+    texpatch_t*		patch;	
+    patch_t*		realpatch;
+    int			x;
+    int			x1;
+    int			x2;
+    int			i;
+    short*		collump;
+    unsigned*		colofs, *colofs2; // killough 4/9/98: make 32-bit
+    int			csize = 0; // killough 10/98
+    int			err = 0; // killough 10/98
+	
     texture = textures[texnum];
 
     // Composited texture not created yet.
@@ -445,39 +445,39 @@ void R_GenerateLookup (int texnum)
     memset (postcount, 0, texture->width);
 
     for (i=0 , patch = texture->patches;
-     i<texture->patchcount;
-     i++, patch++)
+	 i<texture->patchcount;
+	 i++, patch++)
     {
-    realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
-    x1 = patch->originx;
-    x2 = x1 + SHORT(realpatch->width);
+	realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
+	x1 = patch->originx;
+	x2 = x1 + SHORT(realpatch->width);
 
-    // [crispy] detect patches in PNG format... and fail
-    {
-        const unsigned char *magic = (const unsigned char *) realpatch;
+	// [crispy] detect patches in PNG format... and fail
+	{
+		const unsigned char *magic = (const unsigned char *) realpatch;
 
-        if (magic[0] == 0x89 &&
-            magic[1] == 'P' && magic[2] == 'N' && magic[3] == 'G')
-        {
-            I_Error("Patch in PNG format detected: %.8s", lumpinfo[patch->patch]->name);
-        }
-    }
-    
-    if (x1 < 0)
-        x = 0;
-    else
-        x = x1;
+		if (magic[0] == 0x89 &&
+		    magic[1] == 'P' && magic[2] == 'N' && magic[3] == 'G')
+		{
+			I_Error("Patch in PNG format detected: %.8s", lumpinfo[patch->patch]->name);
+		}
+	}
+	
+	if (x1 < 0)
+	    x = 0;
+	else
+	    x = x1;
 
-    if (x2 > texture->width)
-        x2 = texture->width;
-    for ( ; x<x2 ; x++)
-    {
-        patchcount[x]++;
-        collump[x] = patch->patch;
-        colofs[x] = LONG(realpatch->columnofs[x-x1])+3;
+	if (x2 > texture->width)
+	    x2 = texture->width;
+	for ( ; x<x2 ; x++)
+	{
+	    patchcount[x]++;
+	    collump[x] = patch->patch;
+	    colofs[x] = LONG(realpatch->columnofs[x-x1])+3;
+	}
     }
-    }
-    
+	
     // killough 4/9/98: keep a count of the number of posts in column,
     // to fix Medusa bug while allowing for transparent multipatches.
     //
@@ -493,40 +493,40 @@ void R_GenerateLookup (int texnum)
     // [crispy] generate composites for all textures
 //  if (texture->patchcount > 1 && texture->height < 256)
     {
-    // killough 12/98: Warn about a common column construction bug
-    unsigned limit = texture->height * 3 + 3; // absolute column size limit
+	// killough 12/98: Warn about a common column construction bug
+	unsigned limit = texture->height * 3 + 3; // absolute column size limit
 
-    for (i = texture->patchcount, patch = texture->patches; --i >= 0; )
-    {
-        int pat = patch->patch;
-        const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
-        int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
-        const int *cofs = realpatch->columnofs - x1;
+	for (i = texture->patchcount, patch = texture->patches; --i >= 0; )
+	{
+	    int pat = patch->patch;
+	    const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
+	    int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
+	    const int *cofs = realpatch->columnofs - x1;
 
-        if (x2 > texture->width)
-        x2 = texture->width;
-        if (x1 < 0)
-        x1 = 0;
+	    if (x2 > texture->width)
+		x2 = texture->width;
+	    if (x1 < 0)
+		x1 = 0;
 
-        for (x = x1 ; x < x2 ; x++)
-        {
-        // [crispy] generate composites for all columns
-//      if (patchcount[x] > 1) // Only multipatched columns
-        {
-            const column_t *col = (const column_t*)((const byte*) realpatch + LONG(cofs[x]));
-            const byte *base = (const byte *) col;
+	    for (x = x1 ; x < x2 ; x++)
+	    {
+		// [crispy] generate composites for all columns
+//		if (patchcount[x] > 1) // Only multipatched columns
+		{
+		    const column_t *col = (const column_t*)((const byte*) realpatch + LONG(cofs[x]));
+		    const byte *base = (const byte *) col;
 
-            // count posts
-            for ( ; col->topdelta != 0xff; postcount[x]++)
-            {
-            if ((unsigned)((const byte *) col - base) <= limit)
-                col = (const column_t *)((const byte *) col + col->length + 4);
-            else
-                break;
-            }
-        }
-        }
-    }
+		    // count posts
+		    for ( ; col->topdelta != 0xff; postcount[x]++)
+		    {
+			if ((unsigned)((const byte *) col - base) <= limit)
+			    col = (const column_t *)((const byte *) col + col->length + 4);
+			else
+			    break;
+		    }
+		}
+	    }
+	}
     }
 
     // Now count the number of columns
@@ -536,50 +536,50 @@ void R_GenerateLookup (int texnum)
 
     for (x=0 ; x<texture->width ; x++)
     {
-    if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
-    {
-        // [crispy] fix absurd texture name in error message
-        printf ("R_GenerateLookup: column without a patch (%.8s)\n",
-            texture->name);
-        // [crispy] do not return yet
-        /*
-        return;
-        */
-    }
-    // I_Error ("R_GenerateLookup: column without a patch");
-    
-    // [crispy] treat patch-less columns the same as multi-patched
-    if (patchcount[x] > 1 || !patchcount[x])
-    {
-        // Use the cached block.
-        // [crispy] moved up here, the rest in this loop
-        // applies to single-patched textures as well
-        collump[x] = -1;    
-    }
-        // killough 1/25/98, 4/9/98:
-        //
-        // Fix Medusa bug, by adding room for column header
-        // and trailer bytes for each post in merged column.
-        // For now, just allocate conservatively 4 bytes
-        // per post per patch per column, since we don't
-        // yet know how many posts the merged column will
-        // require, and it's bounded above by this limit.
+	if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
+	{
+	    // [crispy] fix absurd texture name in error message
+	    printf ("R_GenerateLookup: column without a patch (%.8s)\n",
+		    texture->name);
+	    // [crispy] do not return yet
+	    /*
+	    return;
+	    */
+	}
+	// I_Error ("R_GenerateLookup: column without a patch");
+	
+	// [crispy] treat patch-less columns the same as multi-patched
+	if (patchcount[x] > 1 || !patchcount[x])
+	{
+	    // Use the cached block.
+	    // [crispy] moved up here, the rest in this loop
+	    // applies to single-patched textures as well
+	    collump[x] = -1;	
+	}
+	    // killough 1/25/98, 4/9/98:
+	    //
+	    // Fix Medusa bug, by adding room for column header
+	    // and trailer bytes for each post in merged column.
+	    // For now, just allocate conservatively 4 bytes
+	    // per post per patch per column, since we don't
+	    // yet know how many posts the merged column will
+	    // require, and it's bounded above by this limit.
 
-        colofs[x] = csize + 3; // three header bytes in a column
-        // killough 12/98: add room for one extra post
-        csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
-        
-        // [crispy] remove limit
-        /*
-        if (texturecompositesize[texnum] > 0x10000-texture->height)
-        {
-        I_Error ("R_GenerateLookup: texture %i is >64k",
-             texnum);
-        }
-        */
-    csize += texture->height; // height bytes of texture data
-    // [crispy] initialize opaque texture column offset
-    colofs2[x] = x * texture->height;
+	    colofs[x] = csize + 3; // three header bytes in a column
+	    // killough 12/98: add room for one extra post
+	    csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
+	    
+	    // [crispy] remove limit
+	    /*
+	    if (texturecompositesize[texnum] > 0x10000-texture->height)
+	    {
+		I_Error ("R_GenerateLookup: texture %i is >64k",
+			 texnum);
+	    }
+	    */
+	csize += texture->height; // height bytes of texture data
+	// [crispy] initialize opaque texture column offset
+	colofs2[x] = x * texture->height;
     }
 
     texturecompositesize[texnum] = csize;
@@ -596,16 +596,16 @@ void R_GenerateLookup (int texnum)
 //
 byte*
 R_GetColumn
-( int       tex,
-  int       col )
+( int		tex,
+  int		col )
 {
-    int     ofs;
-    
+    int		ofs;
+	
     col &= texturewidthmask[tex];
     ofs = texturecolumnofs2[tex][col];
 
     if (!texturecomposite2[tex])
-    R_GenerateComposite (tex);
+	R_GenerateComposite (tex);
 
     return texturecomposite2[tex] + ofs;
 }
@@ -613,19 +613,19 @@ R_GetColumn
 // [crispy] wrapping column getter function for composited translucent mid-textures on 2S walls
 byte*
 R_GetColumnMod
-( int       tex,
-  int       col )
+( int		tex,
+  int		col )
 {
-    int     ofs;
+    int		ofs;
 
     while (col < 0)
-    col += texturewidth[tex];
+	col += texturewidth[tex];
 
     col %= texturewidth[tex];
     ofs = texturecolumnofs[tex][col];
 
     if (!texturecomposite[tex])
-    R_GenerateComposite (tex);
+	R_GenerateComposite (tex);
 
     return texturecomposite[tex] + ofs;
 }
@@ -681,59 +681,59 @@ static void GenerateTextureHashTable(void)
 // [crispy] partly rewritten to merge PNAMES and TEXTURE1/2 lumps
 void R_InitTextures (void)
 {
-    maptexture_t*   mtexture;
-    texture_t*      texture;
-    mappatch_t*     mpatch;
-    texpatch_t*     patch;
+    maptexture_t*	mtexture;
+    texture_t*		texture;
+    mappatch_t*		mpatch;
+    texpatch_t*		patch;
 
-    int         i;
-    int         j;
-    int         k;
+    int			i;
+    int			j;
+    int			k;
 
-    int*        maptex = NULL;
+    int*		maptex = NULL;
     
-    char        name[9];
+    char		name[9];
     
-    int*        patchlookup;
+    int*		patchlookup;
     
-    int         totalwidth;
-    int         nummappatches;
-    int         offset;
-    int         maxoff = 0;
+    int			totalwidth;
+    int			nummappatches;
+    int			offset;
+    int			maxoff = 0;
 
-    int*        directory = NULL;
+    int*		directory = NULL;
     
-    int         temp1;
-    int         temp2;
-    int         temp3;
+    int			temp1;
+    int			temp2;
+    int			temp3;
 
     typedef struct
     {
-    int lumpnum;
-    void *names;
-    short nummappatches;
-    short summappatches;
-    char *name_p;
+	int lumpnum;
+	void *names;
+	short nummappatches;
+	short summappatches;
+	char *name_p;
     } pnameslump_t;
 
     typedef struct
     {
-    int lumpnum;
-    int *maptex;
-    int maxoff;
-    short numtextures;
-    short sumtextures;
-    short pnamesoffset;
+	int lumpnum;
+	int *maptex;
+	int maxoff;
+	short numtextures;
+	short sumtextures;
+	short pnamesoffset;
     } texturelump_t;
 
-    pnameslump_t    *pnameslumps = NULL;
-    texturelump_t   *texturelumps = NULL, *texturelump;
+    pnameslump_t	*pnameslumps = NULL;
+    texturelump_t	*texturelumps = NULL, *texturelump;
 
-    int         maxpnameslumps = 1; // PNAMES
-    int         maxtexturelumps = 2; // TEXTURE1, TEXTURE2
+    int			maxpnameslumps = 1; // PNAMES
+    int			maxtexturelumps = 2; // TEXTURE1, TEXTURE2
 
-    int         numpnameslumps = 0;
-    int         numtexturelumps = 0;
+    int			numpnameslumps = 0;
+    int			numtexturelumps = 0;
 
     // [crispy] allocate memory for the pnameslumps and texturelumps arrays
     pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
@@ -743,62 +743,62 @@ void R_InitTextures (void)
     // are always processed first
     texturelumps[numtexturelumps++].lumpnum = W_GetNumForName(DEH_String("TEXTURE1"));
     if ((i = W_CheckNumForName(DEH_String("TEXTURE2"))) != -1)
-    texturelumps[numtexturelumps++].lumpnum = i;
+	texturelumps[numtexturelumps++].lumpnum = i;
     else
-    texturelumps[numtexturelumps].lumpnum = -1;
+	texturelumps[numtexturelumps].lumpnum = -1;
 
     // [crispy] fill the arrays with all available PNAMES lumps
     // and the remaining available TEXTURE1/2 lumps
     nummappatches = 0;
     for (i = numlumps - 1; i >= 0; i--)
     {
-    if (!strncasecmp(lumpinfo[i]->name, DEH_String("PNAMES"), 6))
-    {
-        if (numpnameslumps == maxpnameslumps)
-        {
-        maxpnameslumps++;
-        pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
-        }
+	if (!strncasecmp(lumpinfo[i]->name, DEH_String("PNAMES"), 6))
+	{
+	    if (numpnameslumps == maxpnameslumps)
+	    {
+		maxpnameslumps++;
+		pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
+	    }
 
-        pnameslumps[numpnameslumps].lumpnum = i;
-        pnameslumps[numpnameslumps].names = W_CacheLumpNum(pnameslumps[numpnameslumps].lumpnum, PU_STATIC);
-        pnameslumps[numpnameslumps].nummappatches = LONG(*((int *) pnameslumps[numpnameslumps].names));
+	    pnameslumps[numpnameslumps].lumpnum = i;
+	    pnameslumps[numpnameslumps].names = W_CacheLumpNum(pnameslumps[numpnameslumps].lumpnum, PU_STATIC);
+	    pnameslumps[numpnameslumps].nummappatches = LONG(*((int *) pnameslumps[numpnameslumps].names));
 
-        // [crispy] accumulated number of patches in the lookup tables
-        // excluding the current one
-        pnameslumps[numpnameslumps].summappatches = nummappatches;
-        pnameslumps[numpnameslumps].name_p = (char*)pnameslumps[numpnameslumps].names + 4;
+	    // [crispy] accumulated number of patches in the lookup tables
+	    // excluding the current one
+	    pnameslumps[numpnameslumps].summappatches = nummappatches;
+	    pnameslumps[numpnameslumps].name_p = (char*)pnameslumps[numpnameslumps].names + 4;
 
-        // [crispy] calculate total number of patches
-        nummappatches += pnameslumps[numpnameslumps].nummappatches;
-        numpnameslumps++;
-    }
-    else
-    if (!strncasecmp(lumpinfo[i]->name, DEH_String("TEXTURE"), 7))
-    {
-        // [crispy] support only TEXTURE1/2 lumps, not TEXTURE3 etc.
-        if (lumpinfo[i]->name[7] != '1' &&
-            lumpinfo[i]->name[7] != '2')
-        continue;
+	    // [crispy] calculate total number of patches
+	    nummappatches += pnameslumps[numpnameslumps].nummappatches;
+	    numpnameslumps++;
+	}
+	else
+	if (!strncasecmp(lumpinfo[i]->name, DEH_String("TEXTURE"), 7))
+	{
+	    // [crispy] support only TEXTURE1/2 lumps, not TEXTURE3 etc.
+	    if (lumpinfo[i]->name[7] != '1' &&
+	        lumpinfo[i]->name[7] != '2')
+		continue;
 
-        // [crispy] make sure the first available TEXTURE1/2 lumps
-        // are not processed again
-        if (i == texturelumps[0].lumpnum ||
-            i == texturelumps[1].lumpnum) // [crispy] may still be -1
-        continue;
+	    // [crispy] make sure the first available TEXTURE1/2 lumps
+	    // are not processed again
+	    if (i == texturelumps[0].lumpnum ||
+	        i == texturelumps[1].lumpnum) // [crispy] may still be -1
+		continue;
 
-        if (numtexturelumps == maxtexturelumps)
-        {
-        maxtexturelumps++;
-        texturelumps = I_Realloc(texturelumps, maxtexturelumps * sizeof(*texturelumps));
-        }
+	    if (numtexturelumps == maxtexturelumps)
+	    {
+		maxtexturelumps++;
+		texturelumps = I_Realloc(texturelumps, maxtexturelumps * sizeof(*texturelumps));
+	    }
 
-        // [crispy] do not proceed any further, yet
-        // we first need a complete pnameslumps[] array and need
-        // to process texturelumps[0] (and also texturelumps[1]) as well
-        texturelumps[numtexturelumps].lumpnum = i;
-        numtexturelumps++;
-    }
+	    // [crispy] do not proceed any further, yet
+	    // we first need a complete pnameslumps[] array and need
+	    // to process texturelumps[0] (and also texturelumps[1]) as well
+	    texturelumps[numtexturelumps].lumpnum = i;
+	    numtexturelumps++;
+	}
     }
 
     // [crispy] fill up the patch lookup table
@@ -806,53 +806,53 @@ void R_InitTextures (void)
     patchlookup = Z_Malloc(nummappatches * sizeof(*patchlookup), PU_STATIC, NULL);
     for (i = 0, k = 0; i < numpnameslumps; i++)
     {
-    for (j = 0; j < pnameslumps[i].nummappatches; j++)
-    {
-        int p, po;
+	for (j = 0; j < pnameslumps[i].nummappatches; j++)
+	{
+	    int p, po;
 
-        M_StringCopy(name, pnameslumps[i].name_p + j * 8, sizeof(name));
-        p = po = W_CheckNumForName(name);
-        // [crispy] prevent flat lumps from being mistaken as patches
-        while (p >= firstflat && p <= lastflat)
-        {
-        p = W_CheckNumForNameFromTo (name, p - 1, 0);
-        }
-        // [crispy] if the name is unambiguous, use the lump we found
-        patchlookup[k++] = (p == -1) ? po : p;
-    }
+	    M_StringCopy(name, pnameslumps[i].name_p + j * 8, sizeof(name));
+	    p = po = W_CheckNumForName(name);
+	    // [crispy] prevent flat lumps from being mistaken as patches
+	    while (p >= firstflat && p <= lastflat)
+	    {
+		p = W_CheckNumForNameFromTo (name, p - 1, 0);
+	    }
+	    // [crispy] if the name is unambiguous, use the lump we found
+	    patchlookup[k++] = (p == -1) ? po : p;
+	}
     }
 
     // [crispy] calculate total number of textures
     numtextures = 0;
     for (i = 0; i < numtexturelumps; i++)
     {
-    texturelumps[i].maptex = W_CacheLumpNum(texturelumps[i].lumpnum, PU_STATIC);
-    texturelumps[i].maxoff = W_LumpLength(texturelumps[i].lumpnum);
-    texturelumps[i].numtextures = LONG(*texturelumps[i].maptex);
+	texturelumps[i].maptex = W_CacheLumpNum(texturelumps[i].lumpnum, PU_STATIC);
+	texturelumps[i].maxoff = W_LumpLength(texturelumps[i].lumpnum);
+	texturelumps[i].numtextures = LONG(*texturelumps[i].maptex);
 
-    // [crispy] accumulated number of textures in the texture files
-    // including the current one
-    numtextures += texturelumps[i].numtextures;
-    texturelumps[i].sumtextures = numtextures;
+	// [crispy] accumulated number of textures in the texture files
+	// including the current one
+	numtextures += texturelumps[i].numtextures;
+	texturelumps[i].sumtextures = numtextures;
 
-    // [crispy] link textures to their own WAD's patch lookup table (if any)
-    texturelumps[i].pnamesoffset = 0;
-    for (j = 0; j < numpnameslumps; j++)
-    {
-        // [crispy] both are from the same WAD?
-        if (lumpinfo[texturelumps[i].lumpnum]->wad_file ==
-            lumpinfo[pnameslumps[j].lumpnum]->wad_file)
-        {
-        texturelumps[i].pnamesoffset = pnameslumps[j].summappatches;
-        break;
-        }
-    }
+	// [crispy] link textures to their own WAD's patch lookup table (if any)
+	texturelumps[i].pnamesoffset = 0;
+	for (j = 0; j < numpnameslumps; j++)
+	{
+	    // [crispy] both are from the same WAD?
+	    if (lumpinfo[texturelumps[i].lumpnum]->wad_file ==
+	        lumpinfo[pnameslumps[j].lumpnum]->wad_file)
+	    {
+		texturelumps[i].pnamesoffset = pnameslumps[j].summappatches;
+		break;
+	    }
+	}
     }
 
     // [crispy] release memory allocated for patch lookup tables
     for (i = 0; i < numpnameslumps; i++)
     {
-    W_ReleaseLumpNum(pnameslumps[i].lumpnum);
+	W_ReleaseLumpNum(pnameslumps[i].lumpnum);
     }
     free(pnameslumps);
 
@@ -873,7 +873,7 @@ void R_InitTextures (void)
 
     totalwidth = 0;
     
-    //  Really complex printing shit...
+    //	Really complex printing shit...
     temp1 = W_GetNumForName (DEH_String("S_START"));  // P_???????
     temp2 = W_GetNumForName (DEH_String("S_END")) - 1;
     temp3 = ((temp2-temp1+63)/64) + ((numtextures+63)/64);
@@ -899,82 +899,82 @@ void R_InitTextures (void)
 #endif
             printf("\b");
     }
-    
+	
     for (i=0 ; i<numtextures ; i++, directory++)
     {
-    if (!(i&63))
-        printf (".");
+	if (!(i&63))
+	    printf (".");
 
-    // [crispy] initialize for the first texture file lump,
-    // skip through empty texture file lumps which do not contain any texture
-    while (texturelump == texturelumps - 1 || i == texturelump->sumtextures)
-    {
-        // [crispy] start looking in next texture file
-        texturelump++;
-        maptex = texturelump->maptex;
-        maxoff = texturelump->maxoff;
-        directory = maptex+1;
-    }
-        
-    offset = LONG(*directory);
+	// [crispy] initialize for the first texture file lump,
+	// skip through empty texture file lumps which do not contain any texture
+	while (texturelump == texturelumps - 1 || i == texturelump->sumtextures)
+	{
+	    // [crispy] start looking in next texture file
+	    texturelump++;
+	    maptex = texturelump->maptex;
+	    maxoff = texturelump->maxoff;
+	    directory = maptex+1;
+	}
+		
+	offset = LONG(*directory);
 
-    if (offset > maxoff)
-        I_Error ("R_InitTextures: bad texture directory");
-    
-    mtexture = (maptexture_t *) ( (byte *)maptex + offset);
+	if (offset > maxoff)
+	    I_Error ("R_InitTextures: bad texture directory");
+	
+	mtexture = (maptexture_t *) ( (byte *)maptex + offset);
 
-    texture = textures[i] =
-        Z_Malloc (sizeof(texture_t)
-              + sizeof(texpatch_t)*(SHORT(mtexture->patchcount)-1),
-              PU_STATIC, 0);
-    
-    texture->width = SHORT(mtexture->width);
-    texture->height = SHORT(mtexture->height);
-    texture->patchcount = SHORT(mtexture->patchcount);
-    
-    memcpy (texture->name, mtexture->name, sizeof(texture->name));
-    mpatch = &mtexture->patches[0];
-    patch = &texture->patches[0];
+	texture = textures[i] =
+	    Z_Malloc (sizeof(texture_t)
+		      + sizeof(texpatch_t)*(SHORT(mtexture->patchcount)-1),
+		      PU_STATIC, 0);
+	
+	texture->width = SHORT(mtexture->width);
+	texture->height = SHORT(mtexture->height);
+	texture->patchcount = SHORT(mtexture->patchcount);
+	
+	memcpy (texture->name, mtexture->name, sizeof(texture->name));
+	mpatch = &mtexture->patches[0];
+	patch = &texture->patches[0];
 
-    // [crispy] initialize brightmaps
-    texturebrightmap[i] = R_BrightmapForTexName(texture->name);
+	// [crispy] initialize brightmaps
+	texturebrightmap[i] = R_BrightmapForTexName(texture->name);
 
-    for (j=0 ; j<texture->patchcount ; j++, mpatch++, patch++)
-    {
-        short p;
-        patch->originx = SHORT(mpatch->originx);
-        patch->originy = SHORT(mpatch->originy);
-        // [crispy] apply offset for patches not in the
-        // first available patch offset table
-        p = SHORT(mpatch->patch) + texturelump->pnamesoffset;
-        // [crispy] catch out-of-range patches
-        if (p < nummappatches)
-        patch->patch = patchlookup[p];
-        if (patch->patch == -1 || p >= nummappatches)
-        {
-        char    texturename[9];
-        texturename[8] = '\0';
-        memcpy (texturename, texture->name, 8);
-        // [crispy] make non-fatal
-        fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
-             texturename);
-        patch->patch = 0;
-        }
-    }       
-    texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);
-    texturecolumnofs[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs), PU_STATIC,0);
-    texturecolumnofs2[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs2), PU_STATIC,0);
+	for (j=0 ; j<texture->patchcount ; j++, mpatch++, patch++)
+	{
+	    short p;
+	    patch->originx = SHORT(mpatch->originx);
+	    patch->originy = SHORT(mpatch->originy);
+	    // [crispy] apply offset for patches not in the
+	    // first available patch offset table
+	    p = SHORT(mpatch->patch) + texturelump->pnamesoffset;
+	    // [crispy] catch out-of-range patches
+	    if (p < nummappatches)
+		patch->patch = patchlookup[p];
+	    if (patch->patch == -1 || p >= nummappatches)
+	    {
+		char	texturename[9];
+		texturename[8] = '\0';
+		memcpy (texturename, texture->name, 8);
+		// [crispy] make non-fatal
+		fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
+			 texturename);
+		patch->patch = 0;
+	    }
+	}		
+	texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);
+	texturecolumnofs[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs), PU_STATIC,0);
+	texturecolumnofs2[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs2), PU_STATIC,0);
 
-    j = 1;
-    while (j*2 <= texture->width)
-        j<<=1;
+	j = 1;
+	while (j*2 <= texture->width)
+	    j<<=1;
 
-    texturewidthmask[i] = j-1;
-    textureheight[i] = texture->height<<FRACBITS;
-    // [crispy] texture width for wrapping column getter function
-    texturewidth[i] = texture->width;
-        
-    totalwidth += texture->width;
+	texturewidthmask[i] = j-1;
+	textureheight[i] = texture->height<<FRACBITS;
+	// [crispy] texture width for wrapping column getter function
+	texturewidth[i] = texture->width;
+		
+	totalwidth += texture->width;
     }
 
     Z_Free(patchlookup);
@@ -982,20 +982,20 @@ void R_InitTextures (void)
     // [crispy] release memory allocated for texture files
     for (i = 0; i < numtexturelumps; i++)
     {
-    W_ReleaseLumpNum(texturelumps[i].lumpnum);
+	W_ReleaseLumpNum(texturelumps[i].lumpnum);
     }
     free(texturelumps);
     
-    // Precalculate whatever possible.  
+    // Precalculate whatever possible.	
 
     for (i=0 ; i<numtextures ; i++)
-    R_GenerateLookup (i);
+	R_GenerateLookup (i);
     
     // Create translation table for global animation.
     texturetranslation = Z_Malloc ((numtextures+1)*sizeof(*texturetranslation), PU_STATIC, 0);
     
     for (i=0 ; i<numtextures ; i++)
-    texturetranslation[i] = i;
+	texturetranslation[i] = i;
 
     GenerateTextureHashTable();
 }
@@ -1007,17 +1007,17 @@ void R_InitTextures (void)
 //
 void R_InitFlats (void)
 {
-    int     i;
-    
+    int		i;
+	
     firstflat = W_GetNumForName (DEH_String("F_START")) + 1;
     lastflat = W_GetNumForName (DEH_String("F_END")) - 1;
     numflats = lastflat - firstflat + 1;
-    
+	
     // Create translation table for global animation.
     flattranslation = Z_Malloc ((numflats+1)*sizeof(*flattranslation), PU_STATIC, 0);
     
     for (i=0 ; i<numflats ; i++)
-    flattranslation[i] = i;
+	flattranslation[i] = i;
 }
 
 
@@ -1029,9 +1029,9 @@ void R_InitFlats (void)
 //
 void R_InitSpriteLumps (void)
 {
-    int     i;
-    patch_t *patch;
-    
+    int		i;
+    patch_t	*patch;
+	
     firstspritelump = W_GetNumForName (DEH_String("S_START")) + 1;
     lastspritelump = W_GetNumForName (DEH_String("S_END")) - 1;
     
@@ -1039,16 +1039,16 @@ void R_InitSpriteLumps (void)
     spritewidth = Z_Malloc (numspritelumps*sizeof(*spritewidth), PU_STATIC, 0);
     spriteoffset = Z_Malloc (numspritelumps*sizeof(*spriteoffset), PU_STATIC, 0);
     spritetopoffset = Z_Malloc (numspritelumps*sizeof(*spritetopoffset), PU_STATIC, 0);
-    
+	
     for (i=0 ; i< numspritelumps ; i++)
     {
-    if (!(i&63))
-        printf (".");
+	if (!(i&63))
+	    printf (".");
 
-    patch = W_CacheLumpNum (firstspritelump+i, PU_CACHE);
-    spritewidth[i] = SHORT(patch->width)<<FRACBITS;
-    spriteoffset[i] = SHORT(patch->leftoffset)<<FRACBITS;
-    spritetopoffset[i] = SHORT(patch->topoffset)<<FRACBITS;
+	patch = W_CacheLumpNum (firstspritelump+i, PU_CACHE);
+	spritewidth[i] = SHORT(patch->width)<<FRACBITS;
+	spriteoffset[i] = SHORT(patch->leftoffset)<<FRACBITS;
+	spritetopoffset[i] = SHORT(patch->topoffset)<<FRACBITS;
     }
 }
 
@@ -1069,54 +1069,54 @@ static void R_InitTranMap()
     // If a tranlucency filter map lump is present, use it
     if (lump != -1 && W_LumpLength(lump) == 256*256)
     {
-        // Set a pointer to the translucency filter maps.
-        tranmap = W_CacheLumpNum(lump, PU_STATIC);
-        // [crispy] loaded from a lump
-        printf(":");
+	// Set a pointer to the translucency filter maps.
+	tranmap = W_CacheLumpNum(lump, PU_STATIC);
+	// [crispy] loaded from a lump
+	printf(":");
     }
     else
     {
-    // Compose a default transparent filter map based on PLAYPAL.
-    unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	// Compose a default transparent filter map based on PLAYPAL.
+	unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
-    tranmap = Z_Malloc(256*256, PU_STATIC, 0);
-    {
-        byte *fg, *bg, blend[3], *tp = tranmap;
-        int i, j, btmp;
+	tranmap = Z_Malloc(256*256, PU_STATIC, 0);
+	{
+	    byte *fg, *bg, blend[3], *tp = tranmap;
+	    int i, j, btmp;
 
-        // [crispy] background color
-        for (i = 0; i < 256; i++)
-        {
-        // [crispy] foreground color
-        for (j = 0; j < 256; j++)
-        {
-            // [crispy] shortcut: identical foreground and background
-            if (i == j)
-            {
-            *tp++ = i;
-            continue;
-            }
+	    // [crispy] background color
+	    for (i = 0; i < 256; i++)
+	    {
+		// [crispy] foreground color
+		for (j = 0; j < 256; j++)
+		{
+		    // [crispy] shortcut: identical foreground and background
+		    if (i == j)
+		    {
+			*tp++ = i;
+			continue;
+		    }
 
-            bg = playpal + 3*i;
-            fg = playpal + 3*j;
+		    bg = playpal + 3*i;
+		    fg = playpal + 3*j;
 
-            // [crispy] blended color - emphasize blues
-            // Colour matching in RGB space doesn't work very well with the blues
-            // in Doom's palette. Rather than do any colour conversions, just
-            // emphasize the blues when building the translucency table.
-            btmp = fg[b] * 1.666 < (fg[r] + fg[g]) ? 0 : 50;
-            blend[r] = (tran_filter_pct * fg[r] + (100 - tran_filter_pct) * bg[r]) / (100 + btmp);
-            blend[g] = (tran_filter_pct * fg[g] + (100 - tran_filter_pct) * bg[g]) / (100 + btmp);
-            blend[b] = (tran_filter_pct * fg[b] + (100 - tran_filter_pct) * bg[b]) / 100;
+		    // [crispy] blended color - emphasize blues
+		    // Colour matching in RGB space doesn't work very well with the blues
+		    // in Doom's palette. Rather than do any colour conversions, just
+		    // emphasize the blues when building the translucency table.
+		    btmp = fg[b] * 1.666 < (fg[r] + fg[g]) ? 0 : 50;
+		    blend[r] = (tran_filter_pct * fg[r] + (100 - tran_filter_pct) * bg[r]) / (100 + btmp);
+		    blend[g] = (tran_filter_pct * fg[g] + (100 - tran_filter_pct) * bg[g]) / (100 + btmp);
+		    blend[b] = (tran_filter_pct * fg[b] + (100 - tran_filter_pct) * bg[b]) / 100;
 
-            *tp++ = V_GetPaletteIndex(playpal, blend[r], blend[g], blend[b]);
-        }
-        }
-    }
+		    *tp++ = V_GetPaletteIndex(playpal, blend[r], blend[g], blend[b]);
+		}
+	    }
+	}
 
-    printf(".");
+	printf(".");
 
-    W_ReleaseLumpName("PLAYPAL");
+	W_ReleaseLumpName("PLAYPAL");
     }
 }
 #endif
@@ -1127,107 +1127,107 @@ static void R_InitTranMap()
 void R_InitColormaps (void)
 {
 #ifndef CRISPY_TRUECOLOR
-    int lump;
+    int	lump;
 
     // Load in the light tables, 
     //  256 byte align tables.
     lump = W_GetNumForName(DEH_String("COLORMAP"));
     colormaps = W_CacheLumpNum(lump, PU_STATIC);
 #else
-    byte *playpal;
-    int c, i, j = 0;
-    byte r, g, b;
-    extern byte **gamma2table;
+	byte *playpal;
+	int c, i, j = 0;
+	byte r, g, b;
+	extern byte **gamma2table;
 
-    // [crispy] intermediate gamma levels
-    if (!gamma2table)
-    {
-        extern void I_SetGammaTable (void);
-        I_SetGammaTable();
-    }
+	// [crispy] intermediate gamma levels
+	if (!gamma2table)
+	{
+		extern void I_SetGammaTable (void);
+		I_SetGammaTable();
+	}
 
-    playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
-    if (!colormaps)
-    {
-        colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
-    }
+	if (!colormaps)
+	{
+		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
+	}
 
-    if (crispy->truecolor)
-    {
-        for (c = 0; c < NUMCOLORMAPS; c++)
-        {
-            const float scale = 1. * c / NUMCOLORMAPS;
+	if (crispy->truecolor)
+	{
+		for (c = 0; c < NUMCOLORMAPS; c++)
+		{
+			const float scale = 1. * c / NUMCOLORMAPS;
 
-            for (i = 0; i < 256; i++)
-            {
-                r = gamma2table[usegamma][playpal[3 * i + 0]] * (1. - scale) + gamma2table[usegamma][0] * scale;
-                g = gamma2table[usegamma][playpal[3 * i + 1]] * (1. - scale) + gamma2table[usegamma][0] * scale;
-                b = gamma2table[usegamma][playpal[3 * i + 2]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+			for (i = 0; i < 256; i++)
+			{
+				r = gamma2table[usegamma][playpal[3 * i + 0]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+				g = gamma2table[usegamma][playpal[3 * i + 1]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+				b = gamma2table[usegamma][playpal[3 * i + 2]] * (1. - scale) + gamma2table[usegamma][0] * scale;
 
-                colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-            }
-        }
+				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+			}
+		}
 
-        // [crispy] Invulnerability (c == COLORMAPS)
-        for (i = 0; i < 256; i++)
-        {
-            const byte gray = 0xff -
-                 (byte) (0.299 * playpal[3 * i + 0] +
-                         0.587 * playpal[3 * i + 1] +
-                         0.114 * playpal[3 * i + 2]);
-            r = g = b = gamma2table[usegamma][gray];
+		// [crispy] Invulnerability (c == COLORMAPS)
+		for (i = 0; i < 256; i++)
+		{
+			const byte gray = 0xff -
+			     (byte) (0.299 * playpal[3 * i + 0] +
+			             0.587 * playpal[3 * i + 1] +
+			             0.114 * playpal[3 * i + 2]);
+			r = g = b = gamma2table[usegamma][gray];
 
-            colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-        }
-    }
-    else
-    {
-        byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
+			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+		}
+	}
+	else
+	{
+		byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 
-        for (c = 0; c <= NUMCOLORMAPS; c++)
-        {
-            for (i = 0; i < 256; i++)
-            {
-                r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
-                g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
-                b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
+		for (c = 0; c <= NUMCOLORMAPS; c++)
+		{
+			for (i = 0; i < 256; i++)
+			{
+				r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+				g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+				b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
 
-                colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-            }
-        }
+				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+			}
+		}
 
-        W_ReleaseLumpName("COLORMAP");
-    }
+		W_ReleaseLumpName("COLORMAP");
+	}
 #endif
 
     // [crispy] initialize color translation and color strings tables
     {
-    byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-    char c[3];
-    int i, j;
-    boolean keepgray = false;
+	byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	char c[3];
+	int i, j;
+	boolean keepgray = false;
 
-    if (!crstr)
-        crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
+	if (!crstr)
+	    crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
 
-    // [crispy] check for status bar graphics replacements
-    i = W_CheckNumForName(DEH_String("sttnum0")); // [crispy] Status Bar '0'
-    keepgray = (i >= 0 && W_IsIWADLump(lumpinfo[i]));
+	// [crispy] check for status bar graphics replacements
+	i = W_CheckNumForName(DEH_String("sttnum0")); // [crispy] Status Bar '0'
+	keepgray = (i >= 0 && W_IsIWADLump(lumpinfo[i]));
 
-    // [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
-    for (i = 0; i < CRMAX - 2; i++)
-    {
-        for (j = 0; j < 256; j++)
-        {
-        cr[i][j] = V_Colorize(playpal, i, j, keepgray);
-        }
+	// [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
+	for (i = 0; i < CRMAX - 2; i++)
+	{
+	    for (j = 0; j < 256; j++)
+	    {
+		cr[i][j] = V_Colorize(playpal, i, j, keepgray);
+	    }
 
-        M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
-        crstr[i] = M_StringDuplicate(c);
-    }
+	    M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
+	    crstr[i] = M_StringDuplicate(c);
+	}
 
-    W_ReleaseLumpName("PLAYPAL");
+	W_ReleaseLumpName("PLAYPAL");
     }
 }
 
@@ -1268,20 +1268,20 @@ void R_InitData (void)
 //
 int R_FlatNumForName(const char *name)
 {
-    int     i;
-    char    namet[9];
+    int		i;
+    char	namet[9];
 
     i = W_CheckNumForNameFromTo (name, lastflat, firstflat);
 
     if (i == -1)
     {
-    namet[8] = 0;
-    memcpy (namet, name,8);
-    // [crispy] make non-fatal
-    fprintf (stderr, "R_FlatNumForName: %s not found\n", namet);
-    // [crispy] since there is no "No Flat" marker,
-    // render missing flats as SKY
-    return skyflatnum;
+	namet[8] = 0;
+	memcpy (namet, name,8);
+	// [crispy] make non-fatal
+	fprintf (stderr, "R_FlatNumForName: %s not found\n", namet);
+	// [crispy] since there is no "No Flat" marker,
+	// render missing flats as SKY
+	return skyflatnum;
     }
     return i - firstflat;
 }
@@ -1300,17 +1300,17 @@ int R_CheckTextureNumForName(const char *name)
     int key;
 
     // "NoTexture" marker.
-    if (name[0] == '-')     
-    return 0;
-        
+    if (name[0] == '-')		
+	return 0;
+		
     key = W_LumpNameHash(name) % numtextures;
 
     texture=textures_hashtable[key]; 
     
     while (texture != NULL)
     {
-    if (!strncasecmp (texture->name, name, 8) )
-        return texture->index;
+	if (!strncasecmp (texture->name, name, 8) )
+	    return texture->index;
 
         texture = texture->next;
     }
@@ -1327,20 +1327,20 @@ int R_CheckTextureNumForName(const char *name)
 //
 int R_TextureNumForName(const char *name)
 {
-    int     i;
-    
+    int		i;
+	
     i = R_CheckTextureNumForName (name);
 
     if (i==-1)
     {
-    // [crispy] fix absurd texture name in error message
-    char    namet[9];
-    namet[8] = '\0';
-    memcpy (namet, name, 8);
-    // [crispy] make non-fatal
-    fprintf (stderr, "R_TextureNumForName: %s not found\n",
-         namet);
-    return 0;
+	// [crispy] fix absurd texture name in error message
+	char	namet[9];
+	namet[8] = '\0';
+	memcpy (namet, name, 8);
+	// [crispy] make non-fatal
+	fprintf (stderr, "R_TextureNumForName: %s not found\n",
+		 namet);
+	return 0;
     }
     return i;
 }
@@ -1352,48 +1352,48 @@ int R_TextureNumForName(const char *name)
 // R_PrecacheLevel
 // Preloads all relevant graphics for the level.
 //
-int     flatmemory;
-int     texturememory;
-int     spritememory;
+int		flatmemory;
+int		texturememory;
+int		spritememory;
 
 void R_PrecacheLevel (void)
 {
-    char*       flatpresent;
-    char*       texturepresent;
-    char*       spritepresent;
+    char*		flatpresent;
+    char*		texturepresent;
+    char*		spritepresent;
 
-    int         i;
-    int         j;
-    int         k;
-    int         lump;
+    int			i;
+    int			j;
+    int			k;
+    int			lump;
     
-    texture_t*      texture;
-    thinker_t*      th;
-    spriteframe_t*  sf;
+    texture_t*		texture;
+    thinker_t*		th;
+    spriteframe_t*	sf;
 
     if (demoplayback)
-    return;
+	return;
     
     // Precache flats.
     flatpresent = Z_Malloc(numflats, PU_STATIC, NULL);
-    memset (flatpresent,0,numflats);    
+    memset (flatpresent,0,numflats);	
 
     for (i=0 ; i<numsectors ; i++)
     {
-    flatpresent[sectors[i].floorpic] = 1;
-    flatpresent[sectors[i].ceilingpic] = 1;
+	flatpresent[sectors[i].floorpic] = 1;
+	flatpresent[sectors[i].ceilingpic] = 1;
     }
-    
+	
     flatmemory = 0;
 
     for (i=0 ; i<numflats ; i++)
     {
-    if (flatpresent[i])
-    {
-        lump = firstflat + i;
-        flatmemory += lumpinfo[lump]->size;
-        W_CacheLumpNum(lump, PU_CACHE);
-    }
+	if (flatpresent[i])
+	{
+	    lump = firstflat + i;
+	    flatmemory += lumpinfo[lump]->size;
+	    W_CacheLumpNum(lump, PU_CACHE);
+	}
     }
 
     Z_Free(flatpresent);
@@ -1401,12 +1401,12 @@ void R_PrecacheLevel (void)
     // Precache textures.
     texturepresent = Z_Malloc(numtextures, PU_STATIC, NULL);
     memset (texturepresent,0, numtextures);
-    
+	
     for (i=0 ; i<numsides ; i++)
     {
-    texturepresent[sides[i].toptexture] = 1;
-    texturepresent[sides[i].midtexture] = 1;
-    texturepresent[sides[i].bottomtexture] = 1;
+	texturepresent[sides[i].toptexture] = 1;
+	texturepresent[sides[i].midtexture] = 1;
+	texturepresent[sides[i].bottomtexture] = 1;
     }
 
     // Sky texture is always present.
@@ -1416,24 +1416,24 @@ void R_PrecacheLevel (void)
     //  a wall texture, with an episode dependend
     //  name.
     texturepresent[skytexture] = 1;
-    
+	
     texturememory = 0;
     for (i=0 ; i<numtextures ; i++)
     {
-    if (!texturepresent[i])
-        continue;
+	if (!texturepresent[i])
+	    continue;
 
-    // [crispy] precache composite textures
-    R_GenerateComposite(i);
+	// [crispy] precache composite textures
+	R_GenerateComposite(i);
 
-    texture = textures[i];
-    
-    for (j=0 ; j<texture->patchcount ; j++)
-    {
-        lump = texture->patches[j].patch;
-        texturememory += lumpinfo[lump]->size;
-        W_CacheLumpNum(lump , PU_CACHE);
-    }
+	texture = textures[i];
+	
+	for (j=0 ; j<texture->patchcount ; j++)
+	{
+	    lump = texture->patches[j].patch;
+	    texturememory += lumpinfo[lump]->size;
+	    W_CacheLumpNum(lump , PU_CACHE);
+	}
     }
 
     Z_Free(texturepresent);
@@ -1441,29 +1441,29 @@ void R_PrecacheLevel (void)
     // Precache sprites.
     spritepresent = Z_Malloc(numsprites, PU_STATIC, NULL);
     memset (spritepresent,0, numsprites);
-    
+	
     for (th = thinkercap.next ; th != &thinkercap ; th=th->next)
     {
-    if (th->function.acp1 == (actionf_p1)P_MobjThinker)
-        spritepresent[((mobj_t *)th)->sprite] = 1;
+	if (th->function.acp1 == (actionf_p1)P_MobjThinker)
+	    spritepresent[((mobj_t *)th)->sprite] = 1;
     }
-    
+	
     spritememory = 0;
     for (i=0 ; i<numsprites ; i++)
     {
-    if (!spritepresent[i])
-        continue;
+	if (!spritepresent[i])
+	    continue;
 
-    for (j=0 ; j<sprites[i].numframes ; j++)
-    {
-        sf = &sprites[i].spriteframes[j];
-        for (k=0 ; k<8 ; k++)
-        {
-        lump = firstspritelump + sf->lump[k];
-        spritememory += lumpinfo[lump]->size;
-        W_CacheLumpNum(lump , PU_CACHE);
-        }
-    }
+	for (j=0 ; j<sprites[i].numframes ; j++)
+	{
+	    sf = &sprites[i].spriteframes[j];
+	    for (k=0 ; k<8 ; k++)
+	    {
+		lump = firstspritelump + sf->lump[k];
+		spritememory += lumpinfo[lump]->size;
+		W_CacheLumpNum(lump , PU_CACHE);
+	    }
+	}
     }
 
     Z_Free(spritepresent);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1069,10 +1069,10 @@ static void R_InitTranMap()
     // If a tranlucency filter map lump is present, use it
     if (lump != -1 && W_LumpLength(lump) == 256*256)
     {
-	// Set a pointer to the translucency filter maps.
-	tranmap = W_CacheLumpNum(lump, PU_STATIC);
-	// [crispy] loaded from a lump
-	printf(":");
+        // Set a pointer to the translucency filter maps.
+        tranmap = W_CacheLumpNum(lump, PU_STATIC);
+        // [crispy] loaded from a lump
+        printf(":");
     }
     else
     {

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1064,6 +1064,17 @@ static const int tran_filter_pct = 66;
 
 static void R_InitTranMap()
 {
+    int lump = W_CheckNumForName("TRANMAP");
+
+    // If a tranlucency filter map lump is present, use it
+    if (lump != -1)
+    {
+	// Set a pointer to the translucency filter maps.
+	tranmap = W_CacheLumpNum(lump, PU_STATIC);
+	// [crispy] loaded from a lump
+	printf(":");
+    }
+    else
     {
 	// Compose a default transparent filter map based on PLAYPAL.
 	unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1067,7 +1067,7 @@ static void R_InitTranMap()
     int lump = W_CheckNumForName("TRANMAP");
 
     // If a tranlucency filter map lump is present, use it
-    if (lump != -1)
+    if (lump != -1 && W_LumpLength(lump) == 256*256)
     {
 	// Set a pointer to the translucency filter maps.
 	tranmap = W_CacheLumpNum(lump, PU_STATIC);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -13,8 +13,8 @@
 // GNU General Public License for more details.
 //
 // DESCRIPTION:
-//	Preparation of data for rendering,
-//	generation of lookups, caching, retrieval by name.
+//  Preparation of data for rendering,
+//  generation of lookups, caching, retrieval by name.
 //
 
 #include <stdio.h>
@@ -61,11 +61,11 @@
 //
 typedef PACKED_STRUCT (
 {
-    short	originx;
-    short	originy;
-    short	patch;
-    short	stepdir;
-    short	colormap;
+    short   originx;
+    short   originy;
+    short   patch;
+    short   stepdir;
+    short   colormap;
 }) mappatch_t;
 
 
@@ -76,13 +76,13 @@ typedef PACKED_STRUCT (
 //
 typedef PACKED_STRUCT (
 {
-    char		name[8];
-    int			masked;	
-    short		width;
-    short		height;
+    char        name[8];
+    int         masked; 
+    short       width;
+    short       height;
     int                 obsolete;
-    short		patchcount;
-    mappatch_t	patches[1];
+    short       patchcount;
+    mappatch_t  patches[1];
 }) maptexture_t;
 
 
@@ -94,9 +94,9 @@ typedef struct
     // Block origin (allways UL),
     // which has allready accounted
     // for the internal origin of the patch.
-    short	originx;	
-    short	originy;
-    int		patch;
+    short   originx;    
+    short   originy;
+    int     patch;
 } texpatch_t;
 
 
@@ -109,9 +109,9 @@ typedef struct texture_s texture_t;
 struct texture_s
 {
     // Keep name for switch changing, etc.
-    char	name[8];		
-    short	width;
-    short	height;
+    char    name[8];        
+    short   width;
+    short   height;
 
     // Index in textures list
 
@@ -123,51 +123,51 @@ struct texture_s
     
     // All the patches[patchcount]
     //  are drawn back to front into the cached texture.
-    short	patchcount;
-    texpatch_t	patches[1];		
+    short   patchcount;
+    texpatch_t  patches[1];     
 };
 
 
 
-int		firstflat;
-int		lastflat;
-int		numflats;
+int     firstflat;
+int     lastflat;
+int     numflats;
 
-int		firstpatch;
-int		lastpatch;
-int		numpatches;
+int     firstpatch;
+int     lastpatch;
+int     numpatches;
 
-int		firstspritelump;
-int		lastspritelump;
-int		numspritelumps;
+int     firstspritelump;
+int     lastspritelump;
+int     numspritelumps;
 
-int		numtextures;
-texture_t**	textures;
+int     numtextures;
+texture_t** textures;
 texture_t**     textures_hashtable;
 
 
-int*			texturewidthmask;
-int*			texturewidth; // [crispy] texture width for wrapping column getter function
+int*            texturewidthmask;
+int*            texturewidth; // [crispy] texture width for wrapping column getter function
 // needed for texture pegging
-fixed_t*		textureheight; // [crispy] texture height for Tutti-Frutti fix
-int*			texturecompositesize;
-short**			texturecolumnlump;
-unsigned**		texturecolumnofs; // [crispy] column offsets for composited translucent mid-textures on 2S walls
-unsigned**		texturecolumnofs2; // [crispy] column offsets for composited opaque textures
-byte**			texturecomposite; // [crispy] composited translucent mid-textures on 2S walls
-byte**			texturecomposite2; // [crispy] composited opaque textures
-byte**			texturebrightmap; // [crispy] brightmaps
+fixed_t*        textureheight; // [crispy] texture height for Tutti-Frutti fix
+int*            texturecompositesize;
+short**         texturecolumnlump;
+unsigned**      texturecolumnofs; // [crispy] column offsets for composited translucent mid-textures on 2S walls
+unsigned**      texturecolumnofs2; // [crispy] column offsets for composited opaque textures
+byte**          texturecomposite; // [crispy] composited translucent mid-textures on 2S walls
+byte**          texturecomposite2; // [crispy] composited opaque textures
+byte**          texturebrightmap; // [crispy] brightmaps
 
 // for global animation
-int*		flattranslation;
-int*		texturetranslation;
+int*        flattranslation;
+int*        texturetranslation;
 
 // needed for pre rendering
-fixed_t*	spritewidth;	
-fixed_t*	spriteoffset;
-fixed_t*	spritetopoffset;
+fixed_t*    spritewidth;    
+fixed_t*    spriteoffset;
+fixed_t*    spritetopoffset;
 
-lighttable_t	*colormaps;
+lighttable_t    *colormaps;
 
 
 //
@@ -197,53 +197,53 @@ lighttable_t	*colormaps;
 
 void
 R_DrawColumnInCache
-( column_t*	patch,
-  byte*		cache,
-  int		originy,
-  int		cacheheight,
-  byte*		marks )
+( column_t* patch,
+  byte*     cache,
+  int       originy,
+  int       cacheheight,
+  byte*     marks )
 {
-    int		count;
-    int		position;
-    byte*	source;
-    int		top = -1;
+    int     count;
+    int     position;
+    byte*   source;
+    int     top = -1;
 
     while (patch->topdelta != 0xff)
     {
-	// [crispy] support for DeePsea tall patches
-	if (patch->topdelta <= top)
-	{
-		top += patch->topdelta;
-	}
-	else
-	{
-		top = patch->topdelta;
-	}
-	source = (byte *)patch + 3;
-	count = patch->length;
-	position = originy + top;
+    // [crispy] support for DeePsea tall patches
+    if (patch->topdelta <= top)
+    {
+        top += patch->topdelta;
+    }
+    else
+    {
+        top = patch->topdelta;
+    }
+    source = (byte *)patch + 3;
+    count = patch->length;
+    position = originy + top;
 
-	if (position < 0)
-	{
-	    count += position;
-	    position = 0;
-	}
+    if (position < 0)
+    {
+        count += position;
+        position = 0;
+    }
 
-	if (position + count > cacheheight)
-	    count = cacheheight - position;
+    if (position + count > cacheheight)
+        count = cacheheight - position;
 
-	if (count > 0)
-	{
-	    memcpy (cache + position, source, count);
+    if (count > 0)
+    {
+        memcpy (cache + position, source, count);
 
-	    // killough 4/9/98: remember which cells in column have been drawn,
-	    // so that column can later be converted into a series of posts, to
-	    // fix the Medusa bug.
+        // killough 4/9/98: remember which cells in column have been drawn,
+        // so that column can later be converted into a series of posts, to
+        // fix the Medusa bug.
 
-	    memset (marks + position, 0xff, count);
-	}
-		
-	patch = (column_t *)(  (byte *)patch + patch->length + 4); 
+        memset (marks + position, 0xff, count);
+    }
+        
+    patch = (column_t *)(  (byte *)patch + patch->length + 4); 
     }
 }
 
@@ -259,29 +259,29 @@ R_DrawColumnInCache
 
 void R_GenerateComposite (int texnum)
 {
-    byte*		block, *block2;
-    texture_t*		texture;
-    texpatch_t*		patch;	
-    patch_t*		realpatch;
-    int			x;
-    int			x1;
-    int			x2;
-    int			i;
-    column_t*		patchcol;
-    short*		collump;
-    unsigned*		colofs, *colofs2; // killough 4/9/98: make 32-bit
-    byte*		marks; // killough 4/9/98: transparency marks
-    byte*		source; // killough 4/9/98: temporary column
-	
+    byte*       block, *block2;
+    texture_t*      texture;
+    texpatch_t*     patch;  
+    patch_t*        realpatch;
+    int         x;
+    int         x1;
+    int         x2;
+    int         i;
+    column_t*       patchcol;
+    short*      collump;
+    unsigned*       colofs, *colofs2; // killough 4/9/98: make 32-bit
+    byte*       marks; // killough 4/9/98: transparency marks
+    byte*       source; // killough 4/9/98: temporary column
+    
     texture = textures[texnum];
 
     block = Z_Malloc (texturecompositesize[texnum],
-		      PU_STATIC, 
-		      &texturecomposite[texnum]);	
+              PU_STATIC, 
+              &texturecomposite[texnum]);   
     // [crispy] memory block for opaque textures
     block2 = Z_Malloc (texture->width * texture->height,
-		      PU_STATIC,
-		      &texturecomposite2[texnum]);
+              PU_STATIC,
+              &texturecomposite2[texnum]);
 
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
@@ -295,41 +295,41 @@ void R_GenerateComposite (int texnum)
 
     // Composite the columns together.
     for (i=0 , patch = texture->patches;
-	 i<texture->patchcount;
-	 i++, patch++)
+     i<texture->patchcount;
+     i++, patch++)
     {
-	realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
-	x1 = patch->originx;
-	x2 = x1 + SHORT(realpatch->width);
+    realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
+    x1 = patch->originx;
+    x2 = x1 + SHORT(realpatch->width);
 
-	if (x1<0)
-	    x = 0;
-	else
-	    x = x1;
-	
-	if (x2 > texture->width)
-	    x2 = texture->width;
+    if (x1<0)
+        x = 0;
+    else
+        x = x1;
+    
+    if (x2 > texture->width)
+        x2 = texture->width;
 
-	for ( ; x<x2 ; x++)
-	{
-	    // Column does not have multiple patches?
-	    // [crispy] generate composites for single-patched columns as well
-	    /*
-	    if (collump[x] >= 0)
-		continue;
-	    */
-	    
-	    patchcol = (column_t *)((byte *)realpatch
-				    + LONG(realpatch->columnofs[x-x1]));
-	    R_DrawColumnInCache (patchcol,
-				 block + colofs[x],
-				 // [crispy] single-patched columns are normally not composited
-				 // but directly read from the patch lump ignoring their originy
-				 collump[x] >= 0 ? 0 : patch->originy,
-				 texture->height,
-				 marks + x * texture->height);
-	}
-						
+    for ( ; x<x2 ; x++)
+    {
+        // Column does not have multiple patches?
+        // [crispy] generate composites for single-patched columns as well
+        /*
+        if (collump[x] >= 0)
+        continue;
+        */
+        
+        patchcol = (column_t *)((byte *)realpatch
+                    + LONG(realpatch->columnofs[x-x1]));
+        R_DrawColumnInCache (patchcol,
+                 block + colofs[x],
+                 // [crispy] single-patched columns are normally not composited
+                 // but directly read from the patch lump ignoring their originy
+                 collump[x] >= 0 ? 0 : patch->originy,
+                 texture->height,
+                 marks + x * texture->height);
+    }
+                        
     }
 
     // killough 4/9/98: Next, convert multipatched columns into true columns,
@@ -338,57 +338,57 @@ void R_GenerateComposite (int texnum)
     source = I_Realloc(NULL, texture->height); // temporary column
     for (i = 0; i < texture->width; i++)
     {
-	// [crispy] generate composites for all columns
-//	if (collump[i] == -1) // process only multipatched columns
-	{
-	    column_t *col = (column_t *)(block + colofs[i] - 3); // cached column
-	    const byte *mark = marks + i * texture->height;
-	    int j = 0;
-	    // [crispy] absolut topdelta for first 254 pixels, then relative
-	    int abstop, reltop = 0;
-	    boolean relative = false;
+    // [crispy] generate composites for all columns
+//  if (collump[i] == -1) // process only multipatched columns
+    {
+        column_t *col = (column_t *)(block + colofs[i] - 3); // cached column
+        const byte *mark = marks + i * texture->height;
+        int j = 0;
+        // [crispy] absolut topdelta for first 254 pixels, then relative
+        int abstop, reltop = 0;
+        boolean relative = false;
 
-	    // save column in temporary so we can shuffle it around
-	    memcpy(source, (byte *) col + 3, texture->height);
-	    // [crispy] copy composited columns to opaque texture
-	    memcpy(block2 + colofs2[i], source, texture->height);
+        // save column in temporary so we can shuffle it around
+        memcpy(source, (byte *) col + 3, texture->height);
+        // [crispy] copy composited columns to opaque texture
+        memcpy(block2 + colofs2[i], source, texture->height);
 
-	    for ( ; ; ) // reconstruct the column by scanning transparency marks
-	    {
-		unsigned len; // killough 12/98
+        for ( ; ; ) // reconstruct the column by scanning transparency marks
+        {
+        unsigned len; // killough 12/98
 
-		while (j < texture->height && reltop < 254 && !mark[j]) // skip transparent cells
-		    j++, reltop++;
+        while (j < texture->height && reltop < 254 && !mark[j]) // skip transparent cells
+            j++, reltop++;
 
-		if (j >= texture->height) // if at end of column
-		{
-		    col->topdelta = -1; // end-of-column marker
-		    break;
-		}
+        if (j >= texture->height) // if at end of column
+        {
+            col->topdelta = -1; // end-of-column marker
+            break;
+        }
 
-		// [crispy] absolut topdelta for first 254 pixels, then relative
-		col->topdelta = relative ? reltop : j; // starting offset of post
+        // [crispy] absolut topdelta for first 254 pixels, then relative
+        col->topdelta = relative ? reltop : j; // starting offset of post
 
-		// [crispy] once we pass the 254 boundary, topdelta becomes relative
-		if ((abstop = j) >= 254)
-		{
-			relative = true;
-			reltop = 0;
-		}
+        // [crispy] once we pass the 254 boundary, topdelta becomes relative
+        if ((abstop = j) >= 254)
+        {
+            relative = true;
+            reltop = 0;
+        }
 
-		// killough 12/98:
-		// Use 32-bit len counter, to support tall 1s multipatched textures
+        // killough 12/98:
+        // Use 32-bit len counter, to support tall 1s multipatched textures
 
-		for (len = 0; j < texture->height && reltop < 254 && mark[j]; j++, reltop++)
-		    len++; // count opaque cells
+        for (len = 0; j < texture->height && reltop < 254 && mark[j]; j++, reltop++)
+            len++; // count opaque cells
 
-		col->length = len; // killough 12/98: intentionally truncate length
+        col->length = len; // killough 12/98: intentionally truncate length
 
-		// copy opaque cells from the temporary back into the column
-		memcpy((byte *) col + 3, source + abstop, len);
-		col = (column_t *)((byte *) col + len + 4); // next post
-	    }
-	}
+        // copy opaque cells from the temporary back into the column
+        memcpy((byte *) col + 3, source + abstop, len);
+        col = (column_t *)((byte *) col + len + 4); // next post
+        }
+    }
     }
 
     free(source); // free temporary column
@@ -410,20 +410,20 @@ void R_GenerateComposite (int texnum)
 
 void R_GenerateLookup (int texnum)
 {
-    texture_t*		texture;
-    byte*		patchcount;	// patchcount[texture->width]
-    byte*		postcount; // killough 4/9/98: keep count of posts in addition to patches.
-    texpatch_t*		patch;	
-    patch_t*		realpatch;
-    int			x;
-    int			x1;
-    int			x2;
-    int			i;
-    short*		collump;
-    unsigned*		colofs, *colofs2; // killough 4/9/98: make 32-bit
-    int			csize = 0; // killough 10/98
-    int			err = 0; // killough 10/98
-	
+    texture_t*      texture;
+    byte*       patchcount; // patchcount[texture->width]
+    byte*       postcount; // killough 4/9/98: keep count of posts in addition to patches.
+    texpatch_t*     patch;  
+    patch_t*        realpatch;
+    int         x;
+    int         x1;
+    int         x2;
+    int         i;
+    short*      collump;
+    unsigned*       colofs, *colofs2; // killough 4/9/98: make 32-bit
+    int         csize = 0; // killough 10/98
+    int         err = 0; // killough 10/98
+    
     texture = textures[texnum];
 
     // Composited texture not created yet.
@@ -445,39 +445,39 @@ void R_GenerateLookup (int texnum)
     memset (postcount, 0, texture->width);
 
     for (i=0 , patch = texture->patches;
-	 i<texture->patchcount;
-	 i++, patch++)
+     i<texture->patchcount;
+     i++, patch++)
     {
-	realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
-	x1 = patch->originx;
-	x2 = x1 + SHORT(realpatch->width);
+    realpatch = W_CacheLumpNum (patch->patch, PU_CACHE);
+    x1 = patch->originx;
+    x2 = x1 + SHORT(realpatch->width);
 
-	// [crispy] detect patches in PNG format... and fail
-	{
-		const unsigned char *magic = (const unsigned char *) realpatch;
+    // [crispy] detect patches in PNG format... and fail
+    {
+        const unsigned char *magic = (const unsigned char *) realpatch;
 
-		if (magic[0] == 0x89 &&
-		    magic[1] == 'P' && magic[2] == 'N' && magic[3] == 'G')
-		{
-			I_Error("Patch in PNG format detected: %.8s", lumpinfo[patch->patch]->name);
-		}
-	}
-	
-	if (x1 < 0)
-	    x = 0;
-	else
-	    x = x1;
-
-	if (x2 > texture->width)
-	    x2 = texture->width;
-	for ( ; x<x2 ; x++)
-	{
-	    patchcount[x]++;
-	    collump[x] = patch->patch;
-	    colofs[x] = LONG(realpatch->columnofs[x-x1])+3;
-	}
+        if (magic[0] == 0x89 &&
+            magic[1] == 'P' && magic[2] == 'N' && magic[3] == 'G')
+        {
+            I_Error("Patch in PNG format detected: %.8s", lumpinfo[patch->patch]->name);
+        }
     }
-	
+    
+    if (x1 < 0)
+        x = 0;
+    else
+        x = x1;
+
+    if (x2 > texture->width)
+        x2 = texture->width;
+    for ( ; x<x2 ; x++)
+    {
+        patchcount[x]++;
+        collump[x] = patch->patch;
+        colofs[x] = LONG(realpatch->columnofs[x-x1])+3;
+    }
+    }
+    
     // killough 4/9/98: keep a count of the number of posts in column,
     // to fix Medusa bug while allowing for transparent multipatches.
     //
@@ -493,40 +493,40 @@ void R_GenerateLookup (int texnum)
     // [crispy] generate composites for all textures
 //  if (texture->patchcount > 1 && texture->height < 256)
     {
-	// killough 12/98: Warn about a common column construction bug
-	unsigned limit = texture->height * 3 + 3; // absolute column size limit
+    // killough 12/98: Warn about a common column construction bug
+    unsigned limit = texture->height * 3 + 3; // absolute column size limit
 
-	for (i = texture->patchcount, patch = texture->patches; --i >= 0; )
-	{
-	    int pat = patch->patch;
-	    const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
-	    int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
-	    const int *cofs = realpatch->columnofs - x1;
+    for (i = texture->patchcount, patch = texture->patches; --i >= 0; )
+    {
+        int pat = patch->patch;
+        const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
+        int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
+        const int *cofs = realpatch->columnofs - x1;
 
-	    if (x2 > texture->width)
-		x2 = texture->width;
-	    if (x1 < 0)
-		x1 = 0;
+        if (x2 > texture->width)
+        x2 = texture->width;
+        if (x1 < 0)
+        x1 = 0;
 
-	    for (x = x1 ; x < x2 ; x++)
-	    {
-		// [crispy] generate composites for all columns
-//		if (patchcount[x] > 1) // Only multipatched columns
-		{
-		    const column_t *col = (const column_t*)((const byte*) realpatch + LONG(cofs[x]));
-		    const byte *base = (const byte *) col;
+        for (x = x1 ; x < x2 ; x++)
+        {
+        // [crispy] generate composites for all columns
+//      if (patchcount[x] > 1) // Only multipatched columns
+        {
+            const column_t *col = (const column_t*)((const byte*) realpatch + LONG(cofs[x]));
+            const byte *base = (const byte *) col;
 
-		    // count posts
-		    for ( ; col->topdelta != 0xff; postcount[x]++)
-		    {
-			if ((unsigned)((const byte *) col - base) <= limit)
-			    col = (const column_t *)((const byte *) col + col->length + 4);
-			else
-			    break;
-		    }
-		}
-	    }
-	}
+            // count posts
+            for ( ; col->topdelta != 0xff; postcount[x]++)
+            {
+            if ((unsigned)((const byte *) col - base) <= limit)
+                col = (const column_t *)((const byte *) col + col->length + 4);
+            else
+                break;
+            }
+        }
+        }
+    }
     }
 
     // Now count the number of columns
@@ -536,50 +536,50 @@ void R_GenerateLookup (int texnum)
 
     for (x=0 ; x<texture->width ; x++)
     {
-	if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
-	{
-	    // [crispy] fix absurd texture name in error message
-	    printf ("R_GenerateLookup: column without a patch (%.8s)\n",
-		    texture->name);
-	    // [crispy] do not return yet
-	    /*
-	    return;
-	    */
-	}
-	// I_Error ("R_GenerateLookup: column without a patch");
-	
-	// [crispy] treat patch-less columns the same as multi-patched
-	if (patchcount[x] > 1 || !patchcount[x])
-	{
-	    // Use the cached block.
-	    // [crispy] moved up here, the rest in this loop
-	    // applies to single-patched textures as well
-	    collump[x] = -1;	
-	}
-	    // killough 1/25/98, 4/9/98:
-	    //
-	    // Fix Medusa bug, by adding room for column header
-	    // and trailer bytes for each post in merged column.
-	    // For now, just allocate conservatively 4 bytes
-	    // per post per patch per column, since we don't
-	    // yet know how many posts the merged column will
-	    // require, and it's bounded above by this limit.
+    if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
+    {
+        // [crispy] fix absurd texture name in error message
+        printf ("R_GenerateLookup: column without a patch (%.8s)\n",
+            texture->name);
+        // [crispy] do not return yet
+        /*
+        return;
+        */
+    }
+    // I_Error ("R_GenerateLookup: column without a patch");
+    
+    // [crispy] treat patch-less columns the same as multi-patched
+    if (patchcount[x] > 1 || !patchcount[x])
+    {
+        // Use the cached block.
+        // [crispy] moved up here, the rest in this loop
+        // applies to single-patched textures as well
+        collump[x] = -1;    
+    }
+        // killough 1/25/98, 4/9/98:
+        //
+        // Fix Medusa bug, by adding room for column header
+        // and trailer bytes for each post in merged column.
+        // For now, just allocate conservatively 4 bytes
+        // per post per patch per column, since we don't
+        // yet know how many posts the merged column will
+        // require, and it's bounded above by this limit.
 
-	    colofs[x] = csize + 3; // three header bytes in a column
-	    // killough 12/98: add room for one extra post
-	    csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
-	    
-	    // [crispy] remove limit
-	    /*
-	    if (texturecompositesize[texnum] > 0x10000-texture->height)
-	    {
-		I_Error ("R_GenerateLookup: texture %i is >64k",
-			 texnum);
-	    }
-	    */
-	csize += texture->height; // height bytes of texture data
-	// [crispy] initialize opaque texture column offset
-	colofs2[x] = x * texture->height;
+        colofs[x] = csize + 3; // three header bytes in a column
+        // killough 12/98: add room for one extra post
+        csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
+        
+        // [crispy] remove limit
+        /*
+        if (texturecompositesize[texnum] > 0x10000-texture->height)
+        {
+        I_Error ("R_GenerateLookup: texture %i is >64k",
+             texnum);
+        }
+        */
+    csize += texture->height; // height bytes of texture data
+    // [crispy] initialize opaque texture column offset
+    colofs2[x] = x * texture->height;
     }
 
     texturecompositesize[texnum] = csize;
@@ -596,16 +596,16 @@ void R_GenerateLookup (int texnum)
 //
 byte*
 R_GetColumn
-( int		tex,
-  int		col )
+( int       tex,
+  int       col )
 {
-    int		ofs;
-	
+    int     ofs;
+    
     col &= texturewidthmask[tex];
     ofs = texturecolumnofs2[tex][col];
 
     if (!texturecomposite2[tex])
-	R_GenerateComposite (tex);
+    R_GenerateComposite (tex);
 
     return texturecomposite2[tex] + ofs;
 }
@@ -613,19 +613,19 @@ R_GetColumn
 // [crispy] wrapping column getter function for composited translucent mid-textures on 2S walls
 byte*
 R_GetColumnMod
-( int		tex,
-  int		col )
+( int       tex,
+  int       col )
 {
-    int		ofs;
+    int     ofs;
 
     while (col < 0)
-	col += texturewidth[tex];
+    col += texturewidth[tex];
 
     col %= texturewidth[tex];
     ofs = texturecolumnofs[tex][col];
 
     if (!texturecomposite[tex])
-	R_GenerateComposite (tex);
+    R_GenerateComposite (tex);
 
     return texturecomposite[tex] + ofs;
 }
@@ -681,59 +681,59 @@ static void GenerateTextureHashTable(void)
 // [crispy] partly rewritten to merge PNAMES and TEXTURE1/2 lumps
 void R_InitTextures (void)
 {
-    maptexture_t*	mtexture;
-    texture_t*		texture;
-    mappatch_t*		mpatch;
-    texpatch_t*		patch;
+    maptexture_t*   mtexture;
+    texture_t*      texture;
+    mappatch_t*     mpatch;
+    texpatch_t*     patch;
 
-    int			i;
-    int			j;
-    int			k;
+    int         i;
+    int         j;
+    int         k;
 
-    int*		maptex = NULL;
+    int*        maptex = NULL;
     
-    char		name[9];
+    char        name[9];
     
-    int*		patchlookup;
+    int*        patchlookup;
     
-    int			totalwidth;
-    int			nummappatches;
-    int			offset;
-    int			maxoff = 0;
+    int         totalwidth;
+    int         nummappatches;
+    int         offset;
+    int         maxoff = 0;
 
-    int*		directory = NULL;
+    int*        directory = NULL;
     
-    int			temp1;
-    int			temp2;
-    int			temp3;
+    int         temp1;
+    int         temp2;
+    int         temp3;
 
     typedef struct
     {
-	int lumpnum;
-	void *names;
-	short nummappatches;
-	short summappatches;
-	char *name_p;
+    int lumpnum;
+    void *names;
+    short nummappatches;
+    short summappatches;
+    char *name_p;
     } pnameslump_t;
 
     typedef struct
     {
-	int lumpnum;
-	int *maptex;
-	int maxoff;
-	short numtextures;
-	short sumtextures;
-	short pnamesoffset;
+    int lumpnum;
+    int *maptex;
+    int maxoff;
+    short numtextures;
+    short sumtextures;
+    short pnamesoffset;
     } texturelump_t;
 
-    pnameslump_t	*pnameslumps = NULL;
-    texturelump_t	*texturelumps = NULL, *texturelump;
+    pnameslump_t    *pnameslumps = NULL;
+    texturelump_t   *texturelumps = NULL, *texturelump;
 
-    int			maxpnameslumps = 1; // PNAMES
-    int			maxtexturelumps = 2; // TEXTURE1, TEXTURE2
+    int         maxpnameslumps = 1; // PNAMES
+    int         maxtexturelumps = 2; // TEXTURE1, TEXTURE2
 
-    int			numpnameslumps = 0;
-    int			numtexturelumps = 0;
+    int         numpnameslumps = 0;
+    int         numtexturelumps = 0;
 
     // [crispy] allocate memory for the pnameslumps and texturelumps arrays
     pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
@@ -743,62 +743,62 @@ void R_InitTextures (void)
     // are always processed first
     texturelumps[numtexturelumps++].lumpnum = W_GetNumForName(DEH_String("TEXTURE1"));
     if ((i = W_CheckNumForName(DEH_String("TEXTURE2"))) != -1)
-	texturelumps[numtexturelumps++].lumpnum = i;
+    texturelumps[numtexturelumps++].lumpnum = i;
     else
-	texturelumps[numtexturelumps].lumpnum = -1;
+    texturelumps[numtexturelumps].lumpnum = -1;
 
     // [crispy] fill the arrays with all available PNAMES lumps
     // and the remaining available TEXTURE1/2 lumps
     nummappatches = 0;
     for (i = numlumps - 1; i >= 0; i--)
     {
-	if (!strncasecmp(lumpinfo[i]->name, DEH_String("PNAMES"), 6))
-	{
-	    if (numpnameslumps == maxpnameslumps)
-	    {
-		maxpnameslumps++;
-		pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
-	    }
+    if (!strncasecmp(lumpinfo[i]->name, DEH_String("PNAMES"), 6))
+    {
+        if (numpnameslumps == maxpnameslumps)
+        {
+        maxpnameslumps++;
+        pnameslumps = I_Realloc(pnameslumps, maxpnameslumps * sizeof(*pnameslumps));
+        }
 
-	    pnameslumps[numpnameslumps].lumpnum = i;
-	    pnameslumps[numpnameslumps].names = W_CacheLumpNum(pnameslumps[numpnameslumps].lumpnum, PU_STATIC);
-	    pnameslumps[numpnameslumps].nummappatches = LONG(*((int *) pnameslumps[numpnameslumps].names));
+        pnameslumps[numpnameslumps].lumpnum = i;
+        pnameslumps[numpnameslumps].names = W_CacheLumpNum(pnameslumps[numpnameslumps].lumpnum, PU_STATIC);
+        pnameslumps[numpnameslumps].nummappatches = LONG(*((int *) pnameslumps[numpnameslumps].names));
 
-	    // [crispy] accumulated number of patches in the lookup tables
-	    // excluding the current one
-	    pnameslumps[numpnameslumps].summappatches = nummappatches;
-	    pnameslumps[numpnameslumps].name_p = (char*)pnameslumps[numpnameslumps].names + 4;
+        // [crispy] accumulated number of patches in the lookup tables
+        // excluding the current one
+        pnameslumps[numpnameslumps].summappatches = nummappatches;
+        pnameslumps[numpnameslumps].name_p = (char*)pnameslumps[numpnameslumps].names + 4;
 
-	    // [crispy] calculate total number of patches
-	    nummappatches += pnameslumps[numpnameslumps].nummappatches;
-	    numpnameslumps++;
-	}
-	else
-	if (!strncasecmp(lumpinfo[i]->name, DEH_String("TEXTURE"), 7))
-	{
-	    // [crispy] support only TEXTURE1/2 lumps, not TEXTURE3 etc.
-	    if (lumpinfo[i]->name[7] != '1' &&
-	        lumpinfo[i]->name[7] != '2')
-		continue;
+        // [crispy] calculate total number of patches
+        nummappatches += pnameslumps[numpnameslumps].nummappatches;
+        numpnameslumps++;
+    }
+    else
+    if (!strncasecmp(lumpinfo[i]->name, DEH_String("TEXTURE"), 7))
+    {
+        // [crispy] support only TEXTURE1/2 lumps, not TEXTURE3 etc.
+        if (lumpinfo[i]->name[7] != '1' &&
+            lumpinfo[i]->name[7] != '2')
+        continue;
 
-	    // [crispy] make sure the first available TEXTURE1/2 lumps
-	    // are not processed again
-	    if (i == texturelumps[0].lumpnum ||
-	        i == texturelumps[1].lumpnum) // [crispy] may still be -1
-		continue;
+        // [crispy] make sure the first available TEXTURE1/2 lumps
+        // are not processed again
+        if (i == texturelumps[0].lumpnum ||
+            i == texturelumps[1].lumpnum) // [crispy] may still be -1
+        continue;
 
-	    if (numtexturelumps == maxtexturelumps)
-	    {
-		maxtexturelumps++;
-		texturelumps = I_Realloc(texturelumps, maxtexturelumps * sizeof(*texturelumps));
-	    }
+        if (numtexturelumps == maxtexturelumps)
+        {
+        maxtexturelumps++;
+        texturelumps = I_Realloc(texturelumps, maxtexturelumps * sizeof(*texturelumps));
+        }
 
-	    // [crispy] do not proceed any further, yet
-	    // we first need a complete pnameslumps[] array and need
-	    // to process texturelumps[0] (and also texturelumps[1]) as well
-	    texturelumps[numtexturelumps].lumpnum = i;
-	    numtexturelumps++;
-	}
+        // [crispy] do not proceed any further, yet
+        // we first need a complete pnameslumps[] array and need
+        // to process texturelumps[0] (and also texturelumps[1]) as well
+        texturelumps[numtexturelumps].lumpnum = i;
+        numtexturelumps++;
+    }
     }
 
     // [crispy] fill up the patch lookup table
@@ -806,53 +806,53 @@ void R_InitTextures (void)
     patchlookup = Z_Malloc(nummappatches * sizeof(*patchlookup), PU_STATIC, NULL);
     for (i = 0, k = 0; i < numpnameslumps; i++)
     {
-	for (j = 0; j < pnameslumps[i].nummappatches; j++)
-	{
-	    int p, po;
+    for (j = 0; j < pnameslumps[i].nummappatches; j++)
+    {
+        int p, po;
 
-	    M_StringCopy(name, pnameslumps[i].name_p + j * 8, sizeof(name));
-	    p = po = W_CheckNumForName(name);
-	    // [crispy] prevent flat lumps from being mistaken as patches
-	    while (p >= firstflat && p <= lastflat)
-	    {
-		p = W_CheckNumForNameFromTo (name, p - 1, 0);
-	    }
-	    // [crispy] if the name is unambiguous, use the lump we found
-	    patchlookup[k++] = (p == -1) ? po : p;
-	}
+        M_StringCopy(name, pnameslumps[i].name_p + j * 8, sizeof(name));
+        p = po = W_CheckNumForName(name);
+        // [crispy] prevent flat lumps from being mistaken as patches
+        while (p >= firstflat && p <= lastflat)
+        {
+        p = W_CheckNumForNameFromTo (name, p - 1, 0);
+        }
+        // [crispy] if the name is unambiguous, use the lump we found
+        patchlookup[k++] = (p == -1) ? po : p;
+    }
     }
 
     // [crispy] calculate total number of textures
     numtextures = 0;
     for (i = 0; i < numtexturelumps; i++)
     {
-	texturelumps[i].maptex = W_CacheLumpNum(texturelumps[i].lumpnum, PU_STATIC);
-	texturelumps[i].maxoff = W_LumpLength(texturelumps[i].lumpnum);
-	texturelumps[i].numtextures = LONG(*texturelumps[i].maptex);
+    texturelumps[i].maptex = W_CacheLumpNum(texturelumps[i].lumpnum, PU_STATIC);
+    texturelumps[i].maxoff = W_LumpLength(texturelumps[i].lumpnum);
+    texturelumps[i].numtextures = LONG(*texturelumps[i].maptex);
 
-	// [crispy] accumulated number of textures in the texture files
-	// including the current one
-	numtextures += texturelumps[i].numtextures;
-	texturelumps[i].sumtextures = numtextures;
+    // [crispy] accumulated number of textures in the texture files
+    // including the current one
+    numtextures += texturelumps[i].numtextures;
+    texturelumps[i].sumtextures = numtextures;
 
-	// [crispy] link textures to their own WAD's patch lookup table (if any)
-	texturelumps[i].pnamesoffset = 0;
-	for (j = 0; j < numpnameslumps; j++)
-	{
-	    // [crispy] both are from the same WAD?
-	    if (lumpinfo[texturelumps[i].lumpnum]->wad_file ==
-	        lumpinfo[pnameslumps[j].lumpnum]->wad_file)
-	    {
-		texturelumps[i].pnamesoffset = pnameslumps[j].summappatches;
-		break;
-	    }
-	}
+    // [crispy] link textures to their own WAD's patch lookup table (if any)
+    texturelumps[i].pnamesoffset = 0;
+    for (j = 0; j < numpnameslumps; j++)
+    {
+        // [crispy] both are from the same WAD?
+        if (lumpinfo[texturelumps[i].lumpnum]->wad_file ==
+            lumpinfo[pnameslumps[j].lumpnum]->wad_file)
+        {
+        texturelumps[i].pnamesoffset = pnameslumps[j].summappatches;
+        break;
+        }
+    }
     }
 
     // [crispy] release memory allocated for patch lookup tables
     for (i = 0; i < numpnameslumps; i++)
     {
-	W_ReleaseLumpNum(pnameslumps[i].lumpnum);
+    W_ReleaseLumpNum(pnameslumps[i].lumpnum);
     }
     free(pnameslumps);
 
@@ -873,7 +873,7 @@ void R_InitTextures (void)
 
     totalwidth = 0;
     
-    //	Really complex printing shit...
+    //  Really complex printing shit...
     temp1 = W_GetNumForName (DEH_String("S_START"));  // P_???????
     temp2 = W_GetNumForName (DEH_String("S_END")) - 1;
     temp3 = ((temp2-temp1+63)/64) + ((numtextures+63)/64);
@@ -899,82 +899,82 @@ void R_InitTextures (void)
 #endif
             printf("\b");
     }
-	
+    
     for (i=0 ; i<numtextures ; i++, directory++)
     {
-	if (!(i&63))
-	    printf (".");
+    if (!(i&63))
+        printf (".");
 
-	// [crispy] initialize for the first texture file lump,
-	// skip through empty texture file lumps which do not contain any texture
-	while (texturelump == texturelumps - 1 || i == texturelump->sumtextures)
-	{
-	    // [crispy] start looking in next texture file
-	    texturelump++;
-	    maptex = texturelump->maptex;
-	    maxoff = texturelump->maxoff;
-	    directory = maptex+1;
-	}
-		
-	offset = LONG(*directory);
+    // [crispy] initialize for the first texture file lump,
+    // skip through empty texture file lumps which do not contain any texture
+    while (texturelump == texturelumps - 1 || i == texturelump->sumtextures)
+    {
+        // [crispy] start looking in next texture file
+        texturelump++;
+        maptex = texturelump->maptex;
+        maxoff = texturelump->maxoff;
+        directory = maptex+1;
+    }
+        
+    offset = LONG(*directory);
 
-	if (offset > maxoff)
-	    I_Error ("R_InitTextures: bad texture directory");
-	
-	mtexture = (maptexture_t *) ( (byte *)maptex + offset);
+    if (offset > maxoff)
+        I_Error ("R_InitTextures: bad texture directory");
+    
+    mtexture = (maptexture_t *) ( (byte *)maptex + offset);
 
-	texture = textures[i] =
-	    Z_Malloc (sizeof(texture_t)
-		      + sizeof(texpatch_t)*(SHORT(mtexture->patchcount)-1),
-		      PU_STATIC, 0);
-	
-	texture->width = SHORT(mtexture->width);
-	texture->height = SHORT(mtexture->height);
-	texture->patchcount = SHORT(mtexture->patchcount);
-	
-	memcpy (texture->name, mtexture->name, sizeof(texture->name));
-	mpatch = &mtexture->patches[0];
-	patch = &texture->patches[0];
+    texture = textures[i] =
+        Z_Malloc (sizeof(texture_t)
+              + sizeof(texpatch_t)*(SHORT(mtexture->patchcount)-1),
+              PU_STATIC, 0);
+    
+    texture->width = SHORT(mtexture->width);
+    texture->height = SHORT(mtexture->height);
+    texture->patchcount = SHORT(mtexture->patchcount);
+    
+    memcpy (texture->name, mtexture->name, sizeof(texture->name));
+    mpatch = &mtexture->patches[0];
+    patch = &texture->patches[0];
 
-	// [crispy] initialize brightmaps
-	texturebrightmap[i] = R_BrightmapForTexName(texture->name);
+    // [crispy] initialize brightmaps
+    texturebrightmap[i] = R_BrightmapForTexName(texture->name);
 
-	for (j=0 ; j<texture->patchcount ; j++, mpatch++, patch++)
-	{
-	    short p;
-	    patch->originx = SHORT(mpatch->originx);
-	    patch->originy = SHORT(mpatch->originy);
-	    // [crispy] apply offset for patches not in the
-	    // first available patch offset table
-	    p = SHORT(mpatch->patch) + texturelump->pnamesoffset;
-	    // [crispy] catch out-of-range patches
-	    if (p < nummappatches)
-		patch->patch = patchlookup[p];
-	    if (patch->patch == -1 || p >= nummappatches)
-	    {
-		char	texturename[9];
-		texturename[8] = '\0';
-		memcpy (texturename, texture->name, 8);
-		// [crispy] make non-fatal
-		fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
-			 texturename);
-		patch->patch = 0;
-	    }
-	}		
-	texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);
-	texturecolumnofs[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs), PU_STATIC,0);
-	texturecolumnofs2[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs2), PU_STATIC,0);
+    for (j=0 ; j<texture->patchcount ; j++, mpatch++, patch++)
+    {
+        short p;
+        patch->originx = SHORT(mpatch->originx);
+        patch->originy = SHORT(mpatch->originy);
+        // [crispy] apply offset for patches not in the
+        // first available patch offset table
+        p = SHORT(mpatch->patch) + texturelump->pnamesoffset;
+        // [crispy] catch out-of-range patches
+        if (p < nummappatches)
+        patch->patch = patchlookup[p];
+        if (patch->patch == -1 || p >= nummappatches)
+        {
+        char    texturename[9];
+        texturename[8] = '\0';
+        memcpy (texturename, texture->name, 8);
+        // [crispy] make non-fatal
+        fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
+             texturename);
+        patch->patch = 0;
+        }
+    }       
+    texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);
+    texturecolumnofs[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs), PU_STATIC,0);
+    texturecolumnofs2[i] = Z_Malloc (texture->width*sizeof(**texturecolumnofs2), PU_STATIC,0);
 
-	j = 1;
-	while (j*2 <= texture->width)
-	    j<<=1;
+    j = 1;
+    while (j*2 <= texture->width)
+        j<<=1;
 
-	texturewidthmask[i] = j-1;
-	textureheight[i] = texture->height<<FRACBITS;
-	// [crispy] texture width for wrapping column getter function
-	texturewidth[i] = texture->width;
-		
-	totalwidth += texture->width;
+    texturewidthmask[i] = j-1;
+    textureheight[i] = texture->height<<FRACBITS;
+    // [crispy] texture width for wrapping column getter function
+    texturewidth[i] = texture->width;
+        
+    totalwidth += texture->width;
     }
 
     Z_Free(patchlookup);
@@ -982,20 +982,20 @@ void R_InitTextures (void)
     // [crispy] release memory allocated for texture files
     for (i = 0; i < numtexturelumps; i++)
     {
-	W_ReleaseLumpNum(texturelumps[i].lumpnum);
+    W_ReleaseLumpNum(texturelumps[i].lumpnum);
     }
     free(texturelumps);
     
-    // Precalculate whatever possible.	
+    // Precalculate whatever possible.  
 
     for (i=0 ; i<numtextures ; i++)
-	R_GenerateLookup (i);
+    R_GenerateLookup (i);
     
     // Create translation table for global animation.
     texturetranslation = Z_Malloc ((numtextures+1)*sizeof(*texturetranslation), PU_STATIC, 0);
     
     for (i=0 ; i<numtextures ; i++)
-	texturetranslation[i] = i;
+    texturetranslation[i] = i;
 
     GenerateTextureHashTable();
 }
@@ -1007,17 +1007,17 @@ void R_InitTextures (void)
 //
 void R_InitFlats (void)
 {
-    int		i;
-	
+    int     i;
+    
     firstflat = W_GetNumForName (DEH_String("F_START")) + 1;
     lastflat = W_GetNumForName (DEH_String("F_END")) - 1;
     numflats = lastflat - firstflat + 1;
-	
+    
     // Create translation table for global animation.
     flattranslation = Z_Malloc ((numflats+1)*sizeof(*flattranslation), PU_STATIC, 0);
     
     for (i=0 ; i<numflats ; i++)
-	flattranslation[i] = i;
+    flattranslation[i] = i;
 }
 
 
@@ -1029,9 +1029,9 @@ void R_InitFlats (void)
 //
 void R_InitSpriteLumps (void)
 {
-    int		i;
-    patch_t	*patch;
-	
+    int     i;
+    patch_t *patch;
+    
     firstspritelump = W_GetNumForName (DEH_String("S_START")) + 1;
     lastspritelump = W_GetNumForName (DEH_String("S_END")) - 1;
     
@@ -1039,16 +1039,16 @@ void R_InitSpriteLumps (void)
     spritewidth = Z_Malloc (numspritelumps*sizeof(*spritewidth), PU_STATIC, 0);
     spriteoffset = Z_Malloc (numspritelumps*sizeof(*spriteoffset), PU_STATIC, 0);
     spritetopoffset = Z_Malloc (numspritelumps*sizeof(*spritetopoffset), PU_STATIC, 0);
-	
+    
     for (i=0 ; i< numspritelumps ; i++)
     {
-	if (!(i&63))
-	    printf (".");
+    if (!(i&63))
+        printf (".");
 
-	patch = W_CacheLumpNum (firstspritelump+i, PU_CACHE);
-	spritewidth[i] = SHORT(patch->width)<<FRACBITS;
-	spriteoffset[i] = SHORT(patch->leftoffset)<<FRACBITS;
-	spritetopoffset[i] = SHORT(patch->topoffset)<<FRACBITS;
+    patch = W_CacheLumpNum (firstspritelump+i, PU_CACHE);
+    spritewidth[i] = SHORT(patch->width)<<FRACBITS;
+    spriteoffset[i] = SHORT(patch->leftoffset)<<FRACBITS;
+    spritetopoffset[i] = SHORT(patch->topoffset)<<FRACBITS;
     }
 }
 
@@ -1069,54 +1069,54 @@ static void R_InitTranMap()
     // If a tranlucency filter map lump is present, use it
     if (lump != -1 && W_LumpLength(lump) == 256*256)
     {
-	// Set a pointer to the translucency filter maps.
-	tranmap = W_CacheLumpNum(lump, PU_STATIC);
-	// [crispy] loaded from a lump
-	printf(":");
+        // Set a pointer to the translucency filter maps.
+        tranmap = W_CacheLumpNum(lump, PU_STATIC);
+        // [crispy] loaded from a lump
+        printf(":");
     }
     else
     {
-	// Compose a default transparent filter map based on PLAYPAL.
-	unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+    // Compose a default transparent filter map based on PLAYPAL.
+    unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
-	tranmap = Z_Malloc(256*256, PU_STATIC, 0);
-	{
-	    byte *fg, *bg, blend[3], *tp = tranmap;
-	    int i, j, btmp;
+    tranmap = Z_Malloc(256*256, PU_STATIC, 0);
+    {
+        byte *fg, *bg, blend[3], *tp = tranmap;
+        int i, j, btmp;
 
-	    // [crispy] background color
-	    for (i = 0; i < 256; i++)
-	    {
-		// [crispy] foreground color
-		for (j = 0; j < 256; j++)
-		{
-		    // [crispy] shortcut: identical foreground and background
-		    if (i == j)
-		    {
-			*tp++ = i;
-			continue;
-		    }
+        // [crispy] background color
+        for (i = 0; i < 256; i++)
+        {
+        // [crispy] foreground color
+        for (j = 0; j < 256; j++)
+        {
+            // [crispy] shortcut: identical foreground and background
+            if (i == j)
+            {
+            *tp++ = i;
+            continue;
+            }
 
-		    bg = playpal + 3*i;
-		    fg = playpal + 3*j;
+            bg = playpal + 3*i;
+            fg = playpal + 3*j;
 
-		    // [crispy] blended color - emphasize blues
-		    // Colour matching in RGB space doesn't work very well with the blues
-		    // in Doom's palette. Rather than do any colour conversions, just
-		    // emphasize the blues when building the translucency table.
-		    btmp = fg[b] * 1.666 < (fg[r] + fg[g]) ? 0 : 50;
-		    blend[r] = (tran_filter_pct * fg[r] + (100 - tran_filter_pct) * bg[r]) / (100 + btmp);
-		    blend[g] = (tran_filter_pct * fg[g] + (100 - tran_filter_pct) * bg[g]) / (100 + btmp);
-		    blend[b] = (tran_filter_pct * fg[b] + (100 - tran_filter_pct) * bg[b]) / 100;
+            // [crispy] blended color - emphasize blues
+            // Colour matching in RGB space doesn't work very well with the blues
+            // in Doom's palette. Rather than do any colour conversions, just
+            // emphasize the blues when building the translucency table.
+            btmp = fg[b] * 1.666 < (fg[r] + fg[g]) ? 0 : 50;
+            blend[r] = (tran_filter_pct * fg[r] + (100 - tran_filter_pct) * bg[r]) / (100 + btmp);
+            blend[g] = (tran_filter_pct * fg[g] + (100 - tran_filter_pct) * bg[g]) / (100 + btmp);
+            blend[b] = (tran_filter_pct * fg[b] + (100 - tran_filter_pct) * bg[b]) / 100;
 
-		    *tp++ = V_GetPaletteIndex(playpal, blend[r], blend[g], blend[b]);
-		}
-	    }
-	}
+            *tp++ = V_GetPaletteIndex(playpal, blend[r], blend[g], blend[b]);
+        }
+        }
+    }
 
-	printf(".");
+    printf(".");
 
-	W_ReleaseLumpName("PLAYPAL");
+    W_ReleaseLumpName("PLAYPAL");
     }
 }
 #endif
@@ -1127,107 +1127,107 @@ static void R_InitTranMap()
 void R_InitColormaps (void)
 {
 #ifndef CRISPY_TRUECOLOR
-    int	lump;
+    int lump;
 
     // Load in the light tables, 
     //  256 byte align tables.
     lump = W_GetNumForName(DEH_String("COLORMAP"));
     colormaps = W_CacheLumpNum(lump, PU_STATIC);
 #else
-	byte *playpal;
-	int c, i, j = 0;
-	byte r, g, b;
-	extern byte **gamma2table;
+    byte *playpal;
+    int c, i, j = 0;
+    byte r, g, b;
+    extern byte **gamma2table;
 
-	// [crispy] intermediate gamma levels
-	if (!gamma2table)
-	{
-		extern void I_SetGammaTable (void);
-		I_SetGammaTable();
-	}
+    // [crispy] intermediate gamma levels
+    if (!gamma2table)
+    {
+        extern void I_SetGammaTable (void);
+        I_SetGammaTable();
+    }
 
-	playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+    playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
-	if (!colormaps)
-	{
-		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
-	}
+    if (!colormaps)
+    {
+        colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
+    }
 
-	if (crispy->truecolor)
-	{
-		for (c = 0; c < NUMCOLORMAPS; c++)
-		{
-			const float scale = 1. * c / NUMCOLORMAPS;
+    if (crispy->truecolor)
+    {
+        for (c = 0; c < NUMCOLORMAPS; c++)
+        {
+            const float scale = 1. * c / NUMCOLORMAPS;
 
-			for (i = 0; i < 256; i++)
-			{
-				r = gamma2table[usegamma][playpal[3 * i + 0]] * (1. - scale) + gamma2table[usegamma][0] * scale;
-				g = gamma2table[usegamma][playpal[3 * i + 1]] * (1. - scale) + gamma2table[usegamma][0] * scale;
-				b = gamma2table[usegamma][playpal[3 * i + 2]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+            for (i = 0; i < 256; i++)
+            {
+                r = gamma2table[usegamma][playpal[3 * i + 0]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+                g = gamma2table[usegamma][playpal[3 * i + 1]] * (1. - scale) + gamma2table[usegamma][0] * scale;
+                b = gamma2table[usegamma][playpal[3 * i + 2]] * (1. - scale) + gamma2table[usegamma][0] * scale;
 
-				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-			}
-		}
+                colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+            }
+        }
 
-		// [crispy] Invulnerability (c == COLORMAPS)
-		for (i = 0; i < 256; i++)
-		{
-			const byte gray = 0xff -
-			     (byte) (0.299 * playpal[3 * i + 0] +
-			             0.587 * playpal[3 * i + 1] +
-			             0.114 * playpal[3 * i + 2]);
-			r = g = b = gamma2table[usegamma][gray];
+        // [crispy] Invulnerability (c == COLORMAPS)
+        for (i = 0; i < 256; i++)
+        {
+            const byte gray = 0xff -
+                 (byte) (0.299 * playpal[3 * i + 0] +
+                         0.587 * playpal[3 * i + 1] +
+                         0.114 * playpal[3 * i + 2]);
+            r = g = b = gamma2table[usegamma][gray];
 
-			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-		}
-	}
-	else
-	{
-		byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
+            colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+        }
+    }
+    else
+    {
+        byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 
-		for (c = 0; c <= NUMCOLORMAPS; c++)
-		{
-			for (i = 0; i < 256; i++)
-			{
-				r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
-				g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
-				b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
+        for (c = 0; c <= NUMCOLORMAPS; c++)
+        {
+            for (i = 0; i < 256; i++)
+            {
+                r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+                g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+                b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
 
-				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-			}
-		}
+                colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+            }
+        }
 
-		W_ReleaseLumpName("COLORMAP");
-	}
+        W_ReleaseLumpName("COLORMAP");
+    }
 #endif
 
     // [crispy] initialize color translation and color strings tables
     {
-	byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-	char c[3];
-	int i, j;
-	boolean keepgray = false;
+    byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+    char c[3];
+    int i, j;
+    boolean keepgray = false;
 
-	if (!crstr)
-	    crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
+    if (!crstr)
+        crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
 
-	// [crispy] check for status bar graphics replacements
-	i = W_CheckNumForName(DEH_String("sttnum0")); // [crispy] Status Bar '0'
-	keepgray = (i >= 0 && W_IsIWADLump(lumpinfo[i]));
+    // [crispy] check for status bar graphics replacements
+    i = W_CheckNumForName(DEH_String("sttnum0")); // [crispy] Status Bar '0'
+    keepgray = (i >= 0 && W_IsIWADLump(lumpinfo[i]));
 
-	// [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
-	for (i = 0; i < CRMAX - 2; i++)
-	{
-	    for (j = 0; j < 256; j++)
-	    {
-		cr[i][j] = V_Colorize(playpal, i, j, keepgray);
-	    }
+    // [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
+    for (i = 0; i < CRMAX - 2; i++)
+    {
+        for (j = 0; j < 256; j++)
+        {
+        cr[i][j] = V_Colorize(playpal, i, j, keepgray);
+        }
 
-	    M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
-	    crstr[i] = M_StringDuplicate(c);
-	}
+        M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
+        crstr[i] = M_StringDuplicate(c);
+    }
 
-	W_ReleaseLumpName("PLAYPAL");
+    W_ReleaseLumpName("PLAYPAL");
     }
 }
 
@@ -1268,20 +1268,20 @@ void R_InitData (void)
 //
 int R_FlatNumForName(const char *name)
 {
-    int		i;
-    char	namet[9];
+    int     i;
+    char    namet[9];
 
     i = W_CheckNumForNameFromTo (name, lastflat, firstflat);
 
     if (i == -1)
     {
-	namet[8] = 0;
-	memcpy (namet, name,8);
-	// [crispy] make non-fatal
-	fprintf (stderr, "R_FlatNumForName: %s not found\n", namet);
-	// [crispy] since there is no "No Flat" marker,
-	// render missing flats as SKY
-	return skyflatnum;
+    namet[8] = 0;
+    memcpy (namet, name,8);
+    // [crispy] make non-fatal
+    fprintf (stderr, "R_FlatNumForName: %s not found\n", namet);
+    // [crispy] since there is no "No Flat" marker,
+    // render missing flats as SKY
+    return skyflatnum;
     }
     return i - firstflat;
 }
@@ -1300,17 +1300,17 @@ int R_CheckTextureNumForName(const char *name)
     int key;
 
     // "NoTexture" marker.
-    if (name[0] == '-')		
-	return 0;
-		
+    if (name[0] == '-')     
+    return 0;
+        
     key = W_LumpNameHash(name) % numtextures;
 
     texture=textures_hashtable[key]; 
     
     while (texture != NULL)
     {
-	if (!strncasecmp (texture->name, name, 8) )
-	    return texture->index;
+    if (!strncasecmp (texture->name, name, 8) )
+        return texture->index;
 
         texture = texture->next;
     }
@@ -1327,20 +1327,20 @@ int R_CheckTextureNumForName(const char *name)
 //
 int R_TextureNumForName(const char *name)
 {
-    int		i;
-	
+    int     i;
+    
     i = R_CheckTextureNumForName (name);
 
     if (i==-1)
     {
-	// [crispy] fix absurd texture name in error message
-	char	namet[9];
-	namet[8] = '\0';
-	memcpy (namet, name, 8);
-	// [crispy] make non-fatal
-	fprintf (stderr, "R_TextureNumForName: %s not found\n",
-		 namet);
-	return 0;
+    // [crispy] fix absurd texture name in error message
+    char    namet[9];
+    namet[8] = '\0';
+    memcpy (namet, name, 8);
+    // [crispy] make non-fatal
+    fprintf (stderr, "R_TextureNumForName: %s not found\n",
+         namet);
+    return 0;
     }
     return i;
 }
@@ -1352,48 +1352,48 @@ int R_TextureNumForName(const char *name)
 // R_PrecacheLevel
 // Preloads all relevant graphics for the level.
 //
-int		flatmemory;
-int		texturememory;
-int		spritememory;
+int     flatmemory;
+int     texturememory;
+int     spritememory;
 
 void R_PrecacheLevel (void)
 {
-    char*		flatpresent;
-    char*		texturepresent;
-    char*		spritepresent;
+    char*       flatpresent;
+    char*       texturepresent;
+    char*       spritepresent;
 
-    int			i;
-    int			j;
-    int			k;
-    int			lump;
+    int         i;
+    int         j;
+    int         k;
+    int         lump;
     
-    texture_t*		texture;
-    thinker_t*		th;
-    spriteframe_t*	sf;
+    texture_t*      texture;
+    thinker_t*      th;
+    spriteframe_t*  sf;
 
     if (demoplayback)
-	return;
+    return;
     
     // Precache flats.
     flatpresent = Z_Malloc(numflats, PU_STATIC, NULL);
-    memset (flatpresent,0,numflats);	
+    memset (flatpresent,0,numflats);    
 
     for (i=0 ; i<numsectors ; i++)
     {
-	flatpresent[sectors[i].floorpic] = 1;
-	flatpresent[sectors[i].ceilingpic] = 1;
+    flatpresent[sectors[i].floorpic] = 1;
+    flatpresent[sectors[i].ceilingpic] = 1;
     }
-	
+    
     flatmemory = 0;
 
     for (i=0 ; i<numflats ; i++)
     {
-	if (flatpresent[i])
-	{
-	    lump = firstflat + i;
-	    flatmemory += lumpinfo[lump]->size;
-	    W_CacheLumpNum(lump, PU_CACHE);
-	}
+    if (flatpresent[i])
+    {
+        lump = firstflat + i;
+        flatmemory += lumpinfo[lump]->size;
+        W_CacheLumpNum(lump, PU_CACHE);
+    }
     }
 
     Z_Free(flatpresent);
@@ -1401,12 +1401,12 @@ void R_PrecacheLevel (void)
     // Precache textures.
     texturepresent = Z_Malloc(numtextures, PU_STATIC, NULL);
     memset (texturepresent,0, numtextures);
-	
+    
     for (i=0 ; i<numsides ; i++)
     {
-	texturepresent[sides[i].toptexture] = 1;
-	texturepresent[sides[i].midtexture] = 1;
-	texturepresent[sides[i].bottomtexture] = 1;
+    texturepresent[sides[i].toptexture] = 1;
+    texturepresent[sides[i].midtexture] = 1;
+    texturepresent[sides[i].bottomtexture] = 1;
     }
 
     // Sky texture is always present.
@@ -1416,24 +1416,24 @@ void R_PrecacheLevel (void)
     //  a wall texture, with an episode dependend
     //  name.
     texturepresent[skytexture] = 1;
-	
+    
     texturememory = 0;
     for (i=0 ; i<numtextures ; i++)
     {
-	if (!texturepresent[i])
-	    continue;
+    if (!texturepresent[i])
+        continue;
 
-	// [crispy] precache composite textures
-	R_GenerateComposite(i);
+    // [crispy] precache composite textures
+    R_GenerateComposite(i);
 
-	texture = textures[i];
-	
-	for (j=0 ; j<texture->patchcount ; j++)
-	{
-	    lump = texture->patches[j].patch;
-	    texturememory += lumpinfo[lump]->size;
-	    W_CacheLumpNum(lump , PU_CACHE);
-	}
+    texture = textures[i];
+    
+    for (j=0 ; j<texture->patchcount ; j++)
+    {
+        lump = texture->patches[j].patch;
+        texturememory += lumpinfo[lump]->size;
+        W_CacheLumpNum(lump , PU_CACHE);
+    }
     }
 
     Z_Free(texturepresent);
@@ -1441,29 +1441,29 @@ void R_PrecacheLevel (void)
     // Precache sprites.
     spritepresent = Z_Malloc(numsprites, PU_STATIC, NULL);
     memset (spritepresent,0, numsprites);
-	
+    
     for (th = thinkercap.next ; th != &thinkercap ; th=th->next)
     {
-	if (th->function.acp1 == (actionf_p1)P_MobjThinker)
-	    spritepresent[((mobj_t *)th)->sprite] = 1;
+    if (th->function.acp1 == (actionf_p1)P_MobjThinker)
+        spritepresent[((mobj_t *)th)->sprite] = 1;
     }
-	
+    
     spritememory = 0;
     for (i=0 ; i<numsprites ; i++)
     {
-	if (!spritepresent[i])
-	    continue;
+    if (!spritepresent[i])
+        continue;
 
-	for (j=0 ; j<sprites[i].numframes ; j++)
-	{
-	    sf = &sprites[i].spriteframes[j];
-	    for (k=0 ; k<8 ; k++)
-	    {
-		lump = firstspritelump + sf->lump[k];
-		spritememory += lumpinfo[lump]->size;
-		W_CacheLumpNum(lump , PU_CACHE);
-	    }
-	}
+    for (j=0 ; j<sprites[i].numframes ; j++)
+    {
+        sf = &sprites[i].spriteframes[j];
+        for (k=0 ; k<8 ; k++)
+        {
+        lump = firstspritelump + sf->lump[k];
+        spritememory += lumpinfo[lump]->size;
+        W_CacheLumpNum(lump , PU_CACHE);
+        }
+    }
     }
 
     Z_Free(spritepresent);


### PR DESCRIPTION
This restores the old behavior of using a TRANMAP if one is present in a loaded wad.

As a use case, the dehacked mod I'm working on includes a table made with additive blending, and the effects/missiles are designed with this in mind. I've also made an additive table for my Doom autoloads, it looks quite nice:
<img src="https://i.imgur.com/urelX2L.png" />

It also seemed like a good idea to validate the table's size, since this is effectively a modding-specific feature. Please let me know if you don't find it necessary.