### PR TITLE
Customizable Crispness menu background.

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1395,7 +1395,7 @@ static void M_DrawCrispnessBackground(void)
     const byte *src = crispness_background;
     // [NS] Try to load the background from a lump.
     int lump = W_CheckNumForName("CRISPYBG");
-    if (lump != -1 && W_LumpLength(lump) == 64*64)
+    if (lump != -1 && W_LumpLength(lump) >= 64*64)
     {
         src = W_CacheLumpNum(lump, PU_STATIC);
     }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1392,7 +1392,13 @@ static void M_DrawMouse(void)
 #include "m_background.h"
 static void M_DrawCrispnessBackground(void)
 {
-	const byte *const src = crispness_background;
+    const byte *src = crispness_background;
+    // [NS] Try to load the background from a lump.
+    int lump = W_CheckNumForName("CRISPYBG");
+    if (lump != -1 && W_LumpLength(lump) == 64*64)
+    {
+        src = W_CacheLumpNum(lump, PU_STATIC);
+    }
 	pixel_t *dest;
 	int x, y;
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1392,7 +1392,7 @@ static void M_DrawMouse(void)
 #include "m_background.h"
 static void M_DrawCrispnessBackground(void)
 {
-    const byte *src = crispness_background;
+	const byte *src = crispness_background;
     // [NS] Try to load the background from a lump.
     int lump = W_CheckNumForName("CRISPYBG");
     if (lump != -1 && W_LumpLength(lump) >= 64*64)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1393,15 +1393,15 @@ static void M_DrawMouse(void)
 static void M_DrawCrispnessBackground(void)
 {
 	const byte *src = crispness_background;
-    // [NS] Try to load the background from a lump.
-    int lump = W_CheckNumForName("CRISPYBG");
-    if (lump != -1 && W_LumpLength(lump) >= 64*64)
-    {
-        src = W_CacheLumpNum(lump, PU_STATIC);
-    }
 	pixel_t *dest;
 	int x, y;
 
+	// [NS] Try to load the background from a lump.
+	int lump = W_CheckNumForName("CRISPYBG");
+	if (lump != -1 && W_LumpLength(lump) >= 64*64)
+	{
+		src = W_CacheLumpNum(lump, PU_STATIC);
+	}
 	dest = I_VideoBuffer;
 
 	for (y = 0; y < SCREENHEIGHT; y++)


### PR DESCRIPTION
Palette changes can make the Crispness menu background look quite strange. E.G. Back to Saturn X, which replaces several of the browns with new shades:
<img src="https://i.imgur.com/e7gVJgw.png" />
A palette-correct version can be provided by a PWAD autoload to cover these cases, or mods with changed palettes can include the replacement themselves. Any 64x64 flat will do:
<img src="https://i.imgur.com/Dcq1ajW.png" />
(>64 row flats like Heretic/Hexen use should also be fine, we only care about the first 64.)