### PR TITLE
Allow the beta bonus items to be picked up.

### DIFF
--- a/src/doom/d_englsh.h
+++ b/src/doom/d_englsh.h
@@ -121,6 +121,10 @@
 #define GOTSHOTGUN	"You got the shotgun!"
 #define GOTSHOTGUN2	"You got the super shotgun!"
 
+// [NS] Beta pickups.
+#define BETA_BONUS3	"Picked up an evil sceptre."
+#define BETA_BONUS4	"Picked up an unholy bible."
+
 //
 // P_Doors.C
 //

--- a/src/doom/deh_bexstr.c
+++ b/src/doom/deh_bexstr.c
@@ -97,6 +97,9 @@ static const bex_string_t bex_stringtable[] = {
     {"GOTPLASMA", GOTPLASMA},
     {"GOTSHOTGUN", GOTSHOTGUN},
     {"GOTSHOTGUN2", GOTSHOTGUN2},
+    // [NS] Beta pickups.
+    {"BETA_BONUS3", BETA_BONUS3},
+    {"BETA_BONUS4", BETA_BONUS4},
     // part 3 - messages when keys are needed
     {"PD_BLUEO", PD_BLUEO},
     {"PD_REDO", PD_REDO},

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -692,6 +692,15 @@ P_TouchSpecialThing
 	sound = sfx_wpnup;	
 	break;
 		
+	// [NS] Beta pickups.
+      case SPR_BON3:
+	player->message = DEH_String(BETA_BONUS3);
+	break;
+
+      case SPR_BON4:
+	player->message = DEH_String(BETA_BONUS4);
+	break;
+
       default:
 	I_Error ("P_SpecialThing: Unknown gettable thing");
     }


### PR DESCRIPTION
This simply makes the beta scepter & bible (from MBF extensions) gettable without a P_SpecialThing error. The items themselves do nothing (although they already have COUNTITEM so they can work as extra collectibles). Obviously if there are no sprites for them they'll still error out on spawn.

Pickup messages are provided based on ZDoom's keynames (though the text uses release DOOM grammar). They can be replaced through BEX.