### PR TITLE
Add some (optional) extra sounds.

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -438,7 +438,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             crstr[CR_GREEN],
             (joybspeed >= MAX_JOY_BUTTONS) ? "ON" : "OFF");
         player->message = playermessage;
-        S_StartSound(NULL, sfx_swtchn);
+        S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 
         gamekeydown[key_toggleautorun] = false;
     }
@@ -453,7 +453,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             crstr[CR_GREEN],
             !novert ? "ON" : "OFF");
         player->message = playermessage;
-        S_StartSound(NULL, sfx_swtchn);
+        S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 
         gamekeydown[key_togglenovert] = false;
     }
@@ -999,7 +999,7 @@ boolean G_Responder (event_t* ev)
 	    M_StartControlPanel (); 
 	    // [crispy] play a sound if the menu is activated with a different key than ESC
 	    if (crispy->soundfix)
-		S_StartSound(NULL,sfx_swtchn);
+		S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true; 
 	} 
 	return false; 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1045,10 +1045,7 @@ void M_QuickSaveResponse(int key)
     if (key == key_menu_confirm)
     {
 	M_DoSave(quickSaveSlot);
-	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchx);
-	}
+	S_StartSoundOptional(NULL, sfx_mnucls, sfx_swtchx); // [NS] Optional menu sounds.
     }
 }
 
@@ -1056,10 +1053,7 @@ void M_QuickSave(void)
 {
     if (!usergame)
     {
-	if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_oof);
-	}
+	S_StartSoundOptional(NULL, sfx_mnuerr, sfx_oof); // [NS] Optional menu sounds.
 	return;
     }
 
@@ -1089,10 +1083,7 @@ void M_QuickLoadResponse(int key)
     if (key == key_menu_confirm)
     {
 	M_LoadSelect(quickSaveSlot);
-	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchx);
-	}
+	S_StartSoundOptional(NULL, sfx_mnucls, sfx_swtchx); // [NS] Optional menu sounds.
     }
 }
 
@@ -1666,10 +1657,7 @@ void M_EndGame(int choice)
     choice = 0;
     if (!usergame)
     {
-	if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_oof);
-	}
+	S_StartSoundOptional(NULL, sfx_mnuerr, sfx_oof); // [NS] Optional menu sounds.
 	return;
     }
 	
@@ -2244,10 +2232,7 @@ boolean M_Responder (event_t* ev)
         }
         else
         {
-            if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-            {
-            S_StartSound(NULL,sfx_swtchn);
-            }
+            S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
             M_QuitDOOM(0);
         }
 
@@ -2503,10 +2488,7 @@ boolean M_Responder (event_t* ev)
 	menuactive = false;
 	}
 	messageToPrint = 0; // [crispy] moved here
-	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchx);
-	}
+	S_StartSoundOptional(NULL, sfx_mnucls, sfx_swtchx); // [NS] Optional menu sounds.
 	return true;
     }
 
@@ -2531,10 +2513,7 @@ boolean M_Responder (event_t* ev)
 	    if (automapactive || chat_on)
 		return false;
 	    M_SizeDisplay(0);
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_stnmov);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    return true;
 	}
         else if (key == key_menu_incscreen) // Screen size up
@@ -2542,10 +2521,7 @@ boolean M_Responder (event_t* ev)
 	    if (automapactive || chat_on)
 		return false;
 	    M_SizeDisplay(1);
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_stnmov);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    return true;
 	}
         else if (key == key_menu_help)     // Help key
@@ -2558,29 +2534,20 @@ boolean M_Responder (event_t* ev)
 	      currentMenu = &ReadDef1;
 
 	    itemOn = 0;
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}
         else if (key == key_menu_save)     // Save
         {
 	    M_StartControlPanel();
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_SaveGame(0);
 	    return true;
         }
         else if (key == key_menu_load)     // Load
         {
 	    M_StartControlPanel();
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_LoadGame(0);
 	    return true;
         }
@@ -2589,63 +2556,42 @@ boolean M_Responder (event_t* ev)
 	    M_StartControlPanel ();
 	    currentMenu = &SoundDef;
 	    itemOn = sfx_vol;
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}
         else if (key == key_menu_detail)   // Detail toggle
         {
 	    M_ChangeDetail(0);
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
         }
         else if (key == key_menu_qsave)    // Quicksave
         {
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_QuickSave();
 	    return true;
         }
         else if (key == key_menu_endgame)  // End game
         {
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_EndGame(0);
 	    return true;
         }
         else if (key == key_menu_messages) // Toggle messages
         {
 	    M_ChangeMessages(0);
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
         }
         else if (key == key_menu_qload)    // Quickload
         {
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_QuickLoad();
 	    return true;
         }
         else if (key == key_menu_quit)     // Quit DOOM
         {
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    M_QuitDOOM(0);
 	    return true;
         }
@@ -2690,10 +2636,7 @@ boolean M_Responder (event_t* ev)
 	if (key == key_menu_activate)
 	{
 	    M_StartControlPanel ();
-	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}
 	return false;
@@ -2710,10 +2653,7 @@ boolean M_Responder (event_t* ev)
 	    if (itemOn+1 > currentMenu->numitems-1)
 		itemOn = 0;
 	    else itemOn++;
-	    if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_pstop);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnumov, sfx_pstop); // [NS] Optional menu sounds.
 	} while(currentMenu->menuitems[itemOn].status==-1);
 
 	return true;
@@ -2727,10 +2667,7 @@ boolean M_Responder (event_t* ev)
 	    if (!itemOn)
 		itemOn = currentMenu->numitems-1;
 	    else itemOn--;
-	    if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_pstop);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnumov, sfx_pstop); // [NS] Optional menu sounds.
 	} while(currentMenu->menuitems[itemOn].status==-1);
 
 	return true;
@@ -2742,10 +2679,7 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu->menuitems[itemOn].routine &&
 	    currentMenu->menuitems[itemOn].status == 2)
 	{
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_stnmov);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    currentMenu->menuitems[itemOn].routine(0);
 	}
 	return true;
@@ -2757,10 +2691,7 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu->menuitems[itemOn].routine &&
 	    currentMenu->menuitems[itemOn].status == 2)
 	{
-	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_stnmov);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    currentMenu->menuitems[itemOn].routine(1);
 	}
 	return true;
@@ -2776,18 +2707,12 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[itemOn].status == 2)
 	    {
 		currentMenu->menuitems[itemOn].routine(1);      // right arrow
-		if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
-		{
-		S_StartSound(NULL,sfx_stnmov);
-		}
+		S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    }
 	    else
 	    {
 		currentMenu->menuitems[itemOn].routine(itemOn);
-		if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
-		{
-		S_StartSound(NULL,sfx_pistol);
-		}
+		S_StartSoundOptional(NULL, sfx_mnuact, sfx_pistol); // [NS] Optional menu sounds.
 	    }
 	}
 	return true;
@@ -2798,10 +2723,7 @@ boolean M_Responder (event_t* ev)
 
 	currentMenu->lastOn = itemOn;
 	M_ClearMenus ();
-	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchx);
-	}
+	S_StartSoundOptional(NULL, sfx_mnucls, sfx_swtchx); // [NS] Optional menu sounds.
 	return true;
     }
     else if (key == key_menu_back)
@@ -2813,10 +2735,7 @@ boolean M_Responder (event_t* ev)
 	{
 	    currentMenu = currentMenu->prevMenu;
 	    itemOn = currentMenu->lastOn;
-	    if (!S_StartSoundOptional(NULL, sfx_mnubak)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnubak, sfx_swtchn); // [NS] Optional menu sounds.
 	}
 	return true;
     }
@@ -2833,10 +2752,7 @@ boolean M_Responder (event_t* ev)
 	    }
 	    else
 	    {
-		if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
-		{
-		S_StartSound(NULL,sfx_oof);
-		}
+		S_StartSoundOptional(NULL, sfx_mnuerr, sfx_oof); // [NS] Optional menu sounds.
 	    }
 	}
     }
@@ -2847,10 +2763,7 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu == CrispnessMenus[crispness_cur])
 	{
 	    M_CrispnessPrev(0);
-	    if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuact, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}
     }
@@ -2860,10 +2773,7 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu == CrispnessMenus[crispness_cur])
 	{
 	    M_CrispnessNext(0);
-	    if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
-	    {
-	    S_StartSound(NULL,sfx_swtchn);
-	    }
+	    S_StartSoundOptional(NULL, sfx_mnuact, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}
     }
@@ -2879,10 +2789,7 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[i].alphaKey == ch)
 	    {
 		itemOn = i;
-		if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
-		{
-		S_StartSound(NULL,sfx_pstop);
-		}
+		S_StartSoundOptional(NULL, sfx_mnumov, sfx_pstop); // [NS] Optional menu sounds.
 		return true;
 	    }
         }
@@ -2892,10 +2799,7 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[i].alphaKey == ch)
 	    {
 		itemOn = i;
-		if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
-		{
-		S_StartSound(NULL,sfx_pstop);
-		}
+		S_StartSoundOptional(NULL, sfx_mnumov, sfx_pstop); // [NS] Optional menu sounds.
 		return true;
 	    }
         }
@@ -3366,10 +3270,7 @@ void M_ForceLoadGame()
 
 	M_StartMessage(savegwarning, M_ForceLoadGameResponse, savemaplumpinfo != NULL);
 	messageToPrint = 2;
-	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchn);
-	}
+	S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 }
 
 static void M_ConfirmDeleteGameResponse (int key)
@@ -3396,10 +3297,7 @@ void M_ConfirmDeleteGame ()
 
 	M_StartMessage(savegwarning, M_ConfirmDeleteGameResponse, true);
 	messageToPrint = 2;
-	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchn);
-	}
+	S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 }
 
 // [crispy] indicate game version mismatch
@@ -3407,8 +3305,5 @@ void M_LoadGameVerMismatch ()
 {
 	M_StartMessage("Game Version Mismatch\n\n"PRESSKEY, NULL, false);
 	messageToPrint = 2;
-	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
-	{
-	S_StartSound(NULL,sfx_swtchn);
-	}
+	S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1045,7 +1045,10 @@ void M_QuickSaveResponse(int key)
     if (key == key_menu_confirm)
     {
 	M_DoSave(quickSaveSlot);
+	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchx);
+	}
     }
 }
 
@@ -1053,7 +1056,10 @@ void M_QuickSave(void)
 {
     if (!usergame)
     {
+	if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_oof);
+	}
 	return;
     }
 
@@ -1083,7 +1089,10 @@ void M_QuickLoadResponse(int key)
     if (key == key_menu_confirm)
     {
 	M_LoadSelect(quickSaveSlot);
+	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchx);
+	}
     }
 }
 
@@ -1657,7 +1666,10 @@ void M_EndGame(int choice)
     choice = 0;
     if (!usergame)
     {
+	if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_oof);
+	}
 	return;
     }
 	
@@ -2232,7 +2244,10 @@ boolean M_Responder (event_t* ev)
         }
         else
         {
+            if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+            {
             S_StartSound(NULL,sfx_swtchn);
+            }
             M_QuitDOOM(0);
         }
 
@@ -2488,7 +2503,10 @@ boolean M_Responder (event_t* ev)
 	menuactive = false;
 	}
 	messageToPrint = 0; // [crispy] moved here
+	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchx);
+	}
 	return true;
     }
 
@@ -2513,7 +2531,10 @@ boolean M_Responder (event_t* ev)
 	    if (automapactive || chat_on)
 		return false;
 	    M_SizeDisplay(0);
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_stnmov);
+	    }
 	    return true;
 	}
         else if (key == key_menu_incscreen) // Screen size up
@@ -2521,7 +2542,10 @@ boolean M_Responder (event_t* ev)
 	    if (automapactive || chat_on)
 		return false;
 	    M_SizeDisplay(1);
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_stnmov);
+	    }
 	    return true;
 	}
         else if (key == key_menu_help)     // Help key
@@ -2534,20 +2558,29 @@ boolean M_Responder (event_t* ev)
 	      currentMenu = &ReadDef1;
 
 	    itemOn = 0;
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
 	}
         else if (key == key_menu_save)     // Save
         {
 	    M_StartControlPanel();
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_SaveGame(0);
 	    return true;
         }
         else if (key == key_menu_load)     // Load
         {
 	    M_StartControlPanel();
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_LoadGame(0);
 	    return true;
         }
@@ -2556,42 +2589,63 @@ boolean M_Responder (event_t* ev)
 	    M_StartControlPanel ();
 	    currentMenu = &SoundDef;
 	    itemOn = sfx_vol;
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
 	}
         else if (key == key_menu_detail)   // Detail toggle
         {
 	    M_ChangeDetail(0);
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
         }
         else if (key == key_menu_qsave)    // Quicksave
         {
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_QuickSave();
 	    return true;
         }
         else if (key == key_menu_endgame)  // End game
         {
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_EndGame(0);
 	    return true;
         }
         else if (key == key_menu_messages) // Toggle messages
         {
 	    M_ChangeMessages(0);
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
         }
         else if (key == key_menu_qload)    // Quickload
         {
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_QuickLoad();
 	    return true;
         }
         else if (key == key_menu_quit)     // Quit DOOM
         {
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    M_QuitDOOM(0);
 	    return true;
         }
@@ -2636,7 +2690,10 @@ boolean M_Responder (event_t* ev)
 	if (key == key_menu_activate)
 	{
 	    M_StartControlPanel ();
+	    if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
 	}
 	return false;
@@ -2653,7 +2710,10 @@ boolean M_Responder (event_t* ev)
 	    if (itemOn+1 > currentMenu->numitems-1)
 		itemOn = 0;
 	    else itemOn++;
+	    if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_pstop);
+	    }
 	} while(currentMenu->menuitems[itemOn].status==-1);
 
 	return true;
@@ -2667,7 +2727,10 @@ boolean M_Responder (event_t* ev)
 	    if (!itemOn)
 		itemOn = currentMenu->numitems-1;
 	    else itemOn--;
+	    if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_pstop);
+	    }
 	} while(currentMenu->menuitems[itemOn].status==-1);
 
 	return true;
@@ -2679,7 +2742,10 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu->menuitems[itemOn].routine &&
 	    currentMenu->menuitems[itemOn].status == 2)
 	{
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_stnmov);
+	    }
 	    currentMenu->menuitems[itemOn].routine(0);
 	}
 	return true;
@@ -2691,7 +2757,10 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu->menuitems[itemOn].routine &&
 	    currentMenu->menuitems[itemOn].status == 2)
 	{
+	    if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_stnmov);
+	    }
 	    currentMenu->menuitems[itemOn].routine(1);
 	}
 	return true;
@@ -2707,12 +2776,18 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[itemOn].status == 2)
 	    {
 		currentMenu->menuitems[itemOn].routine(1);      // right arrow
+		if (!S_StartSoundOptional(NULL, sfx_mnusli)) // [NS] Optional menu sounds.
+		{
 		S_StartSound(NULL,sfx_stnmov);
+		}
 	    }
 	    else
 	    {
 		currentMenu->menuitems[itemOn].routine(itemOn);
+		if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
+		{
 		S_StartSound(NULL,sfx_pistol);
+		}
 	    }
 	}
 	return true;
@@ -2723,7 +2798,10 @@ boolean M_Responder (event_t* ev)
 
 	currentMenu->lastOn = itemOn;
 	M_ClearMenus ();
+	if (!S_StartSoundOptional(NULL, sfx_mnucls)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchx);
+	}
 	return true;
     }
     else if (key == key_menu_back)
@@ -2735,7 +2813,10 @@ boolean M_Responder (event_t* ev)
 	{
 	    currentMenu = currentMenu->prevMenu;
 	    itemOn = currentMenu->lastOn;
+	    if (!S_StartSoundOptional(NULL, sfx_mnubak)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	}
 	return true;
     }
@@ -2752,7 +2833,10 @@ boolean M_Responder (event_t* ev)
 	    }
 	    else
 	    {
+		if (!S_StartSoundOptional(NULL, sfx_mnuerr)) // [NS] Optional menu sounds.
+		{
 		S_StartSound(NULL,sfx_oof);
+		}
 	    }
 	}
     }
@@ -2763,7 +2847,10 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu == CrispnessMenus[crispness_cur])
 	{
 	    M_CrispnessPrev(0);
+	    if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
 	}
     }
@@ -2773,7 +2860,10 @@ boolean M_Responder (event_t* ev)
 	if (currentMenu == CrispnessMenus[crispness_cur])
 	{
 	    M_CrispnessNext(0);
+	    if (!S_StartSoundOptional(NULL, sfx_mnuact)) // [NS] Optional menu sounds.
+	    {
 	    S_StartSound(NULL,sfx_swtchn);
+	    }
 	    return true;
 	}
     }
@@ -2789,7 +2879,10 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[i].alphaKey == ch)
 	    {
 		itemOn = i;
+		if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
+		{
 		S_StartSound(NULL,sfx_pstop);
+		}
 		return true;
 	    }
         }
@@ -2799,7 +2892,10 @@ boolean M_Responder (event_t* ev)
 	    if (currentMenu->menuitems[i].alphaKey == ch)
 	    {
 		itemOn = i;
+		if (!S_StartSoundOptional(NULL, sfx_mnumov)) // [NS] Optional menu sounds.
+		{
 		S_StartSound(NULL,sfx_pstop);
+		}
 		return true;
 	    }
         }
@@ -3270,7 +3366,10 @@ void M_ForceLoadGame()
 
 	M_StartMessage(savegwarning, M_ForceLoadGameResponse, savemaplumpinfo != NULL);
 	messageToPrint = 2;
+	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchn);
+	}
 }
 
 static void M_ConfirmDeleteGameResponse (int key)
@@ -3297,7 +3396,10 @@ void M_ConfirmDeleteGame ()
 
 	M_StartMessage(savegwarning, M_ConfirmDeleteGameResponse, true);
 	messageToPrint = 2;
+	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchn);
+	}
 }
 
 // [crispy] indicate game version mismatch
@@ -3305,5 +3407,8 @@ void M_LoadGameVerMismatch ()
 {
 	M_StartMessage("Game Version Mismatch\n\n"PRESSKEY, NULL, false);
 	messageToPrint = 2;
+	if (!S_StartSoundOptional(NULL, sfx_mnuopn)) // [NS] Optional menu sounds.
+	{
 	S_StartSound(NULL,sfx_swtchn);
+	}
 }

--- a/src/doom/p_doors.c
+++ b/src/doom/p_doors.c
@@ -223,7 +223,11 @@ EV_DoLockedDoor
 	if (!p->cards[it_bluecard] && !p->cards[it_blueskull])
 	{
 	    p->message = DEH_String(PD_BLUEO);
+	    // [NS] Locked door sound.
+	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_bluecard] = KEYBLINKTICS;
 	    return 0;
@@ -235,7 +239,10 @@ EV_DoLockedDoor
 	if (!p->cards[it_redcard] && !p->cards[it_redskull])
 	{
 	    p->message = DEH_String(PD_REDO);
+	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_redcard] = KEYBLINKTICS;
 	    return 0;
@@ -248,7 +255,10 @@ EV_DoLockedDoor
 	    !p->cards[it_yellowskull])
 	{
 	    p->message = DEH_String(PD_YELLOWO);
+	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_yellowcard] = KEYBLINKTICS;
 	    return 0;
@@ -376,7 +386,10 @@ EV_VerticalDoor
 	if (!player->cards[it_bluecard] && !player->cards[it_blueskull])
 	{
 	    player->message = DEH_String(PD_BLUEK);
+	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_bluecard] = KEYBLINKTICS;
 	    return;
@@ -392,7 +405,10 @@ EV_VerticalDoor
 	    !player->cards[it_yellowskull])
 	{
 	    player->message = DEH_String(PD_YELLOWK);
+	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_yellowcard] = KEYBLINKTICS;
 	    return;
@@ -407,7 +423,10 @@ EV_VerticalDoor
 	if (!player->cards[it_redcard] && !player->cards[it_redskull])
 	{
 	    player->message = DEH_String(PD_REDK);
+	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
+	    {
 	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
+	    }
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_redcard] = KEYBLINKTICS;
 	    return;

--- a/src/doom/p_doors.c
+++ b/src/doom/p_doors.c
@@ -224,10 +224,7 @@ EV_DoLockedDoor
 	{
 	    p->message = DEH_String(PD_BLUEO);
 	    // [NS] Locked door sound.
-	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
-	    }
+	    S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_bluecard] = KEYBLINKTICS;
 	    return 0;
@@ -239,10 +236,8 @@ EV_DoLockedDoor
 	if (!p->cards[it_redcard] && !p->cards[it_redskull])
 	{
 	    p->message = DEH_String(PD_REDO);
-	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
-	    }
+	    // [NS] Locked door sound.
+	    S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_redcard] = KEYBLINKTICS;
 	    return 0;
@@ -255,10 +250,8 @@ EV_DoLockedDoor
 	    !p->cards[it_yellowskull])
 	{
 	    p->message = DEH_String(PD_YELLOWO);
-	    if (!S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? p->mo : NULL,sfx_oof);
-	    }
+	    // [NS] Locked door sound.
+	    S_StartSoundOptional(crispy->soundfix ? p->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    p->tryopen[it_yellowcard] = KEYBLINKTICS;
 	    return 0;
@@ -386,10 +379,8 @@ EV_VerticalDoor
 	if (!player->cards[it_bluecard] && !player->cards[it_blueskull])
 	{
 	    player->message = DEH_String(PD_BLUEK);
-	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
-	    }
+	    // [NS] Locked door sound.
+	    S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_bluecard] = KEYBLINKTICS;
 	    return;
@@ -405,10 +396,8 @@ EV_VerticalDoor
 	    !player->cards[it_yellowskull])
 	{
 	    player->message = DEH_String(PD_YELLOWK);
-	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
-	    }
+	    // [NS] Locked door sound.
+	    S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_yellowcard] = KEYBLINKTICS;
 	    return;
@@ -423,10 +412,8 @@ EV_VerticalDoor
 	if (!player->cards[it_redcard] && !player->cards[it_redskull])
 	{
 	    player->message = DEH_String(PD_REDK);
-	    if (!S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked))
-	    {
-	    S_StartSound(crispy->soundfix ? player->mo : NULL,sfx_oof);
-	    }
+	    // [NS] Locked door sound.
+	    S_StartSoundOptional(crispy->soundfix ? player->mo : NULL, sfx_locked, sfx_oof);
 	    // [crispy] blinking key or skull in the status bar
 	    player->tryopen[it_redcard] = KEYBLINKTICS;
 	    return;

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -450,7 +450,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_bluecard])
 	    player->message = DEH_String(GOTBLUECARD);
 	P_GiveCard (player, it_bluecard);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -459,7 +459,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_yellowcard])
 	    player->message = DEH_String(GOTYELWCARD);
 	P_GiveCard (player, it_yellowcard);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -468,7 +468,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_redcard])
 	    player->message = DEH_String(GOTREDCARD);
 	P_GiveCard (player, it_redcard);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -477,7 +477,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_blueskull])
 	    player->message = DEH_String(GOTBLUESKUL);
 	P_GiveCard (player, it_blueskull);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -486,7 +486,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_yellowskull])
 	    player->message = DEH_String(GOTYELWSKUL);
 	P_GiveCard (player, it_yellowskull);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -495,7 +495,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_redskull])
 	    player->message = DEH_String(GOTREDSKULL);
 	P_GiveCard (player, it_redskull);
-	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
+	sound = sfx_keyup; // [NS] Optional key pickup sound.
 	if (!netgame)
 	    break;
 	return;
@@ -716,7 +716,7 @@ P_TouchSpecialThing
     P_RemoveMobj (special);
     player->bonuscount += BONUSADD;
     if (player == &players[consoleplayer])
-	S_StartSound (NULL, sound);
+	S_StartSoundOptional (NULL, sound, sfx_itemup); // [NS] Fallback to itemup.
 }
 
 

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -450,6 +450,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_bluecard])
 	    player->message = DEH_String(GOTBLUECARD);
 	P_GiveCard (player, it_bluecard);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;
@@ -458,6 +459,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_yellowcard])
 	    player->message = DEH_String(GOTYELWCARD);
 	P_GiveCard (player, it_yellowcard);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;
@@ -466,6 +468,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_redcard])
 	    player->message = DEH_String(GOTREDCARD);
 	P_GiveCard (player, it_redcard);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;
@@ -474,6 +477,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_blueskull])
 	    player->message = DEH_String(GOTBLUESKUL);
 	P_GiveCard (player, it_blueskull);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;
@@ -482,6 +486,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_yellowskull])
 	    player->message = DEH_String(GOTYELWSKUL);
 	P_GiveCard (player, it_yellowskull);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;
@@ -490,6 +495,7 @@ P_TouchSpecialThing
 	if (!player->cards[it_redskull])
 	    player->message = DEH_String(GOTREDSKULL);
 	P_GiveCard (player, it_redskull);
+	sound = S_CheckSoundId(sfx_keyup) ? sfx_keyup : sound;
 	if (!netgame)
 	    break;
 	return;

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -392,6 +392,11 @@ void P_ZMovement (mobj_t* mo)
 		if (mo->health > 0 || !crispy->soundfix)
 		{
 		S_StartSound (mo, sfx_oof);
+		    // [NS] Landing sound for longer falls. (Hexen's calculation.)
+		    if (mo->momz < -GRAVITY * 12)
+		    {
+		        S_StartSoundOptional(mo, sfx_plland);
+		    }
 		}
 	    }
 	    mo->momz = 0;

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -395,7 +395,7 @@ void P_ZMovement (mobj_t* mo)
 		    // [NS] Landing sound for longer falls. (Hexen's calculation.)
 		    if (mo->momz < -GRAVITY * 12)
 		    {
-		        S_StartSoundOptional(mo, sfx_plland);
+		        S_StartSoundOptional(mo, sfx_plland, -1);
 		    }
 		}
 	    }

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -382,7 +382,7 @@ void P_PlayerThink (player_t* player)
             player->mo->momz = (7 + crispy->jump) * FRACUNIT;
             player->jumpTics = 18;
             // [NS] Jump sound.
-            S_StartSoundOptional(player->mo, sfx_pljump);
+            S_StartSoundOptional(player->mo, sfx_pljump, -1);
         }
     }
 

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -30,6 +30,8 @@
 #include "doomstat.h"
 #include "a11y.h" // [crispy] A11Y
 
+#include "s_sound.h" // [NS] Jump sound etc.
+
 
 
 // Index of the special effects (INVUL inverse) map.
@@ -379,6 +381,8 @@ void P_PlayerThink (player_t* player)
             // [crispy] Hexen sets 9; Strife adds 8
             player->mo->momz = (7 + crispy->jump) * FRACUNIT;
             player->jumpTics = 18;
+            // [NS] Jump sound.
+            S_StartSoundOptional(player->mo, sfx_pljump);
         }
     }
 

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -33,7 +33,6 @@
 #include "s_sound.h" // [NS] Jump sound etc.
 
 
-
 // Index of the special effects (INVUL inverse) map.
 #define INVERSECOLORMAP		32
 

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -773,6 +773,21 @@ void S_StartSoundOnce (void *origin_p, int sfx_id)
     S_StartSound(origin_p, sfx_id);
 }
 
+// [NS] Check if a sound ID has a valid lump.
+boolean S_CheckSoundId(int sfx_id)
+{
+    return I_GetSfxLumpNum(&S_sfx[sfx_id]) != -1;
+}
+
+// [NS] Start a sound only if its lump exists.
+void S_StartSoundOptional(void *origin_p, int sfx_id)
+{
+    if (S_CheckSoundId(sfx_id))
+    {
+        S_StartSound(origin_p, sfx_id);
+    }
+}
+
 //
 // Stop and resume music, during game PAUSE.
 //

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -773,21 +773,17 @@ void S_StartSoundOnce (void *origin_p, int sfx_id)
     S_StartSound(origin_p, sfx_id);
 }
 
-// [NS] Check if a sound ID has a valid lump.
-boolean S_CheckSoundId(int sfx_id)
+// [NS] Try to play an optional sound.
+void S_StartSoundOptional(void *origin_p, int sfx_id, int old_sfx_id)
 {
-    return I_GetSfxLumpNum(&S_sfx[sfx_id]) != -1;
-}
-
-// [NS] Start a sound only if its lump exists.
-boolean S_StartSoundOptional(void *origin_p, int sfx_id)
-{
-    if (S_CheckSoundId(sfx_id))
+    if (I_GetSfxLumpNum(&S_sfx[sfx_id]) != -1)
     {
         S_StartSound(origin_p, sfx_id);
-        return true;
     }
-    return false;
+    else if (old_sfx_id != -1) // Play a fallback?
+    {
+        S_StartSound(origin_p, old_sfx_id);
+    }
 }
 
 //

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -780,12 +780,14 @@ boolean S_CheckSoundId(int sfx_id)
 }
 
 // [NS] Start a sound only if its lump exists.
-void S_StartSoundOptional(void *origin_p, int sfx_id)
+boolean S_StartSoundOptional(void *origin_p, int sfx_id)
 {
     if (S_CheckSoundId(sfx_id))
     {
         S_StartSound(origin_p, sfx_id);
+        return true;
     }
+    return false;
 }
 
 //

--- a/src/doom/s_sound.h
+++ b/src/doom/s_sound.h
@@ -77,6 +77,9 @@ void S_StopMusic(void);
 void S_PauseSound(void);
 void S_ResumeSound(void);
 
+// [NS] Optional sound effects.
+boolean S_CheckSoundId(int sound_id);
+void S_StartSoundOptional(void *origin, int sound_id);
 
 //
 // Updates music & sounds

--- a/src/doom/s_sound.h
+++ b/src/doom/s_sound.h
@@ -79,7 +79,7 @@ void S_ResumeSound(void);
 
 // [NS] Optional sound effects.
 boolean S_CheckSoundId(int sound_id);
-void S_StartSoundOptional(void *origin, int sound_id);
+boolean S_StartSoundOptional(void *origin, int sound_id);
 
 //
 // Updates music & sounds

--- a/src/doom/s_sound.h
+++ b/src/doom/s_sound.h
@@ -78,8 +78,7 @@ void S_PauseSound(void);
 void S_ResumeSound(void);
 
 // [NS] Optional sound effects.
-boolean S_CheckSoundId(int sound_id);
-boolean S_StartSoundOptional(void *origin, int sound_id);
+void S_StartSoundOptional(void *origin, int sound_id, int old_sound_id);
 
 //
 // Updates music & sounds

--- a/src/doom/sounds.c
+++ b/src/doom/sounds.c
@@ -261,5 +261,13 @@ sfxinfo_t S_sfx[] =
   SOUND("plland",  78),
   SOUND("locked",  78),
   SOUND("keyup",   78),
+  // [NS] Optional menu sounds.
+  SOUND("mnuopn",  60),
+  SOUND("mnucls",  60),
+  SOUND("mnuact",  60),
+  SOUND("mnubak",  60),
+  SOUND("mnumov",  60),
+  SOUND("mnusli",  60),
+  SOUND("mnuerr",  60),
 };
 

--- a/src/doom/sounds.c
+++ b/src/doom/sounds.c
@@ -261,7 +261,7 @@ sfxinfo_t S_sfx[] =
   SOUND("plland",  78),
   SOUND("locked",  78),
   SOUND("keyup",   78),
-  // [NS] Optional menu sounds.
+  // [NS] Optional menu/intermission sounds.
   SOUND("mnuopn",  60),
   SOUND("mnucls",  60),
   SOUND("mnuact",  60),

--- a/src/doom/sounds.c
+++ b/src/doom/sounds.c
@@ -259,5 +259,7 @@ sfxinfo_t S_sfx[] =
   // [NS] New optional sounds.
   SOUND("pljump",  78),
   SOUND("plland",  78),
+  SOUND("locked",  78),
+  SOUND("keyup",   78),
 };
 

--- a/src/doom/sounds.c
+++ b/src/doom/sounds.c
@@ -269,5 +269,10 @@ sfxinfo_t S_sfx[] =
   SOUND("mnumov",  60),
   SOUND("mnusli",  60),
   SOUND("mnuerr",  60),
+  SOUND("inttic",  60),
+  SOUND("inttot",  60),
+  SOUND("intnex",  60),
+  SOUND("intnet",  60),
+  SOUND("intdms",  60),
 };
 

--- a/src/doom/sounds.c
+++ b/src/doom/sounds.c
@@ -256,5 +256,8 @@ sfxinfo_t S_sfx[] =
   SOUND("dgpain", 96),
   // [crispy] play DSSECRET if available
   SOUND("secret",  60),
+  // [NS] New optional sounds.
+  SOUND("pljump",  78),
+  SOUND("plland",  78),
 };
 

--- a/src/doom/sounds.h
+++ b/src/doom/sounds.h
@@ -254,6 +254,8 @@ typedef enum
     // [NS] New optional sounds.
     sfx_pljump,
     sfx_plland,
+    sfx_locked,
+    sfx_keyup,
     NUMSFX
 } sfxenum_t;
 

--- a/src/doom/sounds.h
+++ b/src/doom/sounds.h
@@ -256,7 +256,7 @@ typedef enum
     sfx_plland,
     sfx_locked,
     sfx_keyup,
-    // [NS] Optional menu sounds.
+    // [NS] Optional menu/intermission sounds.
     sfx_mnuopn,
     sfx_mnucls,
     sfx_mnuact,
@@ -264,6 +264,11 @@ typedef enum
     sfx_mnumov,
     sfx_mnusli,
     sfx_mnuerr,
+    sfx_inttic,
+    sfx_inttot,
+    sfx_intnex,
+    sfx_intnet,
+    sfx_intdms,
     NUMSFX
 } sfxenum_t;
 

--- a/src/doom/sounds.h
+++ b/src/doom/sounds.h
@@ -256,6 +256,14 @@ typedef enum
     sfx_plland,
     sfx_locked,
     sfx_keyup,
+    // [NS] Optional menu sounds.
+    sfx_mnuopn,
+    sfx_mnucls,
+    sfx_mnuact,
+    sfx_mnubak,
+    sfx_mnumov,
+    sfx_mnusli,
+    sfx_mnuerr,
     NUMSFX
 } sfxenum_t;
 

--- a/src/doom/sounds.h
+++ b/src/doom/sounds.h
@@ -251,6 +251,9 @@ typedef enum
     sfx_dgpain,
     // [crispy] play DSSECRET if available
     sfx_secret,
+    // [NS] New optional sounds.
+    sfx_pljump,
+    sfx_plland,
     NUMSFX
 } sfxenum_t;
 

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -973,7 +973,7 @@ void WI_updateDeathmatchStats(void)
 	}
 	
 
-	S_StartSound(0, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	dm_state = 4;
     }
 
@@ -981,7 +981,7 @@ void WI_updateDeathmatchStats(void)
     if (dm_state == 2)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 	
 	stillticking = false;
 
@@ -1020,7 +1020,7 @@ void WI_updateDeathmatchStats(void)
 	}
 	if (!stillticking)
 	{
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    dm_state++;
 	}
 
@@ -1029,7 +1029,7 @@ void WI_updateDeathmatchStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSound(0, sfx_slop);
+	    S_StartSoundOptional(0, sfx_intdms, sfx_slop);
 
 	    if ( gamemode == commercial)
 		WI_initNoState();
@@ -1191,14 +1191,14 @@ void WI_updateNetgameStats(void)
 	    if (dofrags)
 		cnt_frags[i] = WI_fragSum(i);
 	}
-	S_StartSound(0, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	ng_state = 10;
     }
 
     if (ng_state == 2)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	stillticking = false;
 
@@ -1217,14 +1217,14 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    ng_state++;
 	}
     }
     else if (ng_state == 4)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	stillticking = false;
 
@@ -1241,14 +1241,14 @@ void WI_updateNetgameStats(void)
 	}
 	if (!stillticking)
 	{
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    ng_state++;
 	}
     }
     else if (ng_state == 6)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	stillticking = false;
 
@@ -1267,14 +1267,14 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    ng_state += 1 + 2*!dofrags;
 	}
     }
     else if (ng_state == 8)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	stillticking = false;
 
@@ -1293,7 +1293,7 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSound(0, sfx_pldeth);
+	    S_StartSoundOptional(0, sfx_intnet, sfx_pldeth);
 	    ng_state++;
 	}
     }
@@ -1301,7 +1301,7 @@ void WI_updateNetgameStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSound(0, sfx_sgcock);
+	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock);
 	    if ( gamemode == commercial )
 		WI_initNoState();
 	    else
@@ -1402,7 +1402,7 @@ void WI_updateStats(void)
 	cnt_secret[0] = (plrs[me].ssecret * 100) / wbs->maxsecret;
 	cnt_time = plrs[me].stime / TICRATE;
 	cnt_par = wbs->partime / TICRATE;
-	S_StartSound(0, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	sp_state = 10;
     }
 
@@ -1411,12 +1411,12 @@ void WI_updateStats(void)
 	cnt_kills[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	if (cnt_kills[0] >= (plrs[me].skills * 100) / wbs->maxkills)
 	{
 	    cnt_kills[0] = (plrs[me].skills * 100) / wbs->maxkills;
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    sp_state++;
 	}
     }
@@ -1425,12 +1425,12 @@ void WI_updateStats(void)
 	cnt_items[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	if (cnt_items[0] >= (plrs[me].sitems * 100) / wbs->maxitems)
 	{
 	    cnt_items[0] = (plrs[me].sitems * 100) / wbs->maxitems;
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    sp_state++;
 	}
     }
@@ -1439,12 +1439,12 @@ void WI_updateStats(void)
 	cnt_secret[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	if (cnt_secret[0] >= (plrs[me].ssecret * 100) / wbs->maxsecret)
 	{
 	    cnt_secret[0] = (plrs[me].ssecret * 100) / wbs->maxsecret;
-	    S_StartSound(0, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 	    sp_state++;
 	}
     }
@@ -1452,7 +1452,7 @@ void WI_updateStats(void)
     else if (sp_state == 8)
     {
 	if (!(bcnt&3))
-	    S_StartSound(0, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
 
 	cnt_time += 3;
 
@@ -1467,7 +1467,7 @@ void WI_updateStats(void)
 
 	    if (cnt_time >= plrs[me].stime / TICRATE)
 	    {
-		S_StartSound(0, sfx_barexp);
+		S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
 		sp_state++;
 	    }
 	}
@@ -1476,7 +1476,7 @@ void WI_updateStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSound(0, sfx_sgcock);
+	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock);
 
 	    if (gamemode == commercial)
 		WI_initNoState();

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -965,7 +965,7 @@ void WI_updateDeathmatchStats(void)
 	    if (playeringame[i])
 	    {
 		for (j=0 ; j<MAXPLAYERS ; j++)
-		    if (playeringame[j])
+		    if (playeringame[j])
 			dm_frags[i][j] = plrs[i].frags[j];
 
 		dm_totals[i] = WI_fragSum(i);

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -965,7 +965,7 @@ void WI_updateDeathmatchStats(void)
 	    if (playeringame[i])
 	    {
 		for (j=0 ; j<MAXPLAYERS ; j++)
-		    if (playeringame[j])
+		    if (playeringame[j])
 			dm_frags[i][j] = plrs[i].frags[j];
 
 		dm_totals[i] = WI_fragSum(i);
@@ -973,7 +973,7 @@ void WI_updateDeathmatchStats(void)
 	}
 	
 
-	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	dm_state = 4;
     }
 
@@ -981,7 +981,7 @@ void WI_updateDeathmatchStats(void)
     if (dm_state == 2)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 	
 	stillticking = false;
 
@@ -1020,7 +1020,7 @@ void WI_updateDeathmatchStats(void)
 	}
 	if (!stillticking)
 	{
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    dm_state++;
 	}
 
@@ -1029,7 +1029,7 @@ void WI_updateDeathmatchStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSoundOptional(0, sfx_intdms, sfx_slop);
+	    S_StartSoundOptional(0, sfx_intdms, sfx_slop); // [NS] Optional inter sounds.
 
 	    if ( gamemode == commercial)
 		WI_initNoState();
@@ -1191,14 +1191,14 @@ void WI_updateNetgameStats(void)
 	    if (dofrags)
 		cnt_frags[i] = WI_fragSum(i);
 	}
-	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	ng_state = 10;
     }
 
     if (ng_state == 2)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	stillticking = false;
 
@@ -1217,14 +1217,14 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    ng_state++;
 	}
     }
     else if (ng_state == 4)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	stillticking = false;
 
@@ -1241,14 +1241,14 @@ void WI_updateNetgameStats(void)
 	}
 	if (!stillticking)
 	{
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    ng_state++;
 	}
     }
     else if (ng_state == 6)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	stillticking = false;
 
@@ -1267,14 +1267,14 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    ng_state += 1 + 2*!dofrags;
 	}
     }
     else if (ng_state == 8)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	stillticking = false;
 
@@ -1293,7 +1293,7 @@ void WI_updateNetgameStats(void)
 	
 	if (!stillticking)
 	{
-	    S_StartSoundOptional(0, sfx_intnet, sfx_pldeth);
+	    S_StartSoundOptional(0, sfx_intnet, sfx_pldeth); // [NS] Optional inter sounds.
 	    ng_state++;
 	}
     }
@@ -1301,7 +1301,7 @@ void WI_updateNetgameStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock);
+	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock); // [NS] Optional inter sounds.
 	    if ( gamemode == commercial )
 		WI_initNoState();
 	    else
@@ -1402,7 +1402,7 @@ void WI_updateStats(void)
 	cnt_secret[0] = (plrs[me].ssecret * 100) / wbs->maxsecret;
 	cnt_time = plrs[me].stime / TICRATE;
 	cnt_par = wbs->partime / TICRATE;
-	S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	sp_state = 10;
     }
 
@@ -1411,12 +1411,12 @@ void WI_updateStats(void)
 	cnt_kills[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	if (cnt_kills[0] >= (plrs[me].skills * 100) / wbs->maxkills)
 	{
 	    cnt_kills[0] = (plrs[me].skills * 100) / wbs->maxkills;
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    sp_state++;
 	}
     }
@@ -1425,12 +1425,12 @@ void WI_updateStats(void)
 	cnt_items[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	if (cnt_items[0] >= (plrs[me].sitems * 100) / wbs->maxitems)
 	{
 	    cnt_items[0] = (plrs[me].sitems * 100) / wbs->maxitems;
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    sp_state++;
 	}
     }
@@ -1439,12 +1439,12 @@ void WI_updateStats(void)
 	cnt_secret[0] += 2;
 
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	if (cnt_secret[0] >= (plrs[me].ssecret * 100) / wbs->maxsecret)
 	{
 	    cnt_secret[0] = (plrs[me].ssecret * 100) / wbs->maxsecret;
-	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+	    S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 	    sp_state++;
 	}
     }
@@ -1452,7 +1452,7 @@ void WI_updateStats(void)
     else if (sp_state == 8)
     {
 	if (!(bcnt&3))
-	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol);
+	    S_StartSoundOptional(0, sfx_inttic, sfx_pistol); // [NS] Optional inter sounds.
 
 	cnt_time += 3;
 
@@ -1467,7 +1467,7 @@ void WI_updateStats(void)
 
 	    if (cnt_time >= plrs[me].stime / TICRATE)
 	    {
-		S_StartSoundOptional(0, sfx_inttot, sfx_barexp);
+		S_StartSoundOptional(0, sfx_inttot, sfx_barexp); // [NS] Optional inter sounds.
 		sp_state++;
 	    }
 	}
@@ -1476,7 +1476,7 @@ void WI_updateStats(void)
     {
 	if (acceleratestage)
 	{
-	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock);
+	    S_StartSoundOptional(0, sfx_intnex, sfx_sgcock); // [NS] Optional inter sounds.
 
 	    if (gamemode == commercial)
 		WI_initNoState();


### PR DESCRIPTION
A few new sound effects that will only be used if the relevant sound lumps exist. Perfect for modders or autoload goodies.

Gameplay sounds:
* PLJUMP: Player jumping.
* PLLAND: Player hard landing, as in Hexen. (Replaces DSOOF at higher velocity.)
* LOCKED: Trying a locked door. (Replaces DSOOF.)
* KEYUP: Picking up a key. (Replaces DSITEMUP.)

Menu sounds:
* MNUOPN: Opening a menu.
* MNUCLS: Closing the menu.
* MNUACT: Activating a submenu.
* MNUBAK: Returning to a parent menu.
* MNUMOV: Moving the cursor.
* MNUSLI: Moving a slider, window size, detail level, etc.
* MNUERR: Errors. (Quicksaving when not ingame, etc.)


So this is a slightly large addition. I've added two small functions to s_sound to keep changes concise with no deletions. (Fingers crossed.) Comments cross the 80chr wall in a few spots to keep the overall lines down, I hope this is OK.

The only part I'm not 100% on: In p_mobj, The hard landing simply plays after the regular "oof", overriding it. I was mainly trying to avoid wrapping that line in more braces (since indentation would get totally ridiculous).