### PR TITLE
Custom difficulty parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Many additional less user-visible features have been implemented, e.g. fixed eng
  * `-fliplevels` loads mirrored versions of the maps (this was the default on April 1st up to version 5.0).
  * `-flipweapons` flips the player's weapons (new in 5.3).
  * `-levelstat` prints a levelstat.txt file with statistics for each completed level (new in 5.9.0).
+ * `-pistolstart` enables automatic pistol start when advancing from one level to the next in Doom. At the beginning of each level, the player's health is reset to 100, their armor to 0 and their inventory is reduced to the following: pistol, fists and 50 bullets.
+ * `-wandstart` enables automatic wand start when advancing from one level to the next in Heretic. At the beginning of each level, the player's health is reset to 100, their armor to 0 and their inventory is reduced to the following: wand, staff and 50 ammo for the wand.
+ * `-doubleammo` doubles ammo pickup rate in Doom and Strife (new in 5.11).
+ * `-moreammo` increases ammo pickup rate by 50% in Heretic (new in 5.11).
+ * `-moremana` increases mana pickup rate by 50% in Hexen (new in 5.11).
+ * `-fast` enables fast monsters in Heretic and Hexen (new in 5.11).
+ * `-autohealth` enables automatic use of Quartz flasks and Mystic urns in Heretic and Hexen (new in 5.11).
+ * `-keysloc` enables display of keys on the automap in Heretic (new in 5.11).
 
 ### New cheat codes
 

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -94,6 +94,7 @@ typedef struct
 	boolean havee1m10;
 	boolean havemap33;
 	boolean havessg;
+    boolean keysloc;
     boolean moreammo;
 	boolean pistolstart;
 	boolean singleplayer;

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -93,6 +93,7 @@ typedef struct
 	boolean havee1m10;
 	boolean havemap33;
 	boolean havessg;
+    boolean moreammo;
 	boolean pistolstart;
 	boolean singleplayer;
 	boolean stretchsky;

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -86,6 +86,7 @@ typedef struct
 	int demowarp;
 	int fps;
 
+    boolean fast;
 	boolean flashinghom;
 	boolean fliplevels;
 	boolean flipweapons;

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -87,8 +87,8 @@ typedef struct
 	int demowarp;
 	int fps;
 
-    boolean autohealth;
-    boolean fast;
+	boolean autohealth;
+	boolean fast;
 	boolean flashinghom;
 	boolean fliplevels;
 	boolean flipweapons;
@@ -96,8 +96,8 @@ typedef struct
 	boolean havee1m10;
 	boolean havemap33;
 	boolean havessg;
-    boolean keysloc;
-    boolean moreammo;
+	boolean keysloc;
+	boolean moreammo;
 	boolean pistolstart;
 	boolean singleplayer;
 	boolean stretchsky;

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -86,6 +86,7 @@ typedef struct
 	int demowarp;
 	int fps;
 
+    boolean autohealth;
     boolean fast;
 	boolean flashinghom;
 	boolean fliplevels;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1700,6 +1700,16 @@ void D_DoomMain (void)
     crispy->pistolstart = M_ParmExists("-pistolstart");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Double ammo pickup rate. This option is not allowed when recording a
+    // demo, playing back a demo or when starting a network game.
+    //
+
+    crispy->moreammo = M_ParmExists("-doubleammo");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad and .deh files.

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -871,6 +871,16 @@ void G_DoLoadLevel (void)
     // [crispy] update the "singleplayer" variable
     CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
 
+    // [crispy] double ammo
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -doubleammo option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     // [crispy] pistol start
     if (crispy->pistolstart)
     {

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -86,10 +86,12 @@ P_GiveAmmo
 	num = clipammo[ammo]/2;
     
     if (gameskill == sk_baby
-	|| gameskill == sk_nightmare)
+	|| gameskill == sk_nightmare
+    || (crispy->moreammo && !demoplayback))
     {
 	// give double ammo in trainer mode,
 	// you'll need in nightmare
+    // [crispy] double ammo
 	num <<= 1;
     }
     

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -87,7 +87,7 @@ P_GiveAmmo
     
     if (gameskill == sk_baby
 	|| gameskill == sk_nightmare
-    || critical->moreammo)
+	|| critical->moreammo)
     {
 	// give double ammo in trainer mode,
 	// you'll need in nightmare

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -87,11 +87,10 @@ P_GiveAmmo
     
     if (gameskill == sk_baby
 	|| gameskill == sk_nightmare
-    || (crispy->moreammo && !demoplayback))
+    || critical->moreammo)
     {
 	// give double ammo in trainer mode,
 	// you'll need in nightmare
-    // [crispy] double ammo
 	num <<= 1;
     }
     

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -375,7 +375,7 @@ void AM_initVariables(void)
     // load in the location of keys, if in baby mode
 
     memset(KeyPoints, 0, sizeof(vertex_t) * 3);
-    if (gameskill == sk_baby)
+    if (gameskill == sk_baby || crispy->keysloc)
     {
         for (think = thinkercap.next; think != &thinkercap;
              think = think->next)
@@ -1572,7 +1572,7 @@ void AM_Drawer(void)
 //  AM_drawCrosshair(XHAIRCOLORS);
 
 //  AM_drawMarks();
-    if (gameskill == sk_baby)
+    if (gameskill == sk_baby || crispy->keysloc)
     {
         AM_drawkeys();
     }

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1067,6 +1067,15 @@ void D_DoomMain(void)
     crispy->fast = M_ParmExists("-fast");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Show the location of keys on the automap.
+    //
+
+    crispy->keysloc = M_ParmExists("-keysloc");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1047,6 +1047,16 @@ void D_DoomMain(void)
     crispy->pistolstart = M_ParmExists("-wandstart");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Ammo pickups give 50% more ammo. This option is not allowed when recording a
+    // demo, playing back a demo or when starting a network game.
+    //
+
+    crispy->moreammo = M_ParmExists("-moreammo");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -342,6 +342,47 @@ boolean D_GrabMouseCallback(void)
 
 void D_DoomLoop(void)
 {
+    // [crispy] update the "singleplayer" variable
+    CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
+
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -moreammo option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
+    // [crispy] fast monsters
+    if (crispy->fast && !crispy->singleplayer)
+    {
+        const char message[] = "The -fast option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
+
+    // [crispy] wand start
+    // silently ignore pistolstart when playing demo from
+    // the demo reel
+    if (crispy->pistolstart && !crispy->singleplayer)
+    {
+        const char message[] = "The -wandstart option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
+    // [crispy] auto health
+    if (crispy->autohealth && !crispy->singleplayer)
+    {
+        const char message[] = "The -autohealth option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
     if (M_CheckParm("-debugfile"))
     {
         char filename[20];

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1057,6 +1057,16 @@ void D_DoomMain(void)
     crispy->moreammo = M_ParmExists("-moreammo");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Fast monsters. This option is not allowed when recording a demo,
+    // playing back a demo or when starting a network game.
+    //
+
+    crispy->fast = M_ParmExists("-fast");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1070,6 +1070,15 @@ void D_DoomMain(void)
     // @category game
     // @category mod
     //
+    // Automatic use of Quartz flasks and Mystic urns.
+    //
+
+    crispy->autohealth = M_ParmExists("-autohealth");
+
+    //!
+    // @category game
+    // @category mod
+    //
     // Show the location of keys on the automap.
     //
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1099,7 +1099,7 @@ void G_Ticker(void)
     while (gameaction != ga_nothing)
     {
         // [crispy] check if we are in a demo reel
-        CheckCrispySingleplayer(gameaction != ga_playdemo);
+        CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
         switch (gameaction)
         {
             case ga_loadlevel:

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -780,6 +780,16 @@ void G_DoLoadLevel(void)
     // [crispy] update the "singleplayer" variable
     CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
 
+    // [crispy] more ammo
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -moreammo option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     // [crispy] wand start
     if (crispy->pistolstart)
     {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -822,6 +822,16 @@ void G_DoLoadLevel(void)
         }
     }
 
+    // [crispy] auto health
+    if (crispy->autohealth && !crispy->singleplayer)
+    {
+        const char message[] = "The -autohealth option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing
     gameaction = ga_nothing;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1098,6 +1098,8 @@ void G_Ticker(void)
 //
     while (gameaction != ga_nothing)
     {
+        // [crispy] check if we are in a demo reel
+        CheckCrispySingleplayer(gameaction != ga_playdemo);
         switch (gameaction)
         {
             case ga_loadlevel:

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1098,7 +1098,7 @@ void G_Ticker(void)
 //
     while (gameaction != ga_nothing)
     {
-        // [crispy] check if we are in a demo reel
+        // [crispy] check if we are in the demo reel
         CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
         switch (gameaction)
         {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -777,30 +777,6 @@ void G_DoLoadLevel(void)
         memset(players[i].frags, 0, sizeof(players[i].frags));
     }
 
-    // [crispy] update the "singleplayer" variable
-    CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
-
-    // [crispy] more ammo
-    if (crispy->moreammo && !crispy->singleplayer)
-    {
-        const char message[] = "The -moreammo option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
-    }
-
-    // [crispy] fast monsters
-    if (crispy->fast && !crispy->singleplayer)
-    {
-        const char message[] = "The -fast option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
-    }
-
-
     // [crispy] wand start
     if (crispy->pistolstart)
     {
@@ -820,16 +796,6 @@ void G_DoLoadLevel(void)
                                    " network play.";
             I_Error(message);
         }
-    }
-
-    // [crispy] auto health
-    if (crispy->autohealth && !crispy->singleplayer)
-    {
-        const char message[] = "The -autohealth option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
     }
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
@@ -1892,8 +1858,7 @@ void G_InitNew(skill_t skill, int episode, int map)
         respawnmonsters = false;
     }
     // Set monster missile speeds
-    // [crispy] fast monsters
-    speed = skill == sk_nightmare || (crispy->fast && !demoplayback);
+    speed = skill == sk_nightmare || critical->fast;
     for (i = 0; MonsterMissileInfo[i].type != -1; i++)
     {
         mobjinfo[MonsterMissileInfo[i].type].speed

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -790,6 +790,17 @@ void G_DoLoadLevel(void)
         I_Error(message);
     }
 
+    // [crispy] fast monsters
+    if (crispy->fast && !crispy->singleplayer)
+    {
+        const char message[] = "The -fast option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
+
     // [crispy] wand start
     if (crispy->pistolstart)
     {
@@ -1871,7 +1882,8 @@ void G_InitNew(skill_t skill, int episode, int map)
         respawnmonsters = false;
     }
     // Set monster missile speeds
-    speed = skill == sk_nightmare;
+    // [crispy] fast monsters
+    speed = skill == sk_nightmare || (crispy->fast && !demoplayback);
     for (i = 0; MonsterMissileInfo[i].type != -1; i++)
     {
         mobjinfo[MonsterMissileInfo[i].type].speed

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -739,8 +739,7 @@ void A_Chase(mobj_t * actor)
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare
-            && !critical->fast)
+        if (gameskill != sk_nightmare && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -761,8 +760,7 @@ void A_Chase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount &&
-            !critical->fast)
+        if (gameskill < sk_nightmare && actor->movecount && !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -697,8 +697,9 @@ void A_Chase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare)
+    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
     {                           // Monsters move faster in nightmare mode
+                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -735,11 +736,12 @@ void A_Chase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-//
+// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare)
+        if (gameskill != sk_nightmare
+            && !(crispy->fast && !demoplayback))
             P_NewChaseDir(actor);
         return;
     }
@@ -757,10 +759,11 @@ void A_Chase(mobj_t * actor)
 
 //
 // check for missile attack
-//
+// [crispy] fast monsters
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount)
+        if (gameskill < sk_nightmare &&
+            !(crispy->fast && !demoplayback) && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -697,9 +697,8 @@ void A_Chase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
+    if (gameskill == sk_nightmare || critical->fast)
     {                           // Monsters move faster in nightmare mode
-                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -736,12 +735,11 @@ void A_Chase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(crispy->fast && !demoplayback))
+            && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -759,11 +757,10 @@ void A_Chase(mobj_t * actor)
 
 //
 // check for missile attack
-// [crispy] fast monsters
     if (actor->info->missilestate)
     {
         if (gameskill < sk_nightmare &&
-            !(crispy->fast && !demoplayback) && actor->movecount)
+            !critical->fast && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -735,6 +735,7 @@ void A_Chase(mobj_t * actor)
 
 //
 // don't attack twice in a row
+//
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
@@ -757,6 +758,7 @@ void A_Chase(mobj_t * actor)
 
 //
 // check for missile attack
+//
     if (actor->info->missilestate)
     {
         if (gameskill < sk_nightmare &&

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -761,8 +761,8 @@ void A_Chase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare &&
-            !critical->fast && actor->movecount)
+        if (gameskill < sk_nightmare && actor->movecount &&
+            !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -1213,8 +1213,9 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             superCount = player->inventory[i].count;
         }
     }
-    if ((gameskill == sk_baby) && (normalCount * 25 >= saveHealth))
+    if ((gameskill == sk_baby || crispy->autohealth) && (normalCount * 25 >= saveHealth))
     {                           // Use quartz flasks
+                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         for (i = 0; i < count; i++)
         {
@@ -1231,9 +1232,10 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             P_PlayerRemoveArtifact(player, superSlot);
         }
     }
-    else if ((gameskill == sk_baby)
+    else if ((gameskill == sk_baby || crispy->autohealth)
              && (superCount * 100 + normalCount * 25 >= saveHealth))
     {                           // Use mystic urns and quartz flasks
+                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         saveHealth -= count * 25;
         for (i = 0; i < count; i++)
@@ -1452,8 +1454,10 @@ void P_DamageMobj
             damage -= saved;
         }
         if (damage >= player->health
-            && ((gameskill == sk_baby) || deathmatch) && !player->chickenTics)
+            && ((gameskill == sk_baby) || deathmatch || crispy->autohealth)
+            && !player->chickenTics)
         {                       // Try to use some inventory health
+                                // [crispy] auto health
             P_AutoUseHealth(player, damage - player->health + 1);
         }
         player->health -= damage;       // mirror mobj health here for Dave

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -180,8 +180,10 @@ boolean P_GiveAmmo(player_t * player, ammotype_t ammo, int count)
     {
         return (false);
     }
-    if (gameskill == sk_baby || gameskill == sk_nightmare)
+    if (gameskill == sk_baby || gameskill == sk_nightmare
+                             || (crispy->moreammo && !demoplayback))
     {                           // extra ammo in baby mode and nightmare mode
+                                // [crispy] more ammo
         count += count >> 1;
     }
     prevAmmo = player->ammo[ammo];

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -181,9 +181,8 @@ boolean P_GiveAmmo(player_t * player, ammotype_t ammo, int count)
         return (false);
     }
     if (gameskill == sk_baby || gameskill == sk_nightmare
-                             || (crispy->moreammo && !demoplayback))
+                             || critical->moreammo)
     {                           // extra ammo in baby mode and nightmare mode
-                                // [crispy] more ammo
         count += count >> 1;
     }
     prevAmmo = player->ammo[ammo];
@@ -1213,9 +1212,8 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             superCount = player->inventory[i].count;
         }
     }
-    if ((gameskill == sk_baby || crispy->autohealth) && (normalCount * 25 >= saveHealth))
+    if ((gameskill == sk_baby || critical->autohealth) && (normalCount * 25 >= saveHealth))
     {                           // Use quartz flasks
-                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         for (i = 0; i < count; i++)
         {
@@ -1232,10 +1230,9 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             P_PlayerRemoveArtifact(player, superSlot);
         }
     }
-    else if ((gameskill == sk_baby || crispy->autohealth)
+    else if ((gameskill == sk_baby || critical->autohealth)
              && (superCount * 100 + normalCount * 25 >= saveHealth))
     {                           // Use mystic urns and quartz flasks
-                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         saveHealth -= count * 25;
         for (i = 0; i < count; i++)
@@ -1454,10 +1451,9 @@ void P_DamageMobj
             damage -= saved;
         }
         if (damage >= player->health
-            && ((gameskill == sk_baby) || deathmatch || crispy->autohealth)
+            && ((gameskill == sk_baby) || deathmatch || critical->autohealth)
             && !player->chickenTics)
         {                       // Try to use some inventory health
-                                // [crispy] auto health
             P_AutoUseHealth(player, damage - player->health + 1);
         }
         player->health -= damage;       // mirror mobj health here for Dave

--- a/src/heretic/p_mobj.c
+++ b/src/heretic/p_mobj.c
@@ -890,8 +890,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
     mobj->flags2 = info->flags2;
     mobj->damage = info->damage;
     mobj->health = info->spawnhealth;
-    // [crispy] fast monsters
-    if (gameskill != sk_nightmare && !(crispy->fast && !demoplayback))
+    if (gameskill != sk_nightmare && !critical->fast)
     {
         mobj->reactiontime = info->reactiontime;
     }

--- a/src/heretic/p_mobj.c
+++ b/src/heretic/p_mobj.c
@@ -890,7 +890,8 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
     mobj->flags2 = info->flags2;
     mobj->damage = info->damage;
     mobj->health = info->spawnhealth;
-    if (gameskill != sk_nightmare)
+    // [crispy] fast monsters
+    if (gameskill != sk_nightmare && !(crispy->fast && !demoplayback))
     {
         mobj->reactiontime = info->reactiontime;
     }

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -41,8 +41,6 @@ extern void H2_ProcessEvents(void);
 extern void G_BuildTiccmd(ticcmd_t *cmd, int maketic);
 extern boolean G_CheckDemoStatus(void);
 
-extern boolean demorecording;
-
 // Called when a player leaves the game
 
 static void PlayerQuitGame(player_t *player)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -716,6 +716,17 @@ void G_DoLoadLevel(void)
         I_Error(message);
     }
 
+
+    // [crispy] auto health
+    if (crispy->autohealth && !crispy->singleplayer)
+    {
+        const char message[] = "The -autohealth option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing   

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -956,7 +956,7 @@ void G_Ticker(void)
     while (gameaction != ga_nothing)
     {
         // [crispy] check if we are in a demo reel
-        CheckCrispySingleplayer(gameaction != ga_playdemo);
+        CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
         switch (gameaction)
         {
             case ga_loadlevel:

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -706,6 +706,16 @@ void G_DoLoadLevel(void)
         I_Error(message);
     }
 
+    // [crispy] fast monsters
+    if (crispy->fast && !crispy->singleplayer)
+    {
+        const char message[] = "The -fast option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing   

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -693,40 +693,6 @@ void G_DoLoadLevel(void)
         memset(players[i].frags, 0, sizeof(players[i].frags));
     }
 
-    // [crispy] update the "singleplayer" variable
-    CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
-
-    // [crispy] more mana
-    if (crispy->moreammo && !crispy->singleplayer)
-    {
-        const char message[] = "The -moremana option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
-    }
-
-    // [crispy] fast monsters
-    if (crispy->fast && !crispy->singleplayer)
-    {
-        const char message[] = "The -fast option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
-    }
-
-
-    // [crispy] auto health
-    if (crispy->autohealth && !crispy->singleplayer)
-    {
-        const char message[] = "The -autohealth option is not supported"
-                               " for demos and\n"
-                               " network play.";
-        if (!demo_p) demorecording = false;
-        I_Error(message);
-    }
-
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing   

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -693,6 +693,19 @@ void G_DoLoadLevel(void)
         memset(players[i].frags, 0, sizeof(players[i].frags));
     }
 
+    // [crispy] update the "singleplayer" variable
+    CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
+
+    // [crispy] more mana
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -moremana option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing   

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -955,6 +955,8 @@ void G_Ticker(void)
 //
     while (gameaction != ga_nothing)
     {
+        // [crispy] check if we are in a demo reel
+        CheckCrispySingleplayer(gameaction != ga_playdemo);
         switch (gameaction)
         {
             case ga_loadlevel:

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -955,7 +955,7 @@ void G_Ticker(void)
 //
     while (gameaction != ga_nothing)
     {
-        // [crispy] check if we are in a demo reel
+        // [crispy] check if we are in the demo reel
         CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
         switch (gameaction)
         {

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -845,6 +845,36 @@ static void WarpCheck(void)
 
 void H2_GameLoop(void)
 {
+    // [crispy] update the "singleplayer" variable
+    CheckCrispySingleplayer(!demorecording && gameaction != ga_playdemo && !netgame);
+
+    // [crispy] more mana
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -moremana option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
+    // [crispy] fast monsters
+    if (crispy->fast && !crispy->singleplayer)
+    {
+        const char message[] = "The -fast option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
+    // [crispy] auto health
+    if (crispy->autohealth && !crispy->singleplayer)
+    {
+        const char message[] = "The -autohealth option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        I_Error(message);
+    }
+
     if (M_CheckParm("-debugfile"))
     {
         char filename[20];

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -450,6 +450,16 @@ void D_DoomMain(void)
     crispy->moreammo = M_ParmExists("-moremana");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Fast monsters. This option is not allowed when recording a demo,
+    // playing back a demo or when starting a network game.
+    //
+
+    crispy->fast = M_ParmExists("-fast");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -460,6 +460,15 @@ void D_DoomMain(void)
     crispy->fast = M_ParmExists("-fast");
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Automatic use of Quartz flasks and Mystic urns.
+    //
+
+    crispy->autohealth = M_ParmExists("-autohealth");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -440,6 +440,16 @@ void D_DoomMain(void)
     AdjustForMacIWAD();
 
     //!
+    // @category game
+    // @category mod
+    //
+    // Mana pickups give 50% more mana. This option is not allowed when recording a
+    // demo, playing back a demo or when starting a network game.
+    //
+
+    crispy->moreammo = M_ParmExists("-moremana");
+
+    //!
     // @category mod
     //
     // Disable auto-loading of .wad files.

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -619,6 +619,8 @@ extern boolean netgame;         // only true if >1 player
 extern boolean cmdfrag;         // true if a CMD_FRAG packet should be sent out every
                                                 // kill
 
+extern boolean demorecording;
+
 extern boolean playeringame[MAXPLAYERS];
 extern pclass_t PlayerClass[MAXPLAYERS];
 

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -753,8 +753,8 @@ void A_Chase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare &&
-            !critical->fast && actor->movecount)
+        if (gameskill < sk_nightmare && actor->movecount
+            && !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;
@@ -4691,8 +4691,8 @@ void A_FastChase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare &&
-            !(critical->fast) && actor->movecount)
+        if (gameskill < sk_nightmare && actor->movecount
+            && !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -687,9 +687,8 @@ void A_Chase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
+    if (gameskill == sk_nightmare || critical->fast)
     {                           // Monsters move faster in nightmare mode
-                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -726,12 +725,12 @@ void A_Chase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-// [crispy] fast monsters
+//
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(crispy->fast && !demoplayback))
+            && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -751,11 +750,11 @@ void A_Chase(mobj_t * actor)
 
 //
 // check for missile attack
-// [crispy] fast monsters
+//
     if (actor->info->missilestate)
     {
         if (gameskill < sk_nightmare &&
-            !(crispy->fast && !demoplayback) && actor->movecount)
+            !critical->fast && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;
@@ -2022,9 +2021,8 @@ void A_SerpentChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
+    if (gameskill == sk_nightmare || (critical->fast))
     {                           // Monsters move faster in nightmare mode
-                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -2061,12 +2059,12 @@ void A_SerpentChase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-// [crispy] fast monsters
+//
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(crispy->fast && !demoplayback))
+            && !(critical->fast))
             P_NewChaseDir(actor);
         return;
     }
@@ -2225,9 +2223,8 @@ void A_SerpentWalk(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
+    if (gameskill == sk_nightmare || (critical->fast))
     {                           // Monsters move faster in nightmare mode
-                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -2264,12 +2261,12 @@ void A_SerpentWalk(mobj_t * actor)
 
 //
 // don't attack twice in a row
-// [crispy] fast monsters
+//
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(crispy->fast && !demoplayback))
+            && !(critical->fast))
             P_NewChaseDir(actor);
         return;
     }
@@ -4612,9 +4609,8 @@ void A_FastChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
+    if (gameskill == sk_nightmare || (critical->fast))
     {                           // Monsters move faster in nightmare mode
-                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -4651,12 +4647,12 @@ void A_FastChase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-// [crispy] fast monsters
+//
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(crispy->fast && !demoplayback))
+            && !(critical->fast))
             P_NewChaseDir(actor);
         return;
     }
@@ -4692,11 +4688,11 @@ void A_FastChase(mobj_t * actor)
 
 //
 // check for missile attack
-// [crispy] fast monsters
+//
     if (actor->info->missilestate)
     {
         if (gameskill < sk_nightmare &&
-            !(crispy->fast && !demoplayback) && actor->movecount)
+            !(critical->fast) && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -2021,7 +2021,7 @@ void A_SerpentChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (critical->fast))
+    if (gameskill == sk_nightmare || critical->fast)
     {                           // Monsters move faster in nightmare mode
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
@@ -2064,7 +2064,7 @@ void A_SerpentChase(mobj_t * actor)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(critical->fast))
+            && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -2223,7 +2223,7 @@ void A_SerpentWalk(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (critical->fast))
+    if (gameskill == sk_nightmare || critical->fast)
     {                           // Monsters move faster in nightmare mode
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
@@ -2266,7 +2266,7 @@ void A_SerpentWalk(mobj_t * actor)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(critical->fast))
+            && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -4609,7 +4609,7 @@ void A_FastChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare || (critical->fast))
+    if (gameskill == sk_nightmare || critical->fast)
     {                           // Monsters move faster in nightmare mode
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
@@ -4652,7 +4652,7 @@ void A_FastChase(mobj_t * actor)
     {
         actor->flags &= ~MF_JUSTATTACKED;
         if (gameskill != sk_nightmare
-            && !(critical->fast))
+            && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -2063,8 +2063,7 @@ void A_SerpentChase(mobj_t * actor)
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare
-            && !critical->fast)
+        if (gameskill != sk_nightmare && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -2265,8 +2264,7 @@ void A_SerpentWalk(mobj_t * actor)
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare
-            && !critical->fast)
+        if (gameskill != sk_nightmare && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -4691,8 +4689,7 @@ void A_FastChase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount
-            && !critical->fast)
+        if (gameskill < sk_nightmare && actor->movecount && !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -687,8 +687,9 @@ void A_Chase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare)
+    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
     {                           // Monsters move faster in nightmare mode
+                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -725,11 +726,12 @@ void A_Chase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-//
+// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare)
+        if (gameskill != sk_nightmare
+            && !(crispy->fast && !demoplayback))
             P_NewChaseDir(actor);
         return;
     }
@@ -749,10 +751,11 @@ void A_Chase(mobj_t * actor)
 
 //
 // check for missile attack
-//
+// [crispy] fast monsters
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount)
+        if (gameskill < sk_nightmare &&
+            !(crispy->fast && !demoplayback) && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;
@@ -2019,8 +2022,9 @@ void A_SerpentChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare)
+    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
     {                           // Monsters move faster in nightmare mode
+                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -2057,11 +2061,12 @@ void A_SerpentChase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-//
+// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare)
+        if (gameskill != sk_nightmare
+            && !(crispy->fast && !demoplayback))
             P_NewChaseDir(actor);
         return;
     }
@@ -2220,8 +2225,9 @@ void A_SerpentWalk(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare)
+    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
     {                           // Monsters move faster in nightmare mode
+                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -2258,11 +2264,12 @@ void A_SerpentWalk(mobj_t * actor)
 
 //
 // don't attack twice in a row
-//
+// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare)
+        if (gameskill != sk_nightmare
+            && !(crispy->fast && !demoplayback))
             P_NewChaseDir(actor);
         return;
     }
@@ -4605,8 +4612,9 @@ void A_FastChase(mobj_t * actor)
         actor->threshold--;
     }
 
-    if (gameskill == sk_nightmare)
+    if (gameskill == sk_nightmare || (crispy->fast && !demoplayback))
     {                           // Monsters move faster in nightmare mode
+                                // [crispy] fast monsters
         actor->tics -= actor->tics / 2;
         if (actor->tics < 3)
         {
@@ -4643,11 +4651,12 @@ void A_FastChase(mobj_t * actor)
 
 //
 // don't attack twice in a row
-//
+// [crispy] fast monsters
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare)
+        if (gameskill != sk_nightmare
+            && !(crispy->fast && !demoplayback))
             P_NewChaseDir(actor);
         return;
     }
@@ -4683,10 +4692,11 @@ void A_FastChase(mobj_t * actor)
 
 //
 // check for missile attack
-//
+// [crispy] fast monsters
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount)
+        if (gameskill < sk_nightmare &&
+            !(crispy->fast && !demoplayback) && actor->movecount)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -729,8 +729,7 @@ void A_Chase(mobj_t * actor)
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare
-            && !critical->fast)
+        if (gameskill != sk_nightmare && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }
@@ -753,8 +752,7 @@ void A_Chase(mobj_t * actor)
 //
     if (actor->info->missilestate)
     {
-        if (gameskill < sk_nightmare && actor->movecount
-            && !critical->fast)
+        if (gameskill < sk_nightmare && actor->movecount && !critical->fast)
             goto nomissile;
         if (!P_CheckMissileRange(actor))
             goto nomissile;
@@ -4649,8 +4647,7 @@ void A_FastChase(mobj_t * actor)
     if (actor->flags & MF_JUSTATTACKED)
     {
         actor->flags &= ~MF_JUSTATTACKED;
-        if (gameskill != sk_nightmare
-            && !critical->fast)
+        if (gameskill != sk_nightmare && !critical->fast)
             P_NewChaseDir(actor);
         return;
     }

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -164,9 +164,8 @@ boolean P_GiveMana(player_t * player, manatype_t mana, int count)
         return (false);
     }
     if (gameskill == sk_baby || gameskill == sk_nightmare
-                             || (crispy->moreammo && !demoplayback))
+                             || critical->moreammo)
     {                           // extra mana in baby mode and nightmare mode
-                                // [crispy] more mana
         count += count >> 1;
     }
     prevMana = player->mana[mana];
@@ -1683,9 +1682,8 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             superCount = player->inventory[i].count;
         }
     }
-    if ((gameskill == sk_baby || crispy->autohealth) && (normalCount * 25 >= saveHealth))
+    if ((gameskill == sk_baby || critical->autohealth) && (normalCount * 25 >= saveHealth))
     {                           // Use quartz flasks
-                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         for (i = 0; i < count; i++)
         {
@@ -1702,10 +1700,9 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             P_PlayerRemoveArtifact(player, superSlot);
         }
     }
-    else if ((gameskill == sk_baby || crispy->autohealth)
+    else if ((gameskill == sk_baby || critical->autohealth)
              && (superCount * 100 + normalCount * 25 >= saveHealth))
     {                           // Use mystic urns and quartz flasks
-                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         saveHealth -= count * 25;
         for (i = 0; i < count; i++)
@@ -2189,9 +2186,8 @@ void P_PoisonDamage(player_t * player, mobj_t * source, int damage,
         return;
     }
     if (damage >= player->health
-        && ((gameskill == sk_baby) || deathmatch || crispy->autohealth) && !player->morphTics)
+        && ((gameskill == sk_baby) || deathmatch || critical->autohealth) && !player->morphTics)
     {                           // Try to use some inventory health
-                                // [crispy] auto health
         P_AutoUseHealth(player, damage - player->health + 1);
     }
     player->health -= damage;   // mirror mobj health here for Dave

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -164,7 +164,7 @@ boolean P_GiveMana(player_t * player, manatype_t mana, int count)
         return (false);
     }
     if (gameskill == sk_baby || gameskill == sk_nightmare
-                             || crispy->moreammo && !demoplayback)
+                             || (crispy->moreammo && !demoplayback))
     {                           // extra mana in baby mode and nightmare mode
                                 // [crispy] more mana
         count += count >> 1;

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -1683,8 +1683,9 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             superCount = player->inventory[i].count;
         }
     }
-    if ((gameskill == sk_baby) && (normalCount * 25 >= saveHealth))
+    if ((gameskill == sk_baby || crispy->autohealth) && (normalCount * 25 >= saveHealth))
     {                           // Use quartz flasks
+                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         for (i = 0; i < count; i++)
         {
@@ -1701,9 +1702,10 @@ void P_AutoUseHealth(player_t * player, int saveHealth)
             P_PlayerRemoveArtifact(player, superSlot);
         }
     }
-    else if ((gameskill == sk_baby)
+    else if ((gameskill == sk_baby || crispy->autohealth)
              && (superCount * 100 + normalCount * 25 >= saveHealth))
     {                           // Use mystic urns and quartz flasks
+                                // [crispy] auto health
         count = (saveHealth + 24) / 25;
         saveHealth -= count * 25;
         for (i = 0; i < count; i++)
@@ -2187,8 +2189,9 @@ void P_PoisonDamage(player_t * player, mobj_t * source, int damage,
         return;
     }
     if (damage >= player->health
-        && ((gameskill == sk_baby) || deathmatch) && !player->morphTics)
+        && ((gameskill == sk_baby) || deathmatch || crispy->autohealth) && !player->morphTics)
     {                           // Try to use some inventory health
+                                // [crispy] auto health
         P_AutoUseHealth(player, damage - player->health + 1);
     }
     player->health -= damage;   // mirror mobj health here for Dave

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -163,8 +163,10 @@ boolean P_GiveMana(player_t * player, manatype_t mana, int count)
     {
         return (false);
     }
-    if (gameskill == sk_baby || gameskill == sk_nightmare)
+    if (gameskill == sk_baby || gameskill == sk_nightmare
+                             || crispy->moreammo && !demoplayback)
     {                           // extra mana in baby mode and nightmare mode
+                                // [crispy] more mana
         count += count >> 1;
     }
     prevMana = player->mana[mana];

--- a/src/hexen/p_mobj.c
+++ b/src/hexen/p_mobj.c
@@ -1186,7 +1186,8 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
     mobj->flags2 = info->flags2;
     mobj->damage = info->damage;
     mobj->health = info->spawnhealth;
-    if (gameskill != sk_nightmare)
+    // [crispy] fast monsters
+    if (gameskill != sk_nightmare && !(crispy->fast && !demoplayback))
     {
         mobj->reactiontime = info->reactiontime;
     }

--- a/src/hexen/p_mobj.c
+++ b/src/hexen/p_mobj.c
@@ -1186,8 +1186,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
     mobj->flags2 = info->flags2;
     mobj->damage = info->damage;
     mobj->health = info->spawnhealth;
-    // [crispy] fast monsters
-    if (gameskill != sk_nightmare && !(crispy->fast && !demoplayback))
+    if (gameskill != sk_nightmare && !critical->fast)
     {
         mobj->reactiontime = info->reactiontime;
     }

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1640,6 +1640,16 @@ void D_DoomMain (void)
 
     fastparm = M_CheckParm ("-fast");
 
+    //!
+    // @category game
+    // @category mod
+    //
+    // Double ammo pickup rate. This option is not allowed when recording a
+    // demo, playing back a demo or when starting a network game.
+    //
+
+    crispy->moreammo = M_ParmExists("-doubleammo");
+
     I_DisplayFPSDots(devparm);
 
     // haleyjd 20110206 [STRIFE]: -devparm implies -nograph

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -694,6 +694,19 @@ void G_DoLoadLevel (void)
         memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
 
+    // [crispy] update the "singleplayer" variable
+    CheckCrispySingleplayer(!demorecording && !demoplayback && !netgame);
+
+    // [crispy] double ammo
+    if (crispy->moreammo && !crispy->singleplayer)
+    {
+        const char message[] = "The -doubleammo option is not supported"
+                               " for demos and\n"
+                               " network play.";
+        if (!demo_p) demorecording = false;
+        I_Error(message);
+    }
+
     P_SetupLevel (gamemap, 0, gameskill);    
     displayplayer = consoleplayer;      // view the guy you are playing    
     starttime = I_GetTime(); // haleyjd 20110204 [STRIFE]

--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -84,7 +84,7 @@ boolean P_GiveAmmo(player_t* player, ammotype_t ammo, int num)
 
     if(gameskill == sk_baby
         || gameskill == sk_nightmare
-        || crispy->moreammo && !demoplayback)
+        || (crispy->moreammo && !demoplayback))
     {
         // give double ammo in trainer mode,
         // you'll need in nightmare

--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -84,11 +84,10 @@ boolean P_GiveAmmo(player_t* player, ammotype_t ammo, int num)
 
     if(gameskill == sk_baby
         || gameskill == sk_nightmare
-        || (crispy->moreammo && !demoplayback))
+        || critical->moreammo)
     {
         // give double ammo in trainer mode,
         // you'll need in nightmare
-        // [crispy] double ammo
         num <<= 1;
     }
 

--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -83,10 +83,12 @@ boolean P_GiveAmmo(player_t* player, ammotype_t ammo, int num)
         num = clipammo[ammo]/2;
 
     if(gameskill == sk_baby
-        || gameskill == sk_nightmare)
+        || gameskill == sk_nightmare
+        || crispy->moreammo && !demoplayback)
     {
         // give double ammo in trainer mode,
         // you'll need in nightmare
+        // [crispy] double ammo
         num <<= 1;
     }
 


### PR DESCRIPTION
Implements #790. Additional command line parameters for customizing difficulty as per https://doomwiki.org/wiki/Skill_level.

**Doom**
- `-doubleammo` double ammo pickup rate. Demo incompatible.

**Heretic**
- `-fast` fast monsters. Demo incompatible.
- `-moreammo` 50% more ammo pickup rate. Demo incompatible.
- `-autohealth` automatic use of Quartz flasks and Mystic urns.
- `-keysloc` keys are displayed on the automap.

**Hexen**
- `-fast` fast monsters. Demo incompatible.
- `-moremana` 50% more mana pickup rate. Demo incompatible.
- `-autohealth` automatic use of Quartz flasks and Mystic urns.

**Strife**
- `-doubleammo` double ammo pickup rate. Demo incompatible.