### PR TITLE
Demo pause and fast-forward

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -972,7 +972,30 @@ static void SetMouseButtons(unsigned int buttons_mask)
 // Get info needed to make ticcmd_ts for the players.
 // 
 boolean G_Responder (event_t* ev) 
-{ 
+{
+    // [crispy] demo fast-forward
+    if (ev->type == ev_keydown && ev->data1 == key_demospeed && 
+        (demoplayback || gamestate == GS_DEMOSCREEN))
+    {
+        if (singletics == false)
+        singletics = true;
+        else singletics = false;
+    }
+
+    // [crispy] demo pause (from prboom-plus)
+    if (gameaction == ga_nothing && 
+        (demoplayback || gamestate == GS_DEMOSCREEN))
+    {
+         if (ev->type == ev_keydown && ev->data1 == key_pause)
+    {
+              if (paused ^= 2)
+                S_PauseSound();
+              else
+                S_ResumeSound();
+              return true;
+    }
+    }
+ 
     // allow spy mode changes even during the demo
     if (gamestate == GS_LEVEL && ev->type == ev_keydown 
      && ev->data1 == key_spy && (singledemo || !deathmatch) )
@@ -1184,7 +1207,12 @@ void G_Ticker (void)
 	    break; 
 	} 
     }
-    
+
+    // [crispy] demo sync of revenant tracers and RNG (from prboom-plus)
+    if (paused & 2 || (!demoplayback && menuactive && !netgame))
+        demostarttic++;
+    else
+    {     
     // get commands, check consistancy,
     // and build new consistancy check
     buf = (gametic/ticdup)%BACKUPTICS; 
@@ -1197,7 +1225,8 @@ void G_Ticker (void)
 
 	    memcpy(cmd, &netcmds[i], sizeof(ticcmd_t));
 
-	    if (demoplayback) 
+        // [crispy] don't read input from demo when paused
+	    if (demoplayback && !paused)
 		G_ReadDemoTiccmd (cmd); 
 	    // [crispy] do not record tics while still playing back in demo continue mode
 	    if (demorecording && !demoplayback)
@@ -1285,6 +1314,7 @@ void G_Ticker (void)
 	    } 
 	}
     }
+    }
 
     // Have we just finished displaying an intermission screen?
 
@@ -1295,6 +1325,14 @@ void G_Ticker (void)
 
     oldgamestate = gamestate;
     oldleveltime = leveltime;
+
+    // [crispy] no pause at intermission screen during demo playback 
+    // to avoid desyncs (from prboom-plus)
+    if ((paused & 2 || (!demoplayback && menuactive && !netgame)) 
+        && gamestate != GS_LEVEL)
+    {
+    return;
+    }
     
     // do main actions
     switch (gamestate) 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -980,6 +980,7 @@ boolean G_Responder (event_t* ev)
         if (singletics == false)
         singletics = true;
         else singletics = false;
+        return true;
     }
 
     // [crispy] demo pause (from prboom-plus)
@@ -2392,6 +2393,8 @@ void G_DoNewGame (void)
     netdemo = false;
     netgame = false;
     deathmatch = false;
+    // [crispy] reset game speed after demo fast-forward
+    singletics = false;
     playeringame[1] = playeringame[2] = playeringame[3] = 0;
     // [crispy] do not reset -respawn, -fast and -nomonsters parameters
     /*

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -452,6 +452,12 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_speed),
 
     //!
+    // Keyboard key to fast-forward through a demo.
+    //
+
+    CONFIG_VARIABLE_KEY(key_demospeed),
+
+    //!
     // If non-zero, mouse input is enabled.  If zero, mouse input is
     // disabled.
     //

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -42,6 +42,7 @@ int key_fire = KEY_RCTRL;
 int key_use = ' ';
 int key_strafe = KEY_RALT;
 int key_speed = KEY_RSHIFT; 
+int key_demospeed = KEYP_PLUS; // [crispy]
 int key_toggleautorun = KEY_CAPSLOCK; // [crispy]
 int key_togglenovert = 0; // [crispy]
 
@@ -249,6 +250,7 @@ void M_BindBaseControls(void)
     M_BindIntVariable("key_use",            &key_use);
     M_BindIntVariable("key_strafe",         &key_strafe);
     M_BindIntVariable("key_speed",          &key_speed);
+    M_BindIntVariable("key_demospeed",      &key_demospeed); // [crispy]
 
     M_BindIntVariable("mouseb_fire",        &mousebfire);
     M_BindIntVariable("mouseb_strafe",      &mousebstrafe);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -33,6 +33,7 @@ extern int key_fire;
 extern int key_use;
 extern int key_strafe;
 extern int key_speed;
+extern int key_demospeed;  // [crispy]
 
 extern int key_jump;
 extern int key_toggleautorun;

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -56,7 +56,7 @@ static int *controls[] = { &key_left, &key_right, &key_up, &key_down,
                            &key_arti_blastradius, &key_arti_teleport,
                            &key_arti_teleportother, &key_arti_egg,
                            &key_arti_invulnerability,
-                           &key_prevweapon, &key_nextweapon, NULL };
+                           &key_prevweapon, &key_nextweapon, &key_demospeed, NULL };
 
 static int *menu_nav[] = { &key_menu_activate, &key_menu_up, &key_menu_down,
                            &key_menu_left, &key_menu_right, &key_menu_back,
@@ -392,6 +392,7 @@ static void OtherKeysDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 
     AddKeyControl(table, "Display last message",  &key_message_refresh);
     AddKeyControl(table, "Finish recording demo", &key_demo_quit);
+    AddKeyControl(table, "Fast-forward demo",     &key_demospeed);
 
     AddSectionLabel(table, "Map", true);
     AddKeyControl(table, "Toggle map",            &key_map_toggle);

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -58,6 +58,7 @@ static void SensibleDefaults(void)
     key_down = 's';
     key_strafeleft = 'a';
     key_straferight = 'd';
+    key_demospeed = KEYP_PLUS;  // [crispy]
     key_jump = '/';
     key_lookup = KEY_PGUP;
     key_lookdown = KEY_PGDN;


### PR DESCRIPTION
1) Adaptation of demo pausing code and associated demo sync safeguards from prboom-plus.
Used existing _demostarttic_ instead of prboom-plus' _basetic_.
Fixes #463.

2) FF implemented as a simple toggle using _singletics_ (employed by _-timedemo_). Default key set to <kbd>Numpad+</kbd>.
The speed of fast-forward will be dependent on the VSync setting. 
With VSync ON the speed will depend on the display's refresh rate, e.g. 170% speed at 60Hz, 200% at 70hz, 400% at 144hz.
With VSync OFF FF will go as fast as possible. 