### PR TITLE
Demo pause and fast-forward

### DIFF
--- a/src/m_config.c
+++ b/src/m_config.c
@@ -452,6 +452,12 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_speed),
 
     //!
+    // Keyboard key to fast-forward through a demo.
+    //
+
+    CONFIG_VARIABLE_KEY(key_demospeed),
+
+    //!
     // If non-zero, mouse input is enabled.  If zero, mouse input is
     // disabled.
     //

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -42,6 +42,7 @@ int key_fire = KEY_RCTRL;
 int key_use = ' ';
 int key_strafe = KEY_RALT;
 int key_speed = KEY_RSHIFT; 
+int key_demospeed = KEYP_PLUS; // [crispy]
 int key_toggleautorun = KEY_CAPSLOCK; // [crispy]
 int key_togglenovert = 0; // [crispy]
 
@@ -249,6 +250,7 @@ void M_BindBaseControls(void)
     M_BindIntVariable("key_use",            &key_use);
     M_BindIntVariable("key_strafe",         &key_strafe);
     M_BindIntVariable("key_speed",          &key_speed);
+    M_BindIntVariable("key_demospeed",      &key_demospeed); // [crispy]
 
     M_BindIntVariable("mouseb_fire",        &mousebfire);
     M_BindIntVariable("mouseb_strafe",      &mousebstrafe);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -33,6 +33,7 @@ extern int key_fire;
 extern int key_use;
 extern int key_strafe;
 extern int key_speed;
+extern int key_demospeed;  // [crispy]
 
 extern int key_jump;
 extern int key_toggleautorun;

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -56,7 +56,7 @@ static int *controls[] = { &key_left, &key_right, &key_up, &key_down,
                            &key_arti_blastradius, &key_arti_teleport,
                            &key_arti_teleportother, &key_arti_egg,
                            &key_arti_invulnerability,
-                           &key_prevweapon, &key_nextweapon, NULL };
+                           &key_prevweapon, &key_nextweapon, &key_demospeed, NULL };
 
 static int *menu_nav[] = { &key_menu_activate, &key_menu_up, &key_menu_down,
                            &key_menu_left, &key_menu_right, &key_menu_back,
@@ -392,6 +392,7 @@ static void OtherKeysDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 
     AddKeyControl(table, "Display last message",  &key_message_refresh);
     AddKeyControl(table, "Finish recording demo", &key_demo_quit);
+    AddKeyControl(table, "Fast-forward demo",     &key_demospeed);
 
     AddSectionLabel(table, "Map", true);
     AddKeyControl(table, "Toggle map",            &key_map_toggle);

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -58,6 +58,7 @@ static void SensibleDefaults(void)
     key_down = 's';
     key_strafeleft = 'a';
     key_straferight = 'd';
+    key_demospeed = KEYP_PLUS;  // [crispy]
     key_jump = '/';
     key_lookup = KEY_PGUP;
     key_lookdown = KEY_PGDN;


### PR DESCRIPTION
1) Adaptation of demo pausing code and associated demo sync safeguards from prboom-plus.
Used existing 'demostarttic' instead of prb+'s 'basetic'.
Fixes #463.

2) FF implemented as a simple toggle using 'singletics' (employed by '-timedemo'). Default key set to Numpad-Plus.
The speed of fast-forward will be dependent on the VSync setting. 
With VSync ON the speed will depend on the display's refresh rate, e.g. 170% speed @60Hz, 200% @70hz, 400% @144hz.
With VSync OFF FF will go as fast as possible.

3) Incorporates the changes requested in the previous PR. Still not sure if I got the indentation right.
As for demo-continue mode this PR doesn't seem to disrupt it but again I'm not sure I fully understand how to use that mode. The way I see it you can only take over at the end of the first demo, and get a blank screen until then, whereas it doesn't make sense to use Pause during the blank screen as doing so has no visible effect.