### PR TITLE
Demo fast-forward

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -973,6 +973,14 @@ static void SetMouseButtons(unsigned int buttons_mask)
 // 
 boolean G_Responder (event_t* ev) 
 { 
+    // [crispy] demo fast-forward
+    if (ev->type == ev_keydown && ev->data1 == key_demospeed && 
+        (demoplayback || gamestate == GS_DEMOSCREEN))
+    {
+        singletics = !singletics;
+        return true;
+    }
+ 
     // allow spy mode changes even during the demo
     if (gamestate == GS_LEVEL && ev->type == ev_keydown 
      && ev->data1 == key_spy && (singledemo || !deathmatch) )
@@ -2354,6 +2362,8 @@ void G_DoNewGame (void)
     netdemo = false;
     netgame = false;
     deathmatch = false;
+    // [crispy] reset game speed after demo fast-forward
+    singletics = false;
     playeringame[1] = playeringame[2] = playeringame[3] = 0;
     // [crispy] do not reset -respawn, -fast and -nomonsters parameters
     /*

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -452,6 +452,12 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_speed),
 
     //!
+    // Keyboard key to fast-forward through a demo.
+    //
+
+    CONFIG_VARIABLE_KEY(key_demospeed),
+
+    //!
     // If non-zero, mouse input is enabled.  If zero, mouse input is
     // disabled.
     //

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -42,6 +42,7 @@ int key_fire = KEY_RCTRL;
 int key_use = ' ';
 int key_strafe = KEY_RALT;
 int key_speed = KEY_RSHIFT; 
+int key_demospeed = KEYP_PLUS; // [crispy]
 int key_toggleautorun = KEY_CAPSLOCK; // [crispy]
 int key_togglenovert = 0; // [crispy]
 
@@ -249,6 +250,7 @@ void M_BindBaseControls(void)
     M_BindIntVariable("key_use",            &key_use);
     M_BindIntVariable("key_strafe",         &key_strafe);
     M_BindIntVariable("key_speed",          &key_speed);
+    M_BindIntVariable("key_demospeed",      &key_demospeed); // [crispy]
 
     M_BindIntVariable("mouseb_fire",        &mousebfire);
     M_BindIntVariable("mouseb_strafe",      &mousebstrafe);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -33,6 +33,7 @@ extern int key_fire;
 extern int key_use;
 extern int key_strafe;
 extern int key_speed;
+extern int key_demospeed;  // [crispy]
 
 extern int key_jump;
 extern int key_toggleautorun;

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -56,7 +56,7 @@ static int *controls[] = { &key_left, &key_right, &key_up, &key_down,
                            &key_arti_blastradius, &key_arti_teleport,
                            &key_arti_teleportother, &key_arti_egg,
                            &key_arti_invulnerability,
-                           &key_prevweapon, &key_nextweapon, NULL };
+                           &key_prevweapon, &key_nextweapon, &key_demospeed, NULL };
 
 static int *menu_nav[] = { &key_menu_activate, &key_menu_up, &key_menu_down,
                            &key_menu_left, &key_menu_right, &key_menu_back,
@@ -392,6 +392,7 @@ static void OtherKeysDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 
     AddKeyControl(table, "Display last message",  &key_message_refresh);
     AddKeyControl(table, "Finish recording demo", &key_demo_quit);
+    AddKeyControl(table, "Fast-forward demo",     &key_demospeed);
 
     AddSectionLabel(table, "Map", true);
     AddKeyControl(table, "Toggle map",            &key_map_toggle);

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -58,6 +58,7 @@ static void SensibleDefaults(void)
     key_down = 's';
     key_strafeleft = 'a';
     key_straferight = 'd';
+    key_demospeed = KEYP_PLUS;  // [crispy]
     key_jump = '/';
     key_lookup = KEY_PGUP;
     key_lookdown = KEY_PGDN;


### PR DESCRIPTION
Split from #799.

Implemented as a simple toggle using 'singletics' (employed by '-timedemo'). Default key set to <kbd>Numpad+</kbd>.
The speed of fast-forward will be dependent on the user's VSync setting. 
With VSync ON the speed will depend on the display's refresh rate, e.g. 170% speed at 60Hz, 200% at 70hz, 400% at 144hz.
With VSync OFF fast-forward will go as fast as possible.