### PR TITLE
Enable demo pause

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -972,7 +972,7 @@ static void SetMouseButtons(unsigned int buttons_mask)
 // Get info needed to make ticcmd_ts for the players.
 // 
 boolean G_Responder (event_t* ev) 
-{
+{ 
     // [crispy] demo pause (from prboom-plus)
     if (gameaction == ga_nothing && 
         (demoplayback || gamestate == GS_DEMOSCREEN))


### PR DESCRIPTION
Adaptation of demo pausing code and associated demo sync safeguards from prboom-plus.
Uses existing 'demostarttic' instead of prb+'s 'basetic'.
Special thanks to kraflab for his help.
Resolves #463.