### PR TITLE
Heretic/Hexen widescreen improvements

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -469,6 +469,8 @@ void AM_LevelInit(boolean reinit)
     if (scale_mtof > max_scale_mtof)
         scale_mtof = min_scale_mtof;
     scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
+
+    f_h_old = f_h;
 }
 
 static boolean stopped = true;

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -418,7 +418,7 @@ void D_PageTicker(void)
 
 void D_PageDrawer(void)
 {
-    V_DrawRawScreen(W_CacheLumpName(pagename, PU_CACHE));
+    V_DrawFullscreenRawOrPatch(W_GetNumForName(pagename));
     if (demosequence == 1)
     {
         V_DrawPatch(4, 160, W_CacheLumpName(DEH_String("ADVISOR"), PU_CACHE));

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -260,32 +260,62 @@ void F_DemonScroll(void)
 {
     byte *p1, *p2;
     static int yval = 0;
-    static int yval_dest = 0;
+    static int yval_dest = 0; // [crispy]
     static int nextscroll = 0;
+    lumpindex_t i1, i2; // [crispy]
+    int x; // [crispy]
+    patch_t *patch1, *patch2; // [crispy]
+    static int y = 0; // [crispy]
 
     if (finalecount < nextscroll)
     {
         return;
     }
-    p1 = W_CacheLumpName(DEH_String("FINAL1"), PU_LEVEL);
-    p2 = W_CacheLumpName(DEH_String("FINAL2"), PU_LEVEL);
+    i1 = W_GetNumForName(DEH_String("FINAL1"));
+    i2 = W_GetNumForName(DEH_String("FINAL2"));
+    p1 = W_CacheLumpNum(i1, PU_LEVEL);
+    p2 = W_CacheLumpNum(i2, PU_LEVEL);
     if (finalecount < 70)
     {
-        V_CopyScaledBuffer(I_VideoBuffer, p1, ORIGHEIGHT * ORIGWIDTH);
+        V_DrawFullscreenRawOrPatch(i1);
         nextscroll = finalecount;
         return;
     }
     if (yval < 64000)
     {
-        V_CopyScaledBuffer(I_VideoBuffer, p2 + ORIGHEIGHT * ORIGWIDTH - yval, yval);
-        V_CopyScaledBuffer(I_VideoBuffer + yval_dest, p1, ORIGHEIGHT * ORIGWIDTH - yval);
+        if ((W_LumpLength(i1) == 64000) && (W_LumpLength(i2) == 64000))
+        {
+            V_CopyScaledBuffer(I_VideoBuffer, p2 + ORIGHEIGHT * ORIGWIDTH - yval, yval);
+            V_CopyScaledBuffer(I_VideoBuffer + yval_dest, p1, ORIGHEIGHT * ORIGWIDTH - yval);
+
+            yval_dest += SCREENWIDTH << crispy->hires;
+        }
+        else // [crispy] assume that FINAL1 and FINAL2 are in patch format
+        {
+            patch1 = (patch_t *)p1;
+            patch2 = (patch_t *)p2;
+
+            x = ((SCREENWIDTH >> crispy->hires) - SHORT(patch1->width)) / 2
+                - WIDESCREENDELTA;
+
+            // [crispy] pillar boxing
+            if (x > -WIDESCREENDELTA)
+            {
+                V_DrawFilledBox(0, 0, WIDESCREENDELTA + x, SCREENHEIGHT, 0);
+                V_DrawFilledBox(SCREENWIDTH - WIDESCREENDELTA - x, 0,
+                                WIDESCREENDELTA + x, SCREENHEIGHT, 0);
+            }
+
+            V_DrawPatch(x, y - 200, patch2);
+            V_DrawPatch(x, 0 + y, patch1);
+            y++;
+        }
         yval += ORIGWIDTH;
-        yval_dest += SCREENWIDTH << crispy->hires;
         nextscroll = finalecount + 3;
     }
     else
     {                           //else, we'll just sit here and wait, for now
-        V_CopyScaledBuffer(I_VideoBuffer, p2, ORIGWIDTH * ORIGHEIGHT);
+        V_DrawFullscreenRawOrPatch(i2);
     }
 }
 
@@ -320,7 +350,7 @@ void F_DrawUnderwater(void)
                 palette = W_CacheLumpName(lumpname, PU_STATIC);
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
-                V_DrawRawScreen(W_CacheLumpName(DEH_String("E2END"), PU_CACHE));
+                V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("E2END")));
             }
             paused = false;
             MenuActive = false;
@@ -336,7 +366,7 @@ void F_DrawUnderwater(void)
                 W_ReleaseLumpName(lumpname);
                 underwawa = false;
             }
-            V_DrawRawScreen(W_CacheLumpName(DEH_String("TITLE"), PU_CACHE));
+            V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("TITLE")));
             //D_StartTitle(); // go to intro/demo mode.
     }
 }
@@ -423,11 +453,11 @@ void F_Drawer(void)
             case 1:
                 if (gamemode == shareware)
                 {
-                    V_DrawRawScreen(W_CacheLumpName("ORDER", PU_CACHE));
+                    V_DrawFullscreenRawOrPatch(W_GetNumForName("ORDER"));
                 }
                 else
                 {
-                    V_DrawRawScreen(W_CacheLumpName("CREDIT", PU_CACHE));
+                    V_DrawFullscreenRawOrPatch(W_GetNumForName("CREDIT"));
                 }
                 break;
             case 2:
@@ -438,7 +468,7 @@ void F_Drawer(void)
                 break;
             case 4:            // Just show credits screen for extended episodes
             case 5:
-                V_DrawRawScreen(W_CacheLumpName("CREDIT", PU_CACHE));
+                V_DrawFullscreenRawOrPatch(W_GetNumForName("CREDIT"));
                 break;
         }
     }

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -583,21 +583,21 @@ void IN_Drawer(void)
         case 1:                // leaving old level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0, 0, patchINTERPIC);
+                V_DrawPatchFullScreen(patchINTERPIC, false);
                 IN_DrawOldLevel();
             }
             break;
         case 2:                // going to the next level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0, 0, patchINTERPIC);
+                V_DrawPatchFullScreen(patchINTERPIC, false);
                 IN_DrawYAH();
             }
             break;
         case 3:                // waiting before going to the next level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0, 0, patchINTERPIC);
+                V_DrawPatchFullScreen(patchINTERPIC, false);
             }
             break;
         default:

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2033,9 +2033,32 @@ void MN_DeactivateMenu(void)
 
 void MN_DrawInfo(void)
 {
+    lumpindex_t lumpindex; // [crispy]
+
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
-    V_DrawRawScreen(W_CacheLumpNum(W_GetNumForName("TITLE") + InfoType,
-                                   PU_CACHE));
+
+    // [crispy] Refactor to allow for use of V_DrawFullscreenRawOrPatch
+
+    switch (InfoType)
+    {
+        case 1:
+            lumpindex = W_GetNumForName("HELP1");
+            break;
+
+        case 2:
+            lumpindex = W_GetNumForName("HELP2");
+            break;
+
+        case 3:
+            lumpindex = W_GetNumForName("CREDIT");
+            break;
+
+        default:
+            lumpindex = W_GetNumForName("TITLE");
+            break;
+    }
+
+    V_DrawFullscreenRawOrPatch(lumpindex);
 //      V_DrawPatch(0, 0, W_CacheLumpNum(W_GetNumForName("TITLE")+InfoType,
 //              PU_CACHE));
 }

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -77,6 +77,7 @@ void (*tlcolfunc) (void);
 void (*transcolfunc) (void);
 void (*spanfunc) (void);
 
+void SB_ForceRedraw(void); // [crispy] sb_bar.c
 /*
 ===================
 =
@@ -690,6 +691,9 @@ void R_ExecuteSetViewSize(void)
 // draw the border
 //
     R_DrawViewBorder();         // erase old menu stuff
+
+    // [crispy] Redraw status bar, needed for widescreen HUD
+    SB_ForceRedraw();
 }
 
 

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -577,6 +577,12 @@ int playerkeys = 0;
 
 extern boolean automapactive;
 
+// [crispy] Needed to support widescreen status bar.
+void SB_ForceRedraw(void)
+{
+    SB_state = -1;
+}
+
 // [crispy] Create background texture which appears at each side of the status
 // bar in widescreen rendering modes. The chosen textures match those which
 // surround the non-fullscreen game window.
@@ -601,6 +607,18 @@ static void RefreshBackground()
             for (x = 0; x < SCREENWIDTH; x++)
             {
                 *dest++ = src[((y & 63) << 6) + (x & 63)];
+            }
+        }
+
+        // [crispy] preserve bezel bottom edge
+        if (scaledviewwidth == SCREENWIDTH)
+        {
+            patch_t *const patch = W_CacheLumpName("bordb", PU_CACHE);
+
+            for (x = 0; x < WIDESCREENDELTA; x += 16)
+            {
+                V_DrawPatch(x - WIDESCREENDELTA, 0, patch);
+                V_DrawPatch(ORIGWIDTH + WIDESCREENDELTA - x - 16, 0, patch);
             }
         }
     }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -890,7 +890,7 @@ void V_DrawFullscreenRawOrPatch(lumpindex_t index)
     {
         V_DrawRawScreen((pixel_t*)patch);
     }
-    else if ((patch->height == 200) && (patch->width >= 320))
+    else if ((SHORT(patch->height) == 200) && (SHORT(patch->width) >= 320))
     {
         V_DrawPatchFullScreen(patch, false);
     }


### PR DESCRIPTION
Most of this PR is bringing Heretic up to the same level of widescreen support as Hexen. There is also a minor fix to the `V_DrawFullscreenRawOrPatch` function which is used by both Heretic and Hexen.

Attached here is the Heretic widescreen asset pack that I used for testing.
[heretic_ws.zip](https://github.com/fabiangreffrath/crispy-doom/files/7930179/heretic_ws.zip)