### PR TITLE
Deh bfg

### DIFF
--- a/src/doom/deh_thing.c
+++ b/src/doom/deh_thing.c
@@ -60,6 +60,8 @@ static const bex_thingbits_t bex_thingbitstable[] = {
     {"SKULLFLY", MF_SKULLFLY},
     {"NOTDMATCH", MF_NOTDMATCH},
     {"TRANSLUCENT", MF_TRANSLUCENT},
+    // [NS] Beta projectile bouncing.
+    {"BOUNCES", MF_BOUNCES},
     // TRANSLATION consists of 2 bits, not 1
     {"TRANSLATION", 0x04000000},
     {"TRANSLATION1", 0x04000000},

--- a/src/doom/info.c
+++ b/src/doom/info.c
@@ -4869,7 +4869,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	100,		// mass
 	4,		// damage
 	sfx_None,		// activesound
-	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY /* |MF_BOUNCES */,
+	// [NS] Beta projectile bouncing.
+	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES,
 	S_NULL		// raisestate
     },
 
@@ -4895,7 +4896,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	100,		// mass
 	4,		// damage
 	sfx_None,		// activesound
-	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY /* |MF_BOUNCES */,
+	// [NS] Beta projectile bouncing.
+	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES,
 	S_NULL		// raisestate
     },
 

--- a/src/doom/p_bexptr.c
+++ b/src/doom/p_bexptr.c
@@ -243,6 +243,11 @@ void A_FireOldBFG(mobj_t *mobj, player_t *player, pspdef_t *psp)
       th = P_SpawnMobj(mo->x, mo->y,
 		       mo->z + 62*FRACUNIT - player->psprites[ps_weapon].sy,
 		       type);
+      // [NS] Play projectile sound.
+      if (th->info->seesound)
+      {
+	S_StartSound (th, th->info->seesound);
+      }
       th->target = mo; // P_SetTarget(&th->target, mo);
       th->angle = an1;
       th->momx = finecosine[an1>>ANGLETOFINESHIFT] * 25;

--- a/src/doom/p_bexptr.c
+++ b/src/doom/p_bexptr.c
@@ -250,9 +250,10 @@ void A_FireOldBFG(mobj_t *mobj, player_t *player, pspdef_t *psp)
       }
       th->target = mo; // P_SetTarget(&th->target, mo);
       th->angle = an1;
-      th->momx = finecosine[an1>>ANGLETOFINESHIFT] * 25;
-      th->momy = finesine[an1>>ANGLETOFINESHIFT] * 25;
-      th->momz = finetangent[an2>>ANGLETOFINESHIFT] * 25;
+      // [NS] Use speed from thing info.
+      th->momx = FixedMul(th->info->speed, finecosine[an1>>ANGLETOFINESHIFT]);
+      th->momy = FixedMul(th->info->speed, finesine[an1>>ANGLETOFINESHIFT]);
+      th->momz = FixedMul(th->info->speed, finetangent[an2>>ANGLETOFINESHIFT]);
       // [crispy] suppress interpolation of player missiles for the first tic
       th->interp = -1;
       P_CheckMissileSpawn(th);

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -372,6 +372,12 @@ void P_ZMovement (mobj_t* mo)
 	    mo->momz = -mo->momz;
 	}
 	
+	// [NS] Beta projectile bouncing.
+	if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
+	{
+	    mo->momz = -mo->momz;
+	}
+
 	if (mo->momz < 0)
 	{
 	    // [crispy] delay next jump
@@ -414,7 +420,8 @@ void P_ZMovement (mobj_t* mo)
             mo->momz = -mo->momz;
 
 	if ( (mo->flags & MF_MISSILE)
-	     && !(mo->flags & MF_NOCLIP) )
+	     // [NS] Beta projectile bouncing.
+	     && !(mo->flags & MF_NOCLIP) && !(mo->flags & MF_BOUNCES) )
 	{
 	    P_ExplodeMissile (mo);
 	    return;
@@ -430,6 +437,13 @@ void P_ZMovement (mobj_t* mo)
 	
     if (mo->z + mo->height > mo->ceilingz)
     {
+	// [NS] Beta projectile bouncing.
+	if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
+	{
+	    mo->momz = -mo->momz;
+	    mo->z = mo->ceilingz - mo->height;
+	}
+
 	// hit the ceiling
 	if (mo->momz > 0)
 	    mo->momz = 0;
@@ -443,7 +457,7 @@ void P_ZMovement (mobj_t* mo)
 	}
 	
 	if ( (mo->flags & MF_MISSILE)
-	     && !(mo->flags & MF_NOCLIP) )
+	     && !(mo->flags & MF_NOCLIP) && !(mo->flags & MF_BOUNCES) )
 	{
 	    P_ExplodeMissile (mo);
 	    return;

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -372,12 +372,6 @@ void P_ZMovement (mobj_t* mo)
 	    mo->momz = -mo->momz;
 	}
 	
-	// [NS] Beta projectile bouncing.
-	if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
-	{
-	    mo->momz = -mo->momz;
-	}
-
 	if (mo->momz < 0)
 	{
 	    // [crispy] delay next jump
@@ -405,7 +399,15 @@ void P_ZMovement (mobj_t* mo)
 		    }
 		}
 	    }
+	    // [NS] Beta projectile bouncing.
+	    if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
+	    {
+		mo->momz = -mo->momz;
+	    }
+	    else
+	    {
 	    mo->momz = 0;
+	    }
 	}
 	mo->z = mo->floorz;
 
@@ -437,17 +439,18 @@ void P_ZMovement (mobj_t* mo)
 	
     if (mo->z + mo->height > mo->ceilingz)
     {
-	// [NS] Beta projectile bouncing.
-	if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
-	{
-	    mo->momz = -mo->momz;
-	    mo->z = mo->ceilingz - mo->height;
-	}
-
 	// hit the ceiling
 	if (mo->momz > 0)
-	    mo->momz = 0;
 	{
+	// [NS] Beta projectile bouncing.
+	    if ( (mo->flags & MF_MISSILE) && (mo->flags & MF_BOUNCES) )
+	    {
+		mo->momz = -mo->momz;
+	    }
+	    else
+	    {
+		mo->momz = 0;
+	    }
 	    mo->z = mo->ceilingz - mo->height;
 	}
 

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -449,8 +449,10 @@ void P_ZMovement (mobj_t* mo)
 	    }
 	    else
 	    {
-		mo->momz = 0;
+	    mo->momz = 0;
 	    }
+	}
+	{
 	    mo->z = mo->ceilingz - mo->height;
 	}
 

--- a/src/doom/p_mobj.h
+++ b/src/doom/p_mobj.h
@@ -194,6 +194,9 @@ typedef enum
     // Hmm ???.
     MF_TRANSSHIFT	= 26,
 
+    // [NS] Beta projectile bouncing.
+    MF_BOUNCES		= 0x20000000,
+
     // [crispy] randomly flip corpse, blood and death animation sprites
     MF_FLIPPABLE        = 0x40000000,
 


### PR DESCRIPTION
This change does three things to bring the beta BFG function and projectiles more in line with ZDoom's implementation (and moddability besides):
- Makes the BOUNCES flag functional for missiles, allowing simple bouncing off planes.
- Makes A_FireOldBFG use the missile's speed instead of a hardcoded 25.
- Makes the beta plasma shots play their seesound. (Firing 80 of these in just over a second results in a minor cacophony, but a DEH patch can just as easily mute them again.)