### PR TITLE
Bind additional valid variables in setup

### DIFF
--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -105,6 +105,16 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
         M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
         M_BindIntVariable("crispy_vsync",           &crispy->vsync);
+        M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);
+    }
+    else if (gamemission == hexen)
+    {
+        M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
+        M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
+        M_BindIntVariable("crispy_hires",           &crispy->hires);
+        M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
+        M_BindIntVariable("crispy_vsync",           &crispy->vsync);
+        M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);
     }
     else
     {


### PR DESCRIPTION
Sorry to have overlooked this previously. There are a handful of other variables that setup and Heretic/Hexen have binding conflicts over: there are the a11y variables (which I don't think are used yet in Heretic/Hexen), a few y-axis mouse configs and also `video_display`. If you want I can try to address those here as well.

Fixes #838.