### PR TITLE
Implement mouse smoothing when running uncapped

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -209,6 +209,7 @@ void NetUpdate (void)
     int nowtime;
     int newtics;
     int	i;
+    extern fixed_t fractionaltic; // [crispy]
 
     // If we are running with singletics (timing a demo), this
     // is all done separately.
@@ -226,6 +227,12 @@ void NetUpdate (void)
     newtics = nowtime - lasttime;
 
     lasttime = nowtime;
+
+    // [AM] Figure out how far into the current tic we're in as a fixed_t.
+    if (crispy->uncapped)
+    {
+	fractionaltic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+    }
 
     if (skiptics <= newtics)
     {

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -209,7 +209,6 @@ void NetUpdate (void)
     int nowtime;
     int newtics;
     int	i;
-    extern fixed_t fractionaltic; // [crispy]
 
     // If we are running with singletics (timing a demo), this
     // is all done separately.
@@ -227,12 +226,6 @@ void NetUpdate (void)
     newtics = nowtime - lasttime;
 
     lasttime = nowtime;
-
-    // [AM] Figure out how far into the current tic we're in as a fixed_t.
-    if (crispy->uncapped)
-    {
-	fractionaltic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
-    }
 
     if (skiptics <= newtics)
     {

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -26,6 +26,9 @@
 #include "i_input.h"
 #include "m_argv.h"
 #include "m_config.h"
+#include "m_fixed.h" // [crispy]
+
+#include "crispy.h"
 
 static const int scancode_translate_table[] = SCANCODE_TO_KEYS_ARRAY;
 
@@ -445,6 +448,31 @@ static int AccelerateMouseY(int val)
     }
 }
 
+// [crispy] Distribute the mouse movement between the current tic and the next
+// based on how far we are into the current tic. Compensates for mouse sampling
+// jitter.
+static void SmoothMouse(int* x, int* y)
+{
+    static int x_remainder_old = 0;
+    static int y_remainder_old = 0;
+    int x_remainder, y_remainder;
+    fixed_t correction_factor;
+    extern fixed_t fractionaltic;
+
+    *x += x_remainder_old;
+    *y += y_remainder_old;
+
+    correction_factor = FixedDiv(fractionaltic, FRACUNIT + fractionaltic);
+
+    x_remainder = FixedMul(*x, correction_factor);
+    *x -= x_remainder;
+    x_remainder_old = x_remainder;
+
+    y_remainder = FixedMul(*y, correction_factor);
+    *y -= y_remainder;
+    y_remainder_old = y_remainder;
+}
+
 //
 // Read the change in mouse state to generate mouse motion events
 //
@@ -456,6 +484,11 @@ void I_ReadMouse(void)
     event_t ev;
 
     SDL_GetRelativeMouseState(&x, &y);
+
+    if (crispy->uncapped)
+    {
+        SmoothMouse(&x, &y);
+    }
 
     if (x != 0 || y != 0) 
     {

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -24,6 +24,7 @@
 #include "doomtype.h"
 #include "d_event.h"
 #include "i_input.h"
+#include "i_timer.h" // [crispy]
 #include "m_argv.h"
 #include "m_config.h"
 #include "m_fixed.h" // [crispy]
@@ -457,12 +458,13 @@ static void SmoothMouse(int* x, int* y)
     static int y_remainder_old = 0;
     int x_remainder, y_remainder;
     fixed_t correction_factor;
-    extern fixed_t fractionaltic;
+    fixed_t fractic;
 
     *x += x_remainder_old;
     *y += y_remainder_old;
 
-    correction_factor = FixedDiv(fractionaltic, FRACUNIT + fractionaltic);
+    fractic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+    correction_factor = FixedDiv(fractic, FRACUNIT + fractic);
 
     x_remainder = FixedMul(*x, correction_factor);
     *x -= x_remainder;

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -463,7 +463,7 @@ static void SmoothMouse(int* x, int* y)
     *x += x_remainder_old;
     *y += y_remainder_old;
 
-    fractic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+    fractic = I_GetFracRealTime();
     correction_factor = FixedDiv(fractic, FRACUNIT + fractic);
 
     x_remainder = FixedMul(*x, correction_factor);

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -19,6 +19,7 @@
 #include "SDL.h"
 
 #include "i_timer.h"
+#include "m_fixed.h" // [crispy]
 #include "doomtype.h"
 
 //
@@ -80,3 +81,9 @@ void I_InitTimer(void)
     SDL_Init(SDL_INIT_TIMER);
 }
 
+// [crispy]
+
+fixed_t I_GetFracRealTime(void)
+{
+    return (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+}

--- a/src/i_timer.h
+++ b/src/i_timer.h
@@ -20,6 +20,8 @@
 #ifndef __I_TIMER__
 #define __I_TIMER__
 
+#include "m_fixed.h" // [crispy]
+
 #define TICRATE 35
 
 // Called by D_DoomLoop,
@@ -38,5 +40,7 @@ void I_InitTimer(void);
 // Wait for vertical retrace or pause a bit.
 void I_WaitVBL(int count);
 
+// [crispy]
+fixed_t I_GetFracRealTime(void);
 #endif
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -895,7 +895,7 @@ void I_FinishUpdate (void)
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     if (crispy->uncapped)
     {
-	fractionaltic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+	fractionaltic = I_GetFracRealTime();
     }
 
     // Restore background and undo the disk indicator, if it was drawn.

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -892,6 +892,12 @@ void I_FinishUpdate (void)
 
     SDL_RenderPresent(renderer);
 
+    // [AM] Figure out how far into the current tic we're in as a fixed_t.
+    if (crispy->uncapped)
+    {
+	fractionaltic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+    }
+
     // Restore background and undo the disk indicator, if it was drawn.
     V_RestoreDiskBackground();
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -892,12 +892,6 @@ void I_FinishUpdate (void)
 
     SDL_RenderPresent(renderer);
 
-    // [AM] Figure out how far into the current tic we're in as a fixed_t.
-    if (crispy->uncapped)
-    {
-	fractionaltic = (int64_t)I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
-    }
-
     // Restore background and undo the disk indicator, if it was drawn.
     V_RestoreDiskBackground();
 }


### PR DESCRIPTION
As discussed here: [https://www.doomworld.com/forum/topic/127475-sdl2-v-sync-and-mouse-movement/](url)

The idea behind my fix is to adjust each mouse read in proportion to how late we are sampling the mouse, and then to add the excess to the next tic's mouse values. It is essentially linear interpolation for the mouse movement.

I had to move the `fractionaltic` calculation to `NetUpdate` in order for it to be recent enough to be effective for this correction. Otherwise I need to get a local value in the `SmoothMouse` function. I think the main reason is that `NET_SV_Run` takes a not insignificant amount of time, and you can end up rolling over to the new tic while running that function. In that case `fractionaltic` might be some high value around 0.9.