### PR TITLE
Simplify b-map lighting

### DIFF
--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -174,7 +174,7 @@ R_MapPlane
 	    index = MAXLIGHTZ-1;
 
 	ds_colormap[0] = planezlight[index];
-	ds_colormap[1] = zlight[LIGHTLEVELS-1][MAXLIGHTZ-1];
+	ds_colormap[1] = colormaps;
     }
 	
     ds_y = y;

--- a/src/doom/r_segs.c
+++ b/src/doom/r_segs.c
@@ -389,7 +389,7 @@ void R_RenderSegLoop (void)
 
 	    // [crispy] optional brightmaps
 	    dc_colormap[0] = walllights[index];
-	    dc_colormap[1] = (!fixedcolormap && (crispy->brightmaps & BRIGHTMAPS_TEXTURES)) ? scalelight[LIGHTLEVELS-1][MAXLIGHTSCALE-1] : dc_colormap[0];
+	    dc_colormap[1] = (!fixedcolormap && (crispy->brightmaps & BRIGHTMAPS_TEXTURES)) ? colormaps : dc_colormap[0];
 	    dc_x = rw_x;
 	    dc_iscale = 0xffffffffu / (unsigned)rw_scale;
 	}

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -780,7 +780,7 @@ void R_ProjectSprite (mobj_t* thing)
 
 	// [crispy] brightmaps for select sprites
 	vis->colormap[0] = spritelights[index];
-	vis->colormap[1] = scalelight[LIGHTLEVELS-1][MAXLIGHTSCALE-1];
+	vis->colormap[1] = colormaps;
     }	
     vis->brightmap = R_BrightmapForSprite(thing->sprite);
 
@@ -1070,7 +1070,7 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
     {
 	// local light
 	vis->colormap[0] = spritelights[MAXLIGHTSCALE-1];
-	vis->colormap[1] = scalelight[LIGHTLEVELS-1][MAXLIGHTSCALE-1];
+	vis->colormap[1] = colormaps;
     }
     vis->brightmap = R_BrightmapForState(psp->state - states);
 	


### PR DESCRIPTION
This simplifies b-map lightning. `colormaps` is all we need to use a full brightness.
Testing map updated with floor and wall textures in different light levels: [plasmaguns.zip](https://github.com/fabiangreffrath/crispy-doom/files/8659441/plasmaguns.zip)
 