### PR TITLE
Heretic: refer to pointer, not to integer

### DIFF
--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -664,14 +664,14 @@ void R_StoreWallRange(int start, int stop)
 //
     if (((ds_p->silhouette & SIL_TOP) || maskedtexture) && !ds_p->sprtopclip)
     {
-        memcpy(lastopening, ceilingclip + start, sizeof(lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
+        memcpy(lastopening, ceilingclip + start, sizeof(*lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
         ds_p->sprtopclip = lastopening - start;
         lastopening += rw_stopx - start;
     }
     if (((ds_p->silhouette & SIL_BOTTOM) || maskedtexture)
         && !ds_p->sprbottomclip)
     {
-        memcpy(lastopening, floorclip + start, sizeof(lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
+        memcpy(lastopening, floorclip + start, sizeof(*lastopening) * (rw_stopx - start)); // [crispy] 32-bit integer math
         ds_p->sprbottomclip = lastopening - start;
         lastopening += rw_stopx - start;
     }


### PR DESCRIPTION
This should fix #886, thanks @ryan-sg for pointing out.