### PR TITLE
Doom: make brightmaps const

### DIFF
--- a/src/doom/r_bmaps.c
+++ b/src/doom/r_bmaps.c
@@ -26,9 +26,9 @@
 
 // [crispy] brightmap data
 
-static byte nobrightmap[256] = {0};
+static const byte nobrightmap[256] = {0};
 
-static byte notgray[256] =
+static const byte notgray[256] =
 {
 	0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -48,7 +48,7 @@ static byte notgray[256] =
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 };
 
-static byte notgrayorbrown[256] =
+static const byte notgrayorbrown[256] =
 {
 	0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -69,7 +69,7 @@ static byte notgrayorbrown[256] =
 };
 
 
-static byte notgrayorbrown2[256] =
+static const byte notgrayorbrown2[256] =
 {
     0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -89,7 +89,7 @@ static byte notgrayorbrown2[256] =
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 };
 
-static byte redonly[256] =
+static const byte redonly[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -109,7 +109,7 @@ static byte redonly[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte redonly2[256] =
+static const byte redonly2[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -129,7 +129,7 @@ static byte redonly2[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte greenonly1[256] =
+static const byte greenonly1[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -149,7 +149,7 @@ static byte greenonly1[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte greenonly2[256] =
+static const byte greenonly2[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -169,7 +169,7 @@ static byte greenonly2[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte greenonly3[256] =
+static const byte greenonly3[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -189,7 +189,7 @@ static byte greenonly3[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte yellowonly[256] =
+static const byte yellowonly[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -209,7 +209,7 @@ static byte yellowonly[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
 };
 
-static byte redandgreen[256] =
+static const byte redandgreen[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -229,7 +229,7 @@ static byte redandgreen[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte blueandgreen[256] =
+static const byte blueandgreen[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -249,7 +249,7 @@ static byte blueandgreen[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte brighttan[256] =
+static const byte brighttan[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -271,7 +271,7 @@ static byte brighttan[256] =
 
 // [crispy] Chex Quest's "locked" door switches
 
-static byte chexred[256] =
+static const byte chexred[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -293,7 +293,7 @@ static byte chexred[256] =
 
 // [crispy] Chex Quest's "open" door switches
 
-static byte chexgreen[256] =
+static const byte chexgreen[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -315,7 +315,7 @@ static byte chexgreen[256] =
 
 // [crispy] Chex Quest's "lock"/"open" knobs
 
-static byte chexredgreen[256] =
+static const byte chexredgreen[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -335,7 +335,7 @@ static byte chexredgreen[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static byte hacxlightning[256] =
+static const byte hacxlightning[256] =
 {
 	0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -355,7 +355,7 @@ static byte hacxlightning[256] =
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-byte *dc_brightmap = nobrightmap;
+const byte *dc_brightmap = nobrightmap;
 
 // [crispy] brightmaps for textures
 
@@ -370,7 +370,7 @@ typedef struct
 {
 	const char *const texture;
 	const int game;
-	byte *colormask;
+	const byte *colormask;
 } fullbright_t;
 
 static const fullbright_t fullbright_doom[] = {
@@ -570,7 +570,7 @@ static const fullbright_t fullbright_hacx[] = {
 	{"HW512",    DOOM2ONLY, notgrayorbrown},
 };
 
-static byte *R_BrightmapForTexName_Doom (const char *texname)
+static const byte *R_BrightmapForTexName_Doom (const char *texname)
 {
 	int i;
 
@@ -595,7 +595,7 @@ static byte *R_BrightmapForTexName_Doom (const char *texname)
 
 static boolean chex2 = false;
 
-static byte *R_BrightmapForTexName_Chex (const char *texname)
+static const byte *R_BrightmapForTexName_Chex (const char *texname)
 {
 	int i;
 
@@ -618,7 +618,7 @@ static byte *R_BrightmapForTexName_Chex (const char *texname)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForTexName_Hacx (const char *texname)
+static const byte *R_BrightmapForTexName_Hacx (const char *texname)
 {
 	int i;
 
@@ -638,7 +638,7 @@ static byte *R_BrightmapForTexName_Hacx (const char *texname)
 // [crispy] brightmaps for sprites
 
 // [crispy] adapted from russian-doom/src/doom/r_things.c:617-639
-static byte *R_BrightmapForSprite_Doom (const int type)
+static const byte *R_BrightmapForSprite_Doom (const int type)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_SPRITES)
 	{
@@ -678,7 +678,7 @@ static byte *R_BrightmapForSprite_Doom (const int type)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForSprite_Chex (const int type)
+static const byte *R_BrightmapForSprite_Chex (const int type)
 {
 	// [crispy] TODO
 	/*
@@ -708,7 +708,7 @@ static byte *R_BrightmapForSprite_Chex (const int type)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForSprite_Hacx (const int type)
+static const byte *R_BrightmapForSprite_Hacx (const int type)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_SPRITES)
 	{
@@ -760,7 +760,7 @@ static byte *R_BrightmapForSprite_Hacx (const int type)
 
 static int bmapflatnum[12];
 
-static byte *R_BrightmapForFlatNum_Doom (const int num)
+static const byte *R_BrightmapForFlatNum_Doom (const int num)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_TEXTURES)
 	{
@@ -775,7 +775,7 @@ static byte *R_BrightmapForFlatNum_Doom (const int num)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForFlatNum_Hacx (const int num)
+static const byte *R_BrightmapForFlatNum_Hacx (const int num)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_TEXTURES)
 	{
@@ -803,14 +803,14 @@ static byte *R_BrightmapForFlatNum_Hacx (const int num)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForFlatNum_None (const int num)
+static const byte *R_BrightmapForFlatNum_None (const int num)
 {
 	return nobrightmap;
 }
 
 // [crispy] brightmaps for states
 
-static byte *R_BrightmapForState_Doom (const int state)
+static const byte *R_BrightmapForState_Doom (const int state)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_SPRITES)
 	{
@@ -830,7 +830,7 @@ static byte *R_BrightmapForState_Doom (const int state)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForState_Hacx (const int state)
+static const byte *R_BrightmapForState_Hacx (const int state)
 {
 	if (crispy->brightmaps & BRIGHTMAPS_SPRITES)
 	{
@@ -861,17 +861,17 @@ static byte *R_BrightmapForState_Hacx (const int state)
 	return nobrightmap;
 }
 
-static byte *R_BrightmapForState_None (const int state)
+static const byte *R_BrightmapForState_None (const int state)
 {
 	return nobrightmap;
 }
 
 // [crispy] initialize brightmaps
 
-byte *(*R_BrightmapForTexName) (const char *texname);
-byte *(*R_BrightmapForSprite) (const int type);
-byte *(*R_BrightmapForFlatNum) (const int num);
-byte *(*R_BrightmapForState) (const int state);
+const byte *(*R_BrightmapForTexName) (const char *texname);
+const byte *(*R_BrightmapForSprite) (const int type);
+const byte *(*R_BrightmapForFlatNum) (const int num);
+const byte *(*R_BrightmapForState) (const int state);
 
 void R_InitBrightmaps ()
 {

--- a/src/doom/r_bmaps.h
+++ b/src/doom/r_bmaps.h
@@ -24,11 +24,11 @@
 
 extern void R_InitBrightmaps ();
 
-extern byte *(*R_BrightmapForTexName) (const char *texname);
-extern byte *(*R_BrightmapForSprite) (const int type);
-extern byte *(*R_BrightmapForFlatNum) (const int num);
-extern byte *(*R_BrightmapForState) (const int state);
+extern const byte *(*R_BrightmapForTexName) (const char *texname);
+extern const byte *(*R_BrightmapForSprite) (const int type);
+extern const byte *(*R_BrightmapForFlatNum) (const int num);
+extern const byte *(*R_BrightmapForState) (const int state);
 
-extern byte **texturebrightmap;
+extern const byte **texturebrightmap;
 
 #endif

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -156,7 +156,7 @@ unsigned**		texturecolumnofs; // [crispy] column offsets for composited transluc
 unsigned**		texturecolumnofs2; // [crispy] column offsets for composited opaque textures
 byte**			texturecomposite; // [crispy] composited translucent mid-textures on 2S walls
 byte**			texturecomposite2; // [crispy] composited opaque textures
-byte**			texturebrightmap; // [crispy] brightmaps
+const byte**	texturebrightmap; // [crispy] brightmaps
 
 // for global animation
 int*		flattranslation;

--- a/src/doom/r_defs.h
+++ b/src/doom/r_defs.h
@@ -412,7 +412,7 @@ typedef struct vissprite_s
     //  maxbright frames as well
     // [crispy] brightmaps for select sprites
     lighttable_t*	colormap[2];
-    byte		*brightmap;
+    const byte		*brightmap;
    
     int			mobjflags;
     // [crispy] color translation table for blood colored by monster class

--- a/src/doom/r_draw.c
+++ b/src/doom/r_draw.c
@@ -766,7 +766,7 @@ int			ds_x1;
 int			ds_x2;
 
 lighttable_t*		ds_colormap[2];
-byte*			ds_brightmap;
+const byte*			ds_brightmap;
 
 fixed_t			ds_xfrac; 
 fixed_t			ds_yfrac; 

--- a/src/doom/r_draw.h
+++ b/src/doom/r_draw.h
@@ -30,7 +30,7 @@ extern int		dc_yh;
 extern fixed_t		dc_iscale;
 extern fixed_t		dc_texturemid;
 extern int		dc_texheight;
-extern byte*		dc_brightmap;
+extern const byte*		dc_brightmap;
 
 // first pixel in a column
 extern byte*		dc_source;		
@@ -69,7 +69,7 @@ extern int		ds_x1;
 extern int		ds_x2;
 
 extern lighttable_t*	ds_colormap[2];
-extern byte*		ds_brightmap;
+extern const byte*		ds_brightmap;
 
 extern fixed_t		ds_xfrac;
 extern fixed_t		ds_yfrac;


### PR DESCRIPTION
As was suggested earlier. The necessity of adding bmaps support for two sided mid-textures is still under the question (implementation [example](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/hexen/r_segs.c#L136-L140)), but this should be done in separate PR. If needed, of course.