### PR TITLE
Doom & Heretic: brightmaps for mid-textures

### DIFF
--- a/src/doom/r_segs.c
+++ b/src/doom/r_segs.c
@@ -263,8 +263,10 @@ R_RenderMaskedSegRange
 		if (index >=  MAXLIGHTSCALE )
 		    index = MAXLIGHTSCALE-1;
 
-		// [crispy] no brightmaps for mid-textures
-		dc_colormap[0] = dc_colormap[1] = walllights[index];
+		// [crispy] brightmaps for mid-textures
+		dc_brightmap = texturebrightmap[texnum];
+		dc_colormap[0] = walllights[index];
+		dc_colormap[1] = (crispy->brightmaps & BRIGHTMAPS_TEXTURES) ? colormaps : dc_colormap[0];
 	    }
 			
 	    // [crispy] apply Killough's int64 sprtopscreen overflow fix

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -142,8 +142,10 @@ void R_RenderMaskedSegRange(drawseg_t * ds, int x1, int x2)
                 index = spryscale >> (LIGHTSCALESHIFT + crispy->hires);
                 if (index >= MAXLIGHTSCALE)
                     index = MAXLIGHTSCALE - 1;
-                // [crispy] no brightmaps for mid-textures
-                dc_colormap[0] = dc_colormap[1] = walllights[index];
+                // [crispy] brightmaps for mid-textures
+                dc_brightmap = texturebrightmap[texnum];
+                dc_colormap[0] = walllights[index];
+                dc_colormap[1] = (crispy->brightmaps & BRIGHTMAPS_TEXTURES) ? colormaps : dc_colormap[0];
             }
 
             sprtopscreen = centeryfrac - FixedMul(dc_texturemid, spryscale);


### PR DESCRIPTION
This adds support for brightmaps on two sided mid-textures.

Honestly, no idea is it 100,00% ultimately perfect solution. Should be it, since we don't do any extra calculations and just referring to masked texture's `texnum`.  Previous attempts with defining such textures wasn't working, either because of racing conditions, or because masked textures passing through`R_RenderMaskedSegRange` and getting some mess before get into `R_DrawColumn`.

Testing maps:
* Doom: [on_mid_doom.zip](https://github.com/fabiangreffrath/crispy-doom/files/8815359/on_mid_doom.zip)
* Heretic: [on_mid_htic.zip](https://github.com/fabiangreffrath/crispy-doom/files/8815361/on_mid_htic.zip)
 