### PR TITLE
Make V_DrawAltTLPatch() widescreen-compatible

### DIFF
--- a/src/v_video.c
+++ b/src/v_video.c
@@ -582,11 +582,12 @@ void V_DrawAltTLPatch(int x, int y, patch_t * patch)
 
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);
+    x += WIDESCREENDELTA; // [crispy] horizontal widescreen offset
 
     if (x < 0
-     || x + SHORT(patch->width) > ORIGWIDTH
+     || x + SHORT(patch->width) > (SCREENWIDTH >> crispy->hires)
      || y < 0
-     || y + SHORT(patch->height) > ORIGHEIGHT)
+     || y + SHORT(patch->height) > (SCREENHEIGHT >> crispy->hires))
     {
         I_Error("Bad V_DrawAltTLPatch");
     }


### PR DESCRIPTION
Fixes #890.

On a side note, I was wondering why `V_DrawTLPatch()` and `V_DrawAltTLPatch()` are doing the exact same thing. Turns out, they're not supposed to. :) I'll fix that upstream in Chocolate.