### PR TITLE
Heretic/Hexen: Minor update for player view

### DIFF
--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -609,8 +609,6 @@ void R_ExecuteSetViewSize(void)
 		scaledviewwidth = scaledviewwidth_nonwide;
 	}
     }
-    // [crispy] make sure viewheight is always an even number
-    viewheight &= ~1;
 
     detailshift = setdetail;
     viewwidth = scaledviewwidth >> detailshift;

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -609,8 +609,6 @@ void R_ExecuteSetViewSize(void)
 		scaledviewwidth = scaledviewwidth_nonwide;
 	}
     }
-    // [crispy] make sure viewheight is always an even number
-    viewheight &= ~1;
 
     detailshift = setdetail;
     viewwidth = scaledviewwidth >> detailshift;

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -599,7 +599,7 @@ void R_ExecuteSetViewSize(void)
 	{
 		const int widescreen_edge_aligner = (16 << crispy->hires) - 1;
 
-		scaledviewwidth = viewheight*SCREENWIDTH/(SCREENHEIGHT-(42<<crispy->hires));
+		scaledviewwidth = viewheight*SCREENWIDTH/(SCREENHEIGHT-SBARHEIGHT);
 		// [crispy] make sure scaledviewwidth is an integer multiple of the bezel patch width
 		scaledviewwidth = (scaledviewwidth + widescreen_edge_aligner) & (int)~widescreen_edge_aligner;
 		scaledviewwidth = MIN(scaledviewwidth, SCREENWIDTH);


### PR DESCRIPTION
I removed the round down of `screenheight` to the nearest power of 2, which fixes #896. I have tested all combinations of aspect ratio, resolution and view size and have confirmed there are no glitches with the drawing of the view border. So it appears that the rounding is not necessary.

I also fixed a copy-and-paste error where I accidentally used the Heretic status bar height instead of the Hexen. Luckily this error didn't cause any problems for the majority of aspect ratios and view sizes.