### PR TITLE
Heretic/Hexen: Capture mouselook activity when recording a demo

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -38,6 +38,7 @@
 #define AM_STARTKEY     9
 
 #define MLOOKUNIT 8 // [crispy] for mouselook
+#define MLOOKUNITLOWRES 16 // [crispy] for mouselook when recording
 
 // Functions
 
@@ -719,8 +720,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     if (crispy->mouselook || mousebuttons[mousebmouselook])
     {
-        cmd->lookdir = mouse_y_invert ? -mousey : mousey;
-        cmd->lookdir /= MLOOKUNIT;
+        if (demorecording || lowres_turn)
+        {
+            // [crispy] Map mouse movement to look variable when recording
+            look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
+                                        : mousey / MLOOKUNITLOWRES;
+
+            // [crispy] Limit to max speed of keyboard look up/down
+            if (look > 2)
+                look = 2;
+            else if (look < -2)
+                look = -2;
+        }
+        else
+        {
+            cmd->lookdir = mouse_y_invert ? -mousey : mousey;
+            cmd->lookdir /= MLOOKUNIT;
+        }
     }
     else if (!novert)
     {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -33,6 +33,7 @@
 #define AM_STARTKEY	9
 
 #define MLOOKUNIT 8 // [crispy] for mouselook
+#define MLOOKUNITLOWRES 16 // [crispy] for mouselook when recording
 
 // External functions
 
@@ -623,8 +624,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     if (crispy->mouselook || mousebuttons[mousebmouselook])
     {
-        cmd->lookdir = mouse_y_invert ? -mousey : mousey;
-        cmd->lookdir /= MLOOKUNIT;
+        if (demorecording || lowres_turn)
+        {
+            // [crispy] Map mouse movement to look variable when recording
+            look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
+                                        : mousey / MLOOKUNITLOWRES;
+
+            // [crispy] Limit to max speed of keyboard look up/down
+            if (look > 2)
+                look = 2;
+            else if (look < -2)
+                look = -2;
+        }
+        else
+        {
+            cmd->lookdir = mouse_y_invert ? -mousey : mousey;
+            cmd->lookdir /= MLOOKUNIT;
+        }
     }
     else if (!novert)
     {


### PR DESCRIPTION
When recording demos, mouselook movements are now mapped to the "look" variable also used for keyboard look. Compared to normal gameplay, the mouselook fidelity is reduced. This is similar to how turning resolution is lower when recording a vanilla demo.  Furthermore, the amount of travel in a tic is limited to what could be achieved using the keyboard.

Not sure if this is a worthwhile idea or not, but it seems to work reasonably well. Could probably use some refinement.