### PR TITLE
Heretic: Add status bar stats widget

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -163,6 +163,7 @@ void DrawCenterMessage(void)
 //---------------------------------------------------------------------------
 
 int left_widget_w, right_widget_w; // [crispy]
+extern int screenblocks; // [crispy]
 
 static void CrispyDrawStats (void)
 {
@@ -185,7 +186,10 @@ static void CrispyDrawStats (void)
     left_widget_x = 0 - WIDESCREENDELTA;
     right_widget_x = coord_x + WIDESCREENDELTA;
 
-    if (crispy->automapstats == WIDGETS_ALWAYS || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
+    if (crispy->automapstats == WIDGETS_ALWAYS
+            || (automapactive && (crispy->automapstats == WIDGETS_AUTOMAP
+                                || crispy->automapstats == WIDGETS_STBAR))
+            || (screenblocks > 10 && crispy->automapstats == WIDGETS_STBAR))
     {
         M_snprintf(str, sizeof(str), "K %d/%d", player->killcount, totalkills);
         MN_DrTextA(str, left_widget_x, 1*height);
@@ -196,6 +200,14 @@ static void CrispyDrawStats (void)
 
         M_snprintf(str, sizeof(str), "S %d/%d", player->secretcount, totalsecret);
         MN_DrTextA(str, left_widget_x, 3*height);
+    }
+    else if (crispy->automapstats == WIDGETS_STBAR)
+    {
+        M_snprintf(str, sizeof(str), "K %d/%d I %d/%d S %d/%d",
+                    player->killcount, totalkills,
+                    player->itemcount, totalitems,
+                    player->secretcount, totalsecret);
+        MN_DrTextA(str, 20, 145); // same location as level name in automap
     }
 
     if (crispy->leveltime == WIDGETS_ALWAYS || (automapactive && crispy->leveltime == WIDGETS_AUTOMAP))
@@ -800,7 +812,6 @@ void InitThermo(int max)
 
 void D_BindVariables(void)
 {
-    extern int screenblocks;
     extern int snd_Channels;
     int i;
 

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1403,7 +1403,7 @@ static boolean CrispyBrightmaps(int option)
 
 static boolean CrispyAutomapStats(int option)
 {
-    crispy->automapstats = (crispy->automapstats + 1) % (NUM_WIDGETS - 1);
+    crispy->automapstats = (crispy->automapstats + 1) % (NUM_WIDGETS);
     return true;
 }
 
@@ -2315,7 +2315,8 @@ static void DrawCrispness1(void)
     // Show level stats
     MN_DrTextA(crispy->automapstats == WIDGETS_OFF ? "NEVER" :
                crispy->automapstats == WIDGETS_AUTOMAP ? "IN AUTOMAP" :
-                                                         "ALWAYS", 190, 135);
+               crispy->automapstats == WIDGETS_ALWAYS ? "ALWAYS" :
+                                                         "STATUS BAR", 190, 135);
 
     // Show level time
     MN_DrTextA(crispy->leveltime == WIDGETS_OFF ? "NEVER" :


### PR DESCRIPTION
Here's my attempt at the status bar level stats for Heretic. 
![Screenshot from 2022-06-13 22-42-38](https://user-images.githubusercontent.com/43701387/173482474-0116c78c-d1bb-40c4-879f-7940d09fdb7a.png)
One difference from the Doom implementation is that in fullscreen mode I move the stats widget back to the corner, same as when the automap is active. I found it to look a little out of place otherwise.