### PR TITLE
reset mobj_t fields used for interpolation when loading savegame

### DIFF
--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -418,6 +418,13 @@ static void saveg_read_mobj_t(mobj_t *str)
 
     // struct mobj_s* tracer;
     str->tracer = saveg_readp();
+
+    // [crispy] new mobj_t fields used for interpolation
+    str->interp = 0;
+    str->oldx = 0;
+    str->oldy = 0;
+    str->oldz = 0;
+    str->oldangle = 0;
 }
 
 // [crispy] enumerate all thinker pointers


### PR DESCRIPTION
Fixes #915 