### PR TITLE
Doom: various multiplayer fixes

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1866,8 +1866,8 @@ void AM_drawPlayers(void)
 
     for (i=0;i<MAXPLAYERS;i++)
     {
-    // [crispy] interpolate other player arrows angle
-    angle_t theirangle;
+	// [crispy] interpolate other player arrows angle
+	angle_t theirangle;
 
 	their_color++;
 	p = &players[i];

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1896,8 +1896,18 @@ void AM_drawPlayers(void)
 	else
 	    color = their_colors[their_color];
 	
-	pt.x = p->mo->x >> FRACTOMAPBITS;
-	pt.y = p->mo->y >> FRACTOMAPBITS;
+	// [crispy] interpolate other player arrows
+	if (crispy->uncapped && leveltime > oldleveltime)
+	{
+	    pt.x = (p->mo->oldx + FixedMul(p->mo->x - p->mo->oldx, fractionaltic)) >> FRACTOMAPBITS;
+	    pt.y = (p->mo->oldy + FixedMul(p->mo->y - p->mo->oldy, fractionaltic)) >> FRACTOMAPBITS;
+	}
+	else
+	{
+	    pt.x = p->mo->x >> FRACTOMAPBITS;
+	    pt.y = p->mo->y >> FRACTOMAPBITS;
+	}
+
 	if (crispy->automaprotate)
 	{
 	    AM_rotatePoint(&pt);

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -538,7 +538,6 @@ void AM_changeWindowLoc(void)
 //
 void AM_initVariables(void)
 {
-    int pnum;
     static event_t st_notify = { ev_keyup, AM_MSGENTERED, 0, 0 };
 
     automapactive = true;
@@ -555,24 +554,8 @@ void AM_initVariables(void)
     m_w = FTOM(f_w);
     m_h = FTOM(f_h);
 
-    // find player to center on initially
-    if (playeringame[consoleplayer])
-    {
-        plr = &players[consoleplayer];
-    }
-    else
-    {
-        plr = &players[0];
-
-	for (pnum=0;pnum<MAXPLAYERS;pnum++)
-        {
-	    if (playeringame[pnum])
-            {
-                plr = &players[pnum];
-		break;
-            }
-        }
-    }
+    // [crispy] find player to center
+    plr = &players[displayplayer];
 
     next_m_x = (plr->mo->x >> FRACTOMAPBITS) - m_w/2;
     next_m_y = (plr->mo->y >> FRACTOMAPBITS) - m_h/2;
@@ -1848,11 +1831,12 @@ void AM_drawPlayers(void)
     int		their_color = -1;
     int		color;
     mpoint_t	pt;
-    // [crispy] smooth player arrow rotation
-    const angle_t smoothangle = crispy->automaprotate ? plr->mo->angle : viewangle;
 
     if (!netgame)
     {
+	// [crispy] smooth player arrow rotation
+	const angle_t smoothangle = crispy->automaprotate ? plr->mo->angle : viewangle;
+
 	// [crispy] interpolate player arrow
 	if (crispy->uncapped && leveltime > oldleveltime)
 	{
@@ -1882,6 +1866,9 @@ void AM_drawPlayers(void)
 
     for (i=0;i<MAXPLAYERS;i++)
     {
+    // [crispy] interpolate other player arrows angle
+    angle_t theirangle;
+
 	their_color++;
 	p = &players[i];
 
@@ -1911,10 +1898,15 @@ void AM_drawPlayers(void)
 	if (crispy->automaprotate)
 	{
 	    AM_rotatePoint(&pt);
+	    theirangle = p->mo->angle;
+	}
+	else
+	{
+        theirangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
 	}
 
 	AM_drawLineCharacter
-	    (player_arrow, arrlen(player_arrow), 0, p->mo->angle,
+	    (player_arrow, arrlen(player_arrow), 0, theirangle,
 	     color, pt.x, pt.y);
     }
 

--- a/src/doom/am_map.h
+++ b/src/doom/am_map.h
@@ -42,6 +42,8 @@ void AM_Drawer (void);
 // if the level is completed while it is up.
 void AM_Stop (void);
 
+// [crispy] re-init in G_Responder on toggling spy mode (F12)
+void AM_initVariables (void);
 
 extern cheatseq_t cheat_amap;
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -543,7 +543,7 @@ void D_RunFrame()
 
     TryRunTics (); // will run at least one tic
 
-    S_UpdateSounds (players[consoleplayer].mo);// move positional sounds
+    S_UpdateSounds (players[displayplayer].mo);// move positional sounds
 
     // Update display, next frame, with current state if no profiling is on
     if (screenvisible && !nodrawers)

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -919,6 +919,11 @@ void G_DoLoadLevel (void)
     memset(joyarray, 0, sizeof(joyarray));
     R_SetGoobers(false);
 
+    // [crispy] jff 4/26/98 wake up the status bar in case were coming out of a DM demo
+    // [crispy] killough 5/13/98: in case netdemo has consoleplayer other than green
+    ST_Start();
+    HU_Start();
+
     if (testcontrols)
     {
         players[consoleplayer].message = "Press escape to quit.";
@@ -1018,6 +1023,10 @@ boolean G_Responder (event_t* ev)
 	    if (displayplayer == MAXPLAYERS) 
 		displayplayer = 0; 
 	} while (!playeringame[displayplayer] && displayplayer != consoleplayer); 
+	// [crispy] killough 3/7/98: switch status bar views too
+	ST_Start();
+	HU_Start();
+	S_UpdateSounds(players[displayplayer].mo);
 	// [crispy] re-init automap variables for correct player arrow angle
 	if (automapactive)
 	AM_initVariables();

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1018,6 +1018,9 @@ boolean G_Responder (event_t* ev)
 	    if (displayplayer == MAXPLAYERS) 
 		displayplayer = 0; 
 	} while (!playeringame[displayplayer] && displayplayer != consoleplayer); 
+	// [crispy] re-init automap variables for correct player arrow angle
+	if (automapactive)
+	AM_initVariables();
 	return true; 
     }
     

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2628,7 +2628,7 @@ G_InitNew
 #define DEMOMARKER		0x80
 
 // [crispy] demo progress bar and timer widget
-int defdemotics = 0, deftotaldemotics;
+int defdemotics = 0, deftotaldemotics, numplayersingame;
 // [crispy] moved here
 static const char *defdemoname;
 
@@ -3077,8 +3077,10 @@ void G_DoPlayDemo (void)
 
     // [crispy] demo progress bar
     {
-	int i, numplayersingame = 0;
+	int i;
 	byte *demo_ptr = demo_p;
+
+	numplayersingame = 0;
 
 	for (i = 0; i < MAXPLAYERS; i++)
 	{

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1297,6 +1297,12 @@ void G_Ticker (void)
 	}
     }
     
+    // [crispy] increase demo tics counter
+    if (demoplayback || demorecording)
+    {
+	    defdemotics++;
+    }
+
     // check for special buttons
     for (i=0 ; i<MAXPLAYERS ; i++)
     {
@@ -2640,7 +2646,7 @@ G_InitNew
 #define DEMOMARKER		0x80
 
 // [crispy] demo progress bar and timer widget
-int defdemotics = 0, deftotaldemotics, numplayersingame;
+int defdemotics = 0, deftotaldemotics;
 // [crispy] moved here
 static const char *defdemoname;
 
@@ -2696,11 +2702,6 @@ void G_ReadDemoTiccmd (ticcmd_t* cmd)
     }
 
     cmd->buttons = (unsigned char)*demo_p++; 
-
-    // [crispy] increase demo tics counter
-    // applies to both recording and playback,
-    // because G_WriteDemoTiccmd() calls G_ReadDemoTiccmd() once
-    defdemotics++;
 } 
 
 // Increase the size of the demo buffer to allow unlimited demos
@@ -3089,10 +3090,8 @@ void G_DoPlayDemo (void)
 
     // [crispy] demo progress bar
     {
-	int i;
+	int i, numplayersingame = 0;
 	byte *demo_ptr = demo_p;
-
-	numplayersingame = 0;
 
 	for (i = 0; i < MAXPLAYERS; i++)
 	{
@@ -3106,7 +3105,7 @@ void G_DoPlayDemo (void)
 
 	while (*demo_ptr != DEMOMARKER && (demo_ptr - demobuffer) < lumplength)
 	{
-	    demo_ptr += (longtics ? 5 : 4);
+	    demo_ptr += numplayersingame * (longtics ? 5 : 4);
 	    deftotaldemotics++;
 	}
     }

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3092,7 +3092,7 @@ void G_DoPlayDemo (void)
 
 	while (*demo_ptr != DEMOMARKER && (demo_ptr - demobuffer) < lumplength)
 	{
-	    demo_ptr += numplayersingame * (longtics ? 5 : 4);
+	    demo_ptr += (longtics ? 5 : 4);
 	    deftotaldemotics++;
 	}
     }

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -898,7 +898,7 @@ void HU_Drawer(void)
     // [crispy] demo timer widget
     if (demoplayback && (crispy->demotimer & DEMOTIMER_PLAYBACK))
     {
-	ST_DrawDemoTimer(crispy->demotimerdir ? (deftotaldemotics - defdemotics) : defdemotics);
+	ST_DrawDemoTimer((crispy->demotimerdir ? (deftotaldemotics - defdemotics) : defdemotics) / numplayersingame);
     }
     else
     if (demorecording && (crispy->demotimer & DEMOTIMER_RECORD))

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -594,7 +594,7 @@ void HU_Start(void)
     if (headsupactive)
 	HU_Stop();
 
-    plr = &players[consoleplayer];
+    plr = &players[displayplayer];
     message_on = false;
     message_dontfuckwithme = false;
     message_nottobefuckedwith = false;
@@ -898,7 +898,7 @@ void HU_Drawer(void)
     // [crispy] demo timer widget
     if (demoplayback && (crispy->demotimer & DEMOTIMER_PLAYBACK))
     {
-	ST_DrawDemoTimer((crispy->demotimerdir ? (deftotaldemotics - defdemotics) : defdemotics) / numplayersingame);
+	ST_DrawDemoTimer(crispy->demotimerdir ? (deftotaldemotics - defdemotics) : defdemotics);
     }
     else
     if (demorecording && (crispy->demotimer & DEMOTIMER_RECORD))

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -773,7 +773,8 @@ P_KillMobj
 	target->player->fixedcolormap = target->player->powers[pw_infrared] ? 1 : 0;
 
 	if (target->player == &players[consoleplayer]
-	    && automapactive)
+	    && automapactive
+	    && !demoplayback) // [crispy] killough 11/98: don't switch out in demos, though
 	{
 	    // don't die in auto map,
 	    // switch view prior to dying

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -208,7 +208,7 @@ P_GiveWeapon
 	// [crispy] show weapon pickup messages in multiplayer games
 	player->message = DEH_String(WeaponPickupMessages[weapon]);
 
-	if (player == &players[consoleplayer])
+	if (player == &players[displayplayer])
 	    S_StartSound (NULL, sfx_wpnup);
 	return false;
     }
@@ -716,7 +716,7 @@ P_TouchSpecialThing
 	player->itemcount++;
     P_RemoveMobj (special);
     player->bonuscount += BONUSADD;
-    if (player == &players[consoleplayer])
+    if (player == &players[displayplayer])
 	S_StartSoundOptional (NULL, sound, sfx_itemup); // [NS] Fallback to itemup.
 }
 

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -693,15 +693,15 @@ void S_StartSound(void *origin_p, int sfx_id)
 
     // Check to see if it is audible,
     //  and if not, modify the params
-    if (origin && origin != players[consoleplayer].mo && origin != players[consoleplayer].so) // [crispy] weapon sound source
+    if (origin && origin != players[displayplayer].mo && origin != players[displayplayer].so) // [crispy] weapon sound source
     {
-        rc = S_AdjustSoundParams(players[consoleplayer].mo,
+        rc = S_AdjustSoundParams(players[displayplayer].mo,
                                  origin,
                                  &volume,
                                  &sep);
 
-        if (origin->x == players[consoleplayer].mo->x
-         && origin->y == players[consoleplayer].mo->y)
+        if (origin->x == players[displayplayer].mo->x
+         && origin->y == players[displayplayer].mo->y)
         {
             sep = NORM_SEP;
         }
@@ -852,7 +852,7 @@ void S_UpdateSounds(mobj_t *listener)
 
                 // check non-local sounds for distance clipping
                 //  or modify their params
-                if (c->origin && listener != c->origin && c->origin != players[consoleplayer].so) // [crispy] weapon sound source
+                if (c->origin && listener != c->origin && c->origin != players[displayplayer].so) // [crispy] weapon sound source
                 {
                     audible = S_AdjustSoundParams(listener,
                                                   c->origin,

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -35,7 +35,7 @@
 
 // [crispy] Demo Timer widget
 extern void ST_DrawDemoTimer (const int time);
-extern int defdemotics, deftotaldemotics, numplayersingame;
+extern int defdemotics, deftotaldemotics;
 
 //
 // STATUS BAR

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -35,7 +35,7 @@
 
 // [crispy] Demo Timer widget
 extern void ST_DrawDemoTimer (const int time);
-extern int defdemotics, deftotaldemotics;
+extern int defdemotics, deftotaldemotics, numplayersingame;
 
 //
 // STATUS BAR


### PR DESCRIPTION
No desyncs! Just a fixes for demos/games with more than one player. So far, what I have found:

- [x] Demo progress bar length is incorrect if there are more than one player.
- [x] Demo timer is length is incorrect if there are more than one player.
- [x] Other player arrows aren't properly interpolated and have incorrect angle in automap rotate mode.
- [x] Spy mode `F12` is always showing status bar of host (`consoleplayer`) while it can show chosen player (`displayplayer`). Should be discussed separately, it's really nice feature for more-than-two players.
- [x] Don't close automap on dying in demo playing.

Testing map and demo with four players: [yardz.zip](https://github.com/chocolate-doom/chocolate-doom/files/9331105/yardz.zip)

_Demo is originally "SPB_MSC1.LMP", but renamed for simpler loading. It's a deathmatch of St.Petersburg vs. Moscow, dated 1996-05-28. Good old times..._