### PR TITLE
REKKR: Sunken Land support attempt

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -45,9 +45,7 @@ static const iwad_t iwads[] =
     { "freedoom1.wad", doom,     retail,     "Freedoom: Phase 1" },
     { "freedm.wad",   doom2,     commercial, "FreeDM" },
     { "rekkrsa.wad",  doom,      retail,     "REKKR" }, // [crispy] REKKR standalone freeware
-    { "rekkrsa.iwad",  doom,      retail,     "REKKR" }, // [crispy] REKKR standalone freeware non-renamed
-    { "rekkrsl.wad",  doom,      retail,     "REKKR: Sunken Land" }, // [crispy] REKKR Steam retail
-	{ "rekkrsl.iwad",  doom,      retail,     "REKKR: Sunken Land" }, // [crispy] REKKR Steam retail non-renamed
+    { "rekkrsl.wad",  doom,      retail,     "REKKR: Sunken Land" }, // [crispy] REKKR: Sunken Land (Steam retail)
     { "heretic.wad",  heretic,   retail,     "Heretic" },
     { "heretic1.wad", heretic,   shareware,  "Heretic Shareware" },
     { "hexen.wad",    hexen,     commercial, "Hexen" },

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -44,7 +44,10 @@ static const iwad_t iwads[] =
     { "freedoom2.wad", doom2,    commercial, "Freedoom: Phase 2" },
     { "freedoom1.wad", doom,     retail,     "Freedoom: Phase 1" },
     { "freedm.wad",   doom2,     commercial, "FreeDM" },
-    { "rekkrsa.wad",  doom,      retail,     "REKKR" }, // [crispy] REKKR
+    { "rekkrsa.wad",  doom,      retail,     "REKKR" }, // [crispy] REKKR standalone freeware
+    { "rekkrsa.iwad",  doom,      retail,     "REKKR" }, // [crispy] REKKR standalone freeware non-renamed
+    { "rekkrsl.wad",  doom,      retail,     "REKKR: Sunken Land" }, // [crispy] REKKR Steam retail
+	{ "rekkrsl.iwad",  doom,      retail,     "REKKR: Sunken Land" }, // [crispy] REKKR Steam retail non-renamed
     { "heretic.wad",  heretic,   retail,     "Heretic" },
     { "heretic1.wad", heretic,   shareware,  "Heretic Shareware" },
     { "hexen.wad",    hexen,     commercial, "Hexen" },

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -62,11 +62,11 @@
 #define HU_TITLE_CHEX   (mapnames_chex[(gameepisode-1)*9+gamemap-1])
 #define HU_TITLEHEIGHT	1
 #define HU_TITLEX	(0 - WIDESCREENDELTA)
-#define HU_TITLEY	(167 - SHORT(hu_font[0]->height))
+#define HU_TITLEY	(167 - SHORT(hu_font['A'-HU_FONTSTART]->height))
 
 #define HU_INPUTTOGGLE	't'
 #define HU_INPUTX	HU_MSGX
-#define HU_INPUTY	(HU_MSGY + HU_MSGHEIGHT*(SHORT(hu_font[0]->height) +1))
+#define HU_INPUTY	(HU_MSGY + HU_MSGHEIGHT*(SHORT(hu_font['A'-HU_FONTSTART]->height) +1))
 #define HU_INPUTWIDTH	64
 #define HU_INPUTHEIGHT	1
 
@@ -625,7 +625,7 @@ void HU_Start(void)
 
     // [crispy] create the generic map title, kills, items, secrets and level time widgets
     HUlib_initTextLine(&w_map,
-		       HU_TITLEX, HU_TITLEY - SHORT(hu_font[0]->height + 1),
+		       HU_TITLEX, HU_TITLEY - SHORT(hu_font['A'-HU_FONTSTART]->height + 1),
 		       hu_font,
 		       HU_FONTSTART);
 
@@ -716,10 +716,10 @@ void HU_Start(void)
 
     // [crispy] explicitely display (episode and) map if the
     // map is from a PWAD or if the map title string has been dehacked
-    if (DEH_HasStringReplacement(s) ||
-        (!W_IsIWADLump(maplumpinfo) &&
-        !(crispy->havenerve && gamemission == pack_nerve) &&
-        !(crispy->havemaster && gamemission == pack_master)))
+    if (!W_IsIWADLump(maplumpinfo) &&
+        (DEH_HasStringReplacement(s) ||
+        (!(crispy->havenerve && gamemission == pack_nerve) &&
+        !(crispy->havemaster && gamemission == pack_master))))
     {
 	char *m;
 

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -955,7 +955,7 @@ void R_InitTextures (void)
 		// [crispy] make non-fatal
 		fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
 			 texturename);
-		patch->patch = 0;
+		patch->patch = W_CheckNumForName("STCFN033"); // [crispy] dummy patch
 	    }
 	}		
 	texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -955,7 +955,7 @@ void R_InitTextures (void)
 		// [crispy] make non-fatal
 		fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
 			 texturename);
-		patch->patch = 0;
+		patch->patch = 0; //
 	    }
 	}		
 	texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -955,7 +955,7 @@ void R_InitTextures (void)
 		// [crispy] make non-fatal
 		fprintf (stderr, "R_InitTextures: Missing patch in texture %s\n",
 			 texturename);
-		patch->patch = 0; //
+		patch->patch = 0;
 	    }
 	}		
 	texturecolumnlump[i] = Z_Malloc (texture->width*sizeof(**texturecolumnlump), PU_STATIC,0);


### PR DESCRIPTION
Support of standalone free **rekkrsa.iwad** (with .iwad extension) as the Steam standalone rekkrsl.iwad is shipped with it.
I'm puzzled why REKKR: Sunken Land `crispy-doom -iwad rekkrsl.wad` `(.iwad)` causes a crash. REKKRSL.wad is different only by having the 4th episode.

A late thought: maybe this change should go to Chocolate Doom as REKKR is a vanilla-compatible WAD.