### PR TITLE
[Feature Suggestion] Add a kill-switch for Fluidsynth

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -47,6 +47,7 @@
 
 char *fluidsynth_sf_path = "";
 char *timidity_cfg_path = "";
+int *fluidsynth_force_off = 0; // force Fluidsynth off
 
 static char *temp_timidity_cfg = NULL;
 
@@ -265,7 +266,10 @@ static boolean I_SDL_InitMusic(void)
         {
             if (!strcmp(Mix_GetMusicDecoder(i), "FLUIDSYNTH"))
             {
-                fluidsynth_sf_is_set = true;
+                if (!fluidsynth_force_off)
+                    fluidsynth_sf_is_set = true;
+                else
+                    fluidsynth_sf_is_set = false; // force Fluidsynth off
                 break;
             }
         }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -499,7 +499,7 @@ void I_BindSoundVariables(void)
     extern char *snd_dmxoption;
     extern int use_libsamplerate;
     extern float libsamplerate_scale;
-    extern int *fluidsynth_force_off; // force Fluidsynth off
+    extern int fluidsynth_force_off; // force Fluidsynth off
 
     M_BindIntVariable("snd_musicdevice",         &snd_musicdevice);
     M_BindIntVariable("snd_sfxdevice",           &snd_sfxdevice);

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -499,6 +499,7 @@ void I_BindSoundVariables(void)
     extern char *snd_dmxoption;
     extern int use_libsamplerate;
     extern float libsamplerate_scale;
+    extern int *fluidsynth_force_off; // force Fluidsynth off
 
     M_BindIntVariable("snd_musicdevice",         &snd_musicdevice);
     M_BindIntVariable("snd_sfxdevice",           &snd_sfxdevice);
@@ -515,6 +516,7 @@ void I_BindSoundVariables(void)
     M_BindIntVariable("snd_pitchshift",          &snd_pitchshift);
 
     M_BindStringVariable("music_pack_path",      &music_pack_path);
+    M_BindIntVariable("fluidsynth_force_off",    &fluidsynth_force_off); // force Fluidsynth off
     M_BindStringVariable("fluidsynth_sf_path",   &fluidsynth_sf_path);
     M_BindStringVariable("timidity_cfg_path",    &timidity_cfg_path);
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1011,6 +1011,12 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_STRING(music_pack_path),
 
     //!
+    // Force Fluidsynth off even when SDL_SOUNDFONTS environmental variable is present
+    //
+
+    CONFIG_VARIABLE_INT(fluidsynth_force_off),
+
+    //!
     // Full path to a soundfont file to use with FluidSynth MIDI playback.
     //
 


### PR DESCRIPTION
When SDL_SOUNDFONTS environmental variable is present in the System, there is no way to fall back to Native Midi from Fluidsynth without tweaking the SDL_SOUNDFONTS variable/renaming Soundonts, etc. The kill-switch is needed when the SDL_SOUNDFONTS tweaking is undesirable.