### PR TITLE
Force mapping secret sector lines even if they are hidden

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1714,7 +1714,7 @@ void AM_drawWalls(void)
 		// [SoDOOManiac] [crispy] if no IDDT, no extended automap colors and no secret report, draw 2S secret sector boundaries in gray if no floor/ceiling level change
 		else if (lines[i].backsector->floorheight == lines[i].frontsector->floorheight && lines[i].backsector->ceilingheight == lines[i].frontsector->ceilingheight &&
 		    ((lines[i].frontsector->oldspecial == 9 || lines[i].backsector->oldspecial == 9 ||
-		    lines[i].frontsector->special == 9 || lines[i].backsector->special == 9))) // revealed secret boundaries are greened, exclude them
+		    lines[i].frontsector->special == 9 || lines[i].backsector->special == 9)))
 		{
 		    AM_drawMline(&l, TSWALLCOLORS+lightlev);
 		}

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1617,9 +1617,13 @@ void AM_drawWalls(void)
 	    AM_rotatePoint(&l.a);
 	    AM_rotatePoint(&l.b);
 	}
+
 	if (cheating || (lines[i].flags & ML_MAPPED))
 	{
-	    if ((lines[i].flags & LINE_NEVERSEE) && !cheating)
+	    if ((lines[i].flags & LINE_NEVERSEE) && !cheating && // [SoDOOManiac] [crispy] force mapping of secret sector lines
+	    !((lines[i].backsector && // upon seeing even if they're neversee like in REKKR
+	    (lines[i].frontsector->oldspecial == 9 || lines[i].backsector->oldspecial == 9 || lines[i].frontsector->special == 9 || lines[i].backsector->special == 9)) || 
+	    (!lines[i].backsector && (lines[i].frontsector->oldspecial == 9 || lines[i].frontsector->special == 9))))
 		continue;
 	    {
 		// [crispy] draw keyed doors in their respective colors
@@ -1664,7 +1668,7 @@ void AM_drawWalls(void)
 		    cheating && (lines[i].frontsector->special == 9))
 		    AM_drawMline(&l, SECRETWALLCOLORS);
 #if defined CRISPY_HIGHLIGHT_REVEALED_SECRETS
-		// [crispy] draw revealed secret sector boundaries in green
+		// [crispy] draw revealed secret sector boundaries in bright green
 		else
 		if (crispy->extautomap &&
 		    crispy->secretmessage && (lines[i].frontsector->oldspecial == 9))
@@ -1691,7 +1695,7 @@ void AM_drawWalls(void)
 		    else AM_drawMline(&l, WALLCOLORS+lightlev);
 		}
 #if defined CRISPY_HIGHLIGHT_REVEALED_SECRETS
-		// [crispy] draw revealed secret sector boundaries in green
+		// [crispy] draw revealed secret sector boundaries in bright green
 		else if (crispy->extautomap && crispy->secretmessage &&
 		    (lines[i].backsector->oldspecial == 9 ||
 		    lines[i].frontsector->oldspecial == 9))
@@ -1706,6 +1710,15 @@ void AM_drawWalls(void)
 		{
 		    AM_drawMline(&l, SECRETWALLCOLORS);
 		}
+
+		// [SoDOOManiac] [crispy] if no IDDT, no extended automap colors and no secret report, draw 2S secret sector boundaries in gray if no floor/ceiling level change
+		else if (lines[i].backsector->floorheight == lines[i].frontsector->floorheight && lines[i].backsector->ceilingheight == lines[i].frontsector->ceilingheight &&
+		    ((lines[i].frontsector->oldspecial == 9 || lines[i].backsector->oldspecial == 9 ||
+		    lines[i].frontsector->special == 9 || lines[i].backsector->special == 9))) // revealed secret boundaries are greened, exclude them
+		{
+		    AM_drawMline(&l, TSWALLCOLORS+lightlev);
+		}
+
 		else if (lines[i].backsector->floorheight
 			   != lines[i].frontsector->floorheight) {
 		    AM_drawMline(&l, FDWALLCOLORS + lightlev); // floor level change

--- a/src/doom/r_bsp.c
+++ b/src/doom/r_bsp.c
@@ -363,12 +363,17 @@ void R_AddLine (seg_t*	line)
 	|| backsector->interpfloorheight != frontsector->interpfloorheight)
 	goto clippass;	
 		
+    // [SoDOOManiac] [crispy] all lines that belong to secret sectors should get mapped when in field of view, so that hidden secret lines in e.g. REKKR are mapped upon seeing
+    if (frontsector->oldspecial == 9 || backsector->oldspecial == 9 || frontsector->special == 9 || backsector->special == 9)
+	goto clippass;
+	
     // Reject empty lines used for triggers
-    //  and special events.
+    // and special events.
     // Identical floor and ceiling on both sides,
     // identical light levels on both sides,
     // and no middle texture.
-    if (backsector->ceilingpic == frontsector->ceilingpic
+    // [SoDOOManiac] added else because there are some lines for which both last conditions are met
+    else if (backsector->ceilingpic == frontsector->ceilingpic
 	&& backsector->floorpic == frontsector->floorpic
 	&& backsector->lightlevel == frontsector->lightlevel
 	&& curline->sidedef->midtexture == 0)


### PR DESCRIPTION
As we're going for better REKKR support, maybe include a fix for the step that Revae took aside from Doom community standards?
He made all the secret lines hidden so that they don't display with Automap powerup.
I propose a more subtle solution: secret lines still don't display with Automap powerup if the player hasn't seen them,
**but if the player has seen the secret hidden lines, force drawing them on the automap.**
I tried this approach in my fork and it works quite well.
For example, here in white rectangles there are secret sectors that the player has seen, one triggered, one not, their lines are hidden:
![DOOM0039](https://user-images.githubusercontent.com/15119473/189474150-56d0efb2-51c9-4bed-b00e-b31a0729da94.png)
Here I force mapping the seen secret sector lines even if they're hidden:
![DOOM0002](https://user-images.githubusercontent.com/15119473/189474200-47bd2044-12b4-4161-b349-7b1e2895c77f.png)
same with extended automap colors
![DOOM0003](https://user-images.githubusercontent.com/15119473/189474220-5ade3796-a36a-4e42-95c4-85e474fcd7fd.png)
and (extended automap colors && reporting revealed secrets): on or count
![DOOM0004](https://user-images.githubusercontent.com/15119473/189474240-3357c4ad-259f-4647-b27e-b2646990953f.png)
revealed sector is bright green.