### PR TITLE
Doom: shift widgets one line down so chat typing line may appear

### DIFF
--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -668,6 +668,7 @@ void HU_Start(void)
 		       HU_COORDX, HU_MSGY,
 		       hu_font,
 		       HU_FONTSTART);
+
     
     switch ( logical_gamemission )
     {
@@ -1065,7 +1066,8 @@ void HU_Ticker(void)
         w_kills.y = HU_MSGY + 1 * 8 + chat_line;
         w_items.y = HU_MSGY + 2 * 8 + chat_line;
         w_scrts.y = HU_MSGY + 3 * 8 + chat_line;
-        w_ltime.y = HU_MSGY + 4 * 8 + chat_line;
+        // [crispy] do not shift level time widget if no stats widget is used
+        w_ltime.y = HU_MSGY + 4 * 8 + (crispy->automapstats ? chat_line : 0);
         w_coordx.y = HU_MSGY + 1 * 8 + chat_line;
         w_coordy.y = HU_MSGY + 2 * 8 + chat_line;
         w_coorda.y = HU_MSGY + 3 * 8 + chat_line;
@@ -1085,7 +1087,6 @@ void HU_Ticker(void)
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
 
-	if (crispy->automapstats == WIDGETS_STBAR)
 	w_kills.y = HU_TITLEY;
 
 	crispy_statsline(str, sizeof(str), "K ", plr->killcount, totalkills, extrakills);

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -581,6 +581,51 @@ static void HU_SetSpecialLevelName (const char *wad, const char **name)
     }
 }
 
+static void HU_InitWidgets (const boolean shift_down)
+{
+    const int chat_line = shift_down ? 8 : 0;
+
+    HUlib_initTextLine(&w_kills,
+		       HU_TITLEX, HU_MSGY + 1 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_items,
+		       HU_TITLEX, HU_MSGY + 2 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_scrts,
+		       HU_TITLEX, HU_MSGY + 3 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_ltime,
+		       HU_TITLEX, HU_MSGY + 4 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coordx,
+		       HU_COORDX, HU_MSGY + 1 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coordy,
+		       HU_COORDX, HU_MSGY + 2 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coorda,
+		       HU_COORDX, HU_MSGY + 3 * 8 + chat_line,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_fps,
+		       HU_COORDX, HU_MSGY,
+		       hu_font,
+		       HU_FONTSTART);
+}
+
 static int hu_widescreendelta;
 
 void HU_Start(void)
@@ -590,8 +635,6 @@ void HU_Start(void)
     const char *s;
     // [crispy] string buffers for map title and WAD file name
     char	buf[8], *ptr;
-    // [crispy] shift widgets one line down so chat typing line may appear
-    const int net_chatline = netgame ? 8 : 0;
 
     if (headsupactive)
 	HU_Stop();
@@ -631,45 +674,8 @@ void HU_Start(void)
 		       hu_font,
 		       HU_FONTSTART);
 
-    HUlib_initTextLine(&w_kills,
-		       HU_TITLEX, HU_MSGY + 1 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_items,
-		       HU_TITLEX, HU_MSGY + 2 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_scrts,
-		       HU_TITLEX, HU_MSGY + 3 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_ltime,
-		       HU_TITLEX, HU_MSGY + 4 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coordx,
-		       HU_COORDX, HU_MSGY + 1 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coordy,
-		       HU_COORDX, HU_MSGY + 2 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coorda,
-		       HU_COORDX, HU_MSGY + 3 * 8 + net_chatline,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_fps,
-		       HU_COORDX, HU_MSGY,
-		       hu_font,
-		       HU_FONTSTART);
+    // [crispy] initialize widgets, no shifting initially
+    HU_InitWidgets(false);
 
     
     switch ( logical_gamemission )
@@ -1060,6 +1066,9 @@ void HU_Ticker(void)
 		players[i].cmd.chatchar = 0;
 	    }
 	}
+    // [crispy] shift widgets one line down so chat typing line may appear
+    if (chat_on)
+    HU_InitWidgets(true);
     }
 
     if (automapactive)
@@ -1230,6 +1239,8 @@ static void StopChatInput(void)
 {
     chat_on = false;
     I_StopTextInput();
+    // [crispy] input stopped, back widgets to standard position
+    HU_InitWidgets(false);
 }
 
 boolean HU_Responder(event_t *ev)

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -591,7 +591,7 @@ void HU_Start(void)
     // [crispy] string buffers for map title and WAD file name
     char	buf[8], *ptr;
     // [crispy] shift widgets one line down so chat typing line may appear
-    const int net_y = netgame ? 8 : 0;
+    const int net_chatline = netgame ? 8 : 0;
 
     if (headsupactive)
 	HU_Stop();
@@ -632,37 +632,37 @@ void HU_Start(void)
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_kills,
-		       HU_TITLEX, HU_MSGY + 1 * 8 + net_y,
+		       HU_TITLEX, HU_MSGY + 1 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_items,
-		       HU_TITLEX, HU_MSGY + 2 * 8 + net_y,
+		       HU_TITLEX, HU_MSGY + 2 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_scrts,
-		       HU_TITLEX, HU_MSGY + 3 * 8 + net_y,
+		       HU_TITLEX, HU_MSGY + 3 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_ltime,
-		       HU_TITLEX, HU_MSGY + 4 * 8 + net_y,
+		       HU_TITLEX, HU_MSGY + 4 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_coordx,
-		       HU_COORDX, HU_MSGY + 1 * 8,
+		       HU_COORDX, HU_MSGY + 1 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_coordy,
-		       HU_COORDX, HU_MSGY + 2 * 8,
+		       HU_COORDX, HU_MSGY + 2 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_coorda,
-		       HU_COORDX, HU_MSGY + 3 * 8,
+		       HU_COORDX, HU_MSGY + 3 * 8 + net_chatline,
 		       hu_font,
 		       HU_FONTSTART);
 

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -590,6 +590,8 @@ void HU_Start(void)
     const char *s;
     // [crispy] string buffers for map title and WAD file name
     char	buf[8], *ptr;
+    // [crispy] shift widgets one line down so chat typing line may appear
+    const int net_y = netgame ? 8 : 0;
 
     if (headsupactive)
 	HU_Stop();
@@ -630,22 +632,22 @@ void HU_Start(void)
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_kills,
-		       HU_TITLEX, HU_MSGY + 1 * 8,
+		       HU_TITLEX, HU_MSGY + 1 * 8 + net_y,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_items,
-		       HU_TITLEX, HU_MSGY + 2 * 8,
+		       HU_TITLEX, HU_MSGY + 2 * 8 + net_y,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_scrts,
-		       HU_TITLEX, HU_MSGY + 3 * 8,
+		       HU_TITLEX, HU_MSGY + 3 * 8 + net_y,
 		       hu_font,
 		       HU_FONTSTART);
 
     HUlib_initTextLine(&w_ltime,
-		       HU_TITLEX, HU_MSGY + 4 * 8,
+		       HU_TITLEX, HU_MSGY + 4 * 8 + net_y,
 		       hu_font,
 		       HU_FONTSTART);
 
@@ -1073,8 +1075,6 @@ void HU_Ticker(void)
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
 
-	w_kills.y = HU_TITLEY;
-
 	crispy_statsline(str, sizeof(str), "K ", plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);
 	s = str;
@@ -1095,8 +1095,6 @@ void HU_Ticker(void)
     if ((crispy->automapstats & WIDGETS_ALWAYS) || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
-
-	w_kills.y = HU_MSGY + 1 * 8;
 
 	crispy_statsline(str, sizeof(str), kills, plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -581,51 +581,6 @@ static void HU_SetSpecialLevelName (const char *wad, const char **name)
     }
 }
 
-static void HU_InitWidgets (const boolean shift_down)
-{
-    const int chat_line = shift_down ? 8 : 0;
-
-    HUlib_initTextLine(&w_kills,
-		       HU_TITLEX, HU_MSGY + 1 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_items,
-		       HU_TITLEX, HU_MSGY + 2 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_scrts,
-		       HU_TITLEX, HU_MSGY + 3 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_ltime,
-		       HU_TITLEX, HU_MSGY + 4 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coordx,
-		       HU_COORDX, HU_MSGY + 1 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coordy,
-		       HU_COORDX, HU_MSGY + 2 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_coorda,
-		       HU_COORDX, HU_MSGY + 3 * 8 + chat_line,
-		       hu_font,
-		       HU_FONTSTART);
-
-    HUlib_initTextLine(&w_fps,
-		       HU_COORDX, HU_MSGY,
-		       hu_font,
-		       HU_FONTSTART);
-}
-
 static int hu_widescreendelta;
 
 void HU_Start(void)
@@ -674,9 +629,45 @@ void HU_Start(void)
 		       hu_font,
 		       HU_FONTSTART);
 
-    // [crispy] initialize widgets, no shifting initially
-    HU_InitWidgets(false);
+    HUlib_initTextLine(&w_kills,
+		       HU_TITLEX, HU_MSGY + 1 * 8,
+		       hu_font,
+		       HU_FONTSTART);
 
+    HUlib_initTextLine(&w_items,
+		       HU_TITLEX, HU_MSGY + 2 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_scrts,
+		       HU_TITLEX, HU_MSGY + 3 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_ltime,
+		       HU_TITLEX, HU_MSGY + 4 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coordx,
+		       HU_COORDX, HU_MSGY + 1 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coordy,
+		       HU_COORDX, HU_MSGY + 2 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_coorda,
+		       HU_COORDX, HU_MSGY + 3 * 8,
+		       hu_font,
+		       HU_FONTSTART);
+
+    HUlib_initTextLine(&w_fps,
+		       HU_COORDX, HU_MSGY,
+		       hu_font,
+		       HU_FONTSTART);
     
     switch ( logical_gamemission )
     {
@@ -1067,8 +1058,18 @@ void HU_Ticker(void)
 	    }
 	}
     // [crispy] shift widgets one line down so chat typing line may appear
-    if (chat_on)
-    HU_InitWidgets(true);
+    if (crispy->automapstats != WIDGETS_STBAR)
+    {
+        const int chat_line = chat_on ? 8 : 0;
+
+        w_kills.y = HU_MSGY + 1 * 8 + chat_line;
+        w_items.y = HU_MSGY + 2 * 8 + chat_line;
+        w_scrts.y = HU_MSGY + 3 * 8 + chat_line;
+        w_ltime.y = HU_MSGY + 4 * 8 + chat_line;
+        w_coordx.y = HU_MSGY + 1 * 8 + chat_line;
+        w_coordy.y = HU_MSGY + 2 * 8 + chat_line;
+        w_coorda.y = HU_MSGY + 3 * 8 + chat_line;
+    }
     }
 
     if (automapactive)
@@ -1083,6 +1084,9 @@ void HU_Ticker(void)
     if (crispy->automapstats == WIDGETS_STBAR && (!automapactive || w_title.y != HU_TITLEY))
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
+
+	if (crispy->automapstats == WIDGETS_STBAR)
+	w_kills.y = HU_TITLEY;
 
 	crispy_statsline(str, sizeof(str), "K ", plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);
@@ -1104,6 +1108,9 @@ void HU_Ticker(void)
     if ((crispy->automapstats & WIDGETS_ALWAYS) || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
+
+	if (crispy->automapstats == WIDGETS_STBAR)
+	w_kills.y = HU_MSGY + 1 * 8;
 
 	crispy_statsline(str, sizeof(str), kills, plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);
@@ -1239,8 +1246,6 @@ static void StopChatInput(void)
 {
     chat_on = false;
     I_StopTextInput();
-    // [crispy] input stopped, back widgets to standard position
-    HU_InitWidgets(false);
 }
 
 boolean HU_Responder(event_t *ev)


### PR DESCRIPTION
Just as I have promised. This should allow chat line properly appear. Comparative screenshots: [before](https://user-images.githubusercontent.com/21193394/189541073-acc34f58-9140-44c5-899c-0f62449defa5.png) and [after](https://user-images.githubusercontent.com/21193394/189541093-1e34adfd-781f-4884-bf8b-639ac586e209.png).

However, I'm starting to forget how original HUD system is working after rewriting it on ID, so... Have I missed something? Any thoughts or corrections? And maybe we don't need it while demo playing since no chat string are recording in demos?