### PR TITLE
Restore old music backend name "Native MIDI"

### DIFF
--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -298,7 +298,7 @@ void ConfigSound(TXT_UNCAST_ARG(widget), void *user_data)
                                     TXT_DIRECTORY),
                 NULL)),
 
-        TXT_NewRadioButton("MIDI/MP3/OGG/FLAC", &snd_musicdevice, SNDDEVICE_GENMIDI), // [crispy] improve ambigious music backend name
+        TXT_NewRadioButton("Native MIDI", &snd_musicdevice, SNDDEVICE_GENMIDI),
 #ifdef _WIN32
         TXT_NewConditional(&snd_musicdevice, SNDDEVICE_GENMIDI,
             TXT_NewHorizBox(

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -303,7 +303,7 @@ void ConfigSound(TXT_UNCAST_ARG(widget), void *user_data)
         TXT_NewConditional(&snd_musicdevice, SNDDEVICE_GENMIDI,
             TXT_NewHorizBox(
                 TXT_NewStrut(4, 0),
-                TXT_NewLabel("Native MIDI Device: "),
+                TXT_NewLabel("Device: "),
                 MidiDeviceSelector(),
                 NULL)),
 #endif


### PR DESCRIPTION
Now Crispy Doom can play MP3/OGG/FLAC music with OPL and GUS backend. Not sure if "Native MIDI" is appropriate.