### PR TITLE
Don't initialize SDL music module twice

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -182,12 +182,6 @@ static boolean I_SDL_InitMusic(void)
 {
     boolean fluidsynth_sf_is_set = false;
 
-    // [crispy] Don't run initialization more than once
-    if (music_initialized)
-    {
-        return true;
-    }
-
     // If SDL_mixer is not initialized, we have to initialize it
     // and have the responsibility to shut it down later on.
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -182,6 +182,12 @@ static boolean I_SDL_InitMusic(void)
 {
     boolean fluidsynth_sf_is_set = false;
 
+    // [crispy] Don't run initialization more than once
+    if (music_initialized)
+    {
+        return true;
+    }
+
     // If SDL_mixer is not initialized, we have to initialize it
     // and have the responsibility to shut it down later on.
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -153,12 +153,6 @@ static void InitSfxModule(boolean use_sfx_prefix)
 static void InitMusicModule(void)
 {
     int i;
-
-    // [crispy] Always initialize SDL music module.
-#ifndef DISABLE_SDL2MIXER
-    music_sdl_module.Init();
-#endif
-
     music_module = NULL;
 
     for (i=0; music_modules[i] != NULL; ++i)
@@ -187,6 +181,15 @@ static void InitMusicModule(void)
             if (music_modules[i]->Init())
             {
                 music_module = music_modules[i];
+
+            #ifndef DISABLE_SDL2MIXER
+                // [crispy] Always initialize SDL music module.
+                if (music_module != &music_sdl_module)
+                {
+                    music_sdl_module.Init();
+                }
+            #endif
+
                 return;
             }
         }


### PR DESCRIPTION
Noticed that after #975 `I_SDL_InitMusic` was being called twice.