### PR TITLE
Add FPS Limit to Crispness menus

### DIFF
--- a/src/crispy.h
+++ b/src/crispy.h
@@ -33,6 +33,9 @@
 #define BETWEEN(l,u,x) (((l)>(x))?(l):((x)>(u))?(u):(x))
 #endif
 
+#define CRISPY_FPSLIMIT_MIN 35
+#define CRISPY_FPSLIMIT_MAX 500
+
 typedef struct
 {
 	// [crispy] "crispness" config variables

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -342,13 +342,7 @@ void M_CrispyToggleFpsLimit(int choice)
         return;
     }
 
-    if (numeric_enter)
-    {
-        crispy->fpslimit = choice;
-        numeric_enter = false;
-        I_StopTextInput();
-    }
-    else if (choice == 0)
+    if (choice == 0)
     {
         crispy->fpslimit--;
 
@@ -363,8 +357,18 @@ void M_CrispyToggleFpsLimit(int choice)
     }
     else if (choice == 2)
     {
-        numeric_enter = true;
-        I_StartTextInput(0, 0, 0, 0);
+        if (numeric_enter)
+        {
+            crispy->fpslimit = numeric_entry;
+            numeric_enter = false;
+            I_StopTextInput();
+        }
+        else
+        {
+            numeric_enter = true;
+            I_StartTextInput(0, 0, 0, 0);
+            return;
+        }
     }
 
     if (crispy->fpslimit && crispy->fpslimit < CRISPY_FPSLIMIT_MIN)

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -339,7 +339,6 @@ void M_CrispyToggleFpsLimit(int choice)
 {
     if (!crispy->uncapped)
     {
-        numeric_enter = false;
         return;
     }
 

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -19,6 +19,7 @@
 
 #include "crispy.h"
 #include "doomstat.h"
+#include "i_input.h" // [crispy] start/stop text input
 #include "m_menu.h" // [crispy] M_SetDefaultDifficulty()
 #include "p_local.h" // [crispy] thinkercap
 #include "s_sound.h"
@@ -338,14 +339,38 @@ void M_CrispyToggleFpsLimit(int choice)
 {
     if (!crispy->uncapped)
     {
+        numeric_enter = false;
         return;
     }
 
-    crispy->fpslimit += choice ? 1 : -1;
-
-    if (crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+    if (numeric_enter)
     {
-        crispy->fpslimit = choice ? CRISPY_FPSLIMIT_MIN : 0;
+        crispy->fpslimit = choice;
+        numeric_enter = false;
+        I_StopTextInput();
+    }
+    else if (choice == 0)
+    {
+        crispy->fpslimit--;
+
+        if (crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+        {
+            crispy->fpslimit = 0;
+        }
+    }
+    else if (choice == 1)
+    {
+        crispy->fpslimit++;
+    }
+    else if (choice == 2)
+    {
+        numeric_enter = true;
+        I_StartTextInput(0, 0, 0, 0);
+    }
+
+    if (crispy->fpslimit && crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MIN;
     }
     else if (crispy->fpslimit > CRISPY_FPSLIMIT_MAX)
     {

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -334,6 +334,25 @@ static void M_CrispyToggleSkyHook (void)
     R_InitSkyMap();
 }
 
+void M_CrispyToggleFpsLimit(int choice)
+{
+    if (!crispy->uncapped)
+    {
+        return;
+    }
+
+    crispy->fpslimit += choice ? 1 : -1;
+
+    if (crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+    {
+        crispy->fpslimit = choice ? CRISPY_FPSLIMIT_MIN : 0;
+    }
+    else if (crispy->fpslimit > CRISPY_FPSLIMIT_MAX)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MAX;
+    }
+}
+
 void M_CrispyToggleFreelook(int choice)
 {
     ChangeSettingEnum(&crispy->freelook, choice, NUM_FREELOOKS);

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -64,6 +64,7 @@ extern void M_CrispyToggleFlipcorpses(int choice);
 extern void M_CrispyToggleFreeaim(int choice);
 extern void M_CrispyToggleFreelook(int choice);
 extern void M_CrispyToggleFullsounds(int choice);
+extern void M_CrispyToggleFpsLimit(int choice);
 extern void M_CrispyToggleHires(int choice);
 extern void M_CrispyToggleJumping(int choice);
 extern void M_CrispyToggleLeveltime(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1458,7 +1458,7 @@ static void M_DrawCrispnessHeader(const char *item)
 {
     M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),
                "%s%s", crstr[CR_GOLD], item);
-    M_WriteText(ORIGWIDTH/2 - M_StringWidth(item) / 2, 2, crispy_menu_text);
+    M_WriteText(ORIGWIDTH/2 - M_StringWidth(item) / 2, 6, crispy_menu_text);
 }
 
 static void M_DrawCrispnessSeparator(int y, const char *item)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1516,6 +1516,7 @@ static void M_DrawCrispnessNumericItem(int y, const char *item, int feat, const 
                cond ? (feat || numeric_enter ? number : zero) : disabled);
     M_WriteText(currentMenu->x, currentMenu->y + CRISPY_LINEHEIGHT * y, crispy_menu_text);
 }
+
 static void M_DrawCrispnessGoto(int y, const char *item)
 {
     M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -431,6 +431,7 @@ enum
     crispness_hires,
     crispness_widescreen,
     crispness_uncapped,
+    crispness_fpslimit,
     crispness_vsync,
     crispness_smoothscaling,
     crispness_sep_rendering_,
@@ -455,6 +456,7 @@ static menuitem_t Crispness1Menu[]=
     {2,"",	M_CrispyToggleHires,'h'},
     {2,"",	M_CrispyToggleWidescreen,'w'},
     {2,"",	M_CrispyToggleUncapped,'u'},
+    {2,"",	M_CrispyToggleFpsLimit,'f'},
     {2,"",	M_CrispyToggleVsync,'v'},
     {2,"",	M_CrispyToggleSmoothScaling,'s'},
     {-1,"",0,'\0'},
@@ -476,7 +478,7 @@ static menu_t  Crispness1Def =
     &OptionsDef,
     Crispness1Menu,
     M_DrawCrispness1,
-    48,28,
+    48,18,
     1
 };
 
@@ -531,7 +533,7 @@ static menu_t  Crispness2Def =
     &OptionsDef,
     Crispness2Menu,
     M_DrawCrispness2,
-    48,28,
+    48,18,
     1
 };
 
@@ -586,7 +588,7 @@ static menu_t  Crispness3Def =
     &OptionsDef,
     Crispness3Menu,
     M_DrawCrispness3,
-    48,28,
+    48,18,
     1
 };
 
@@ -634,7 +636,7 @@ static menu_t  Crispness4Def =
     &OptionsDef,
     Crispness4Menu,
     M_DrawCrispness4,
-    48,28,
+    48,18,
     1
 };
 
@@ -1456,7 +1458,7 @@ static void M_DrawCrispnessHeader(const char *item)
 {
     M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),
                "%s%s", crstr[CR_GOLD], item);
-    M_WriteText(ORIGWIDTH/2 - M_StringWidth(item) / 2, 12, crispy_menu_text);
+    M_WriteText(ORIGWIDTH/2 - M_StringWidth(item) / 2, 2, crispy_menu_text);
 }
 
 static void M_DrawCrispnessSeparator(int y, const char *item)
@@ -1484,6 +1486,17 @@ static void M_DrawCrispnessMultiItem(int y, const char *item, multiitem_t *multi
     M_WriteText(currentMenu->x, currentMenu->y + CRISPY_LINEHEIGHT * y, crispy_menu_text);
 }
 
+static void M_DrawCrispnessNumericItem(int y, const char *item, int feat, const char *zero, boolean cond, const char *disabled)
+{
+    char number[6];
+    M_snprintf(number, 6, "%d", feat);
+
+    M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),
+               "%s%s: %s%s", cond ? crstr[CR_NONE] : crstr[CR_DARK], item,
+               cond ? (feat ? crstr[CR_GREEN] : crstr[CR_DARK]) : crstr[CR_DARK],
+               cond ? (feat ? number : zero) : disabled);
+    M_WriteText(currentMenu->x, currentMenu->y + CRISPY_LINEHEIGHT * y, crispy_menu_text);
+}
 static void M_DrawCrispnessGoto(int y, const char *item)
 {
     M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),
@@ -1501,6 +1514,7 @@ static void M_DrawCrispness1(void)
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
     M_DrawCrispnessMultiItem(crispness_widescreen, "Widescreen Aspect Ratio", multiitem_widescreen, crispy->widescreen, aspect_ratio_correct == 1);
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
+    M_DrawCrispnessNumericItem(crispness_fpslimit, "FPS Limit", crispy->fpslimit, "None", crispy->uncapped, "35");
     M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, !force_software_renderer);
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -162,7 +162,8 @@ typedef struct
     // if status = 2,
     //   choice=0:leftarrow,1:rightarrow
     // [crispy] if status = 3,
-    //   choice=0:leftarrow,1:rightarrow,3:enter
+    //   choice=0:leftarrow,1:rightarrow,2:enter
+    //   choice=numeric value after entry is complete
     void	(*routine)(int choice);
     
     // hotkey in menu

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -125,7 +125,8 @@ char			saveOldString[SAVESTRINGSIZE];
 // [crispy] for entering numeric values
 #define NUMERIC_ENTRY_NUMDIGITS 3
 boolean numeric_enter;
-static char numeric_entry[NUMERIC_ENTRY_NUMDIGITS + 1];
+int numeric_entry;
+static char numeric_entry_str[NUMERIC_ENTRY_NUMDIGITS + 1];
 static int numeric_entry_index;
 
 boolean			inhelpscreens;
@@ -163,7 +164,6 @@ typedef struct
     //   choice=0:leftarrow,1:rightarrow
     // [crispy] if status = 3,
     //   choice=0:leftarrow,1:rightarrow,2:enter
-    //   choice=numeric value after entry is complete
     void	(*routine)(int choice);
     
     // hotkey in menu
@@ -1503,7 +1503,7 @@ static void M_DrawCrispnessNumericItem(int y, const char *item, int feat, const 
 
     if (numeric_enter)
     {
-        M_snprintf(number, size, "%s_", numeric_entry);
+        M_snprintf(number, size, "%s_", numeric_entry_str);
     }
     else
     {
@@ -2541,7 +2541,7 @@ boolean M_Responder (event_t* ev)
                 if (numeric_entry_index > 0)
                 {
                     numeric_entry_index--;
-                    numeric_entry[numeric_entry_index] = '\0';
+                    numeric_entry_str[numeric_entry_index] = '\0';
                 }
                 break;
             case KEY_ESCAPE:
@@ -2549,9 +2549,10 @@ boolean M_Responder (event_t* ev)
                 I_StopTextInput();
                 break;
             case KEY_ENTER:
-                if (numeric_entry[0] != '\0')
+                if (numeric_entry_str[0] != '\0')
                 {
-                    currentMenu->menuitems[itemOn].routine(atoi(numeric_entry));
+                    numeric_entry = atoi(numeric_entry_str);
+                    currentMenu->menuitems[itemOn].routine(2);
                 }
                 else
                 {
@@ -2577,8 +2578,8 @@ boolean M_Responder (event_t* ev)
                 if (ch >= '0' && ch <= '9' &&
                         numeric_entry_index < NUMERIC_ENTRY_NUMDIGITS)
                 {
-                    numeric_entry[numeric_entry_index++] = ch;
-                    numeric_entry[numeric_entry_index] = '\0';
+                    numeric_entry_str[numeric_entry_index++] = ch;
+                    numeric_entry_str[numeric_entry_index] = '\0';
                 }
                 else
                 {
@@ -2835,7 +2836,7 @@ boolean M_Responder (event_t* ev)
             {
                 currentMenu->menuitems[itemOn].routine(2); // enter key
                 numeric_entry_index = 0;
-                numeric_entry[0] = '\0';
+                numeric_entry_str[0] = '\0';
                 S_StartSoundOptional(NULL, sfx_mnuact, sfx_pistol);
             }
 	    else

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1501,7 +1501,7 @@ static void M_DrawCrispness1(void)
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
     M_DrawCrispnessMultiItem(crispness_widescreen, "Widescreen Aspect Ratio", multiitem_widescreen, crispy->widescreen, aspect_ratio_correct == 1);
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);
-    M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer && !crispy->fpslimit);
+    M_DrawCrispnessItem(crispness_vsync, "Enable VSync", crispy->vsync, !force_software_renderer);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, !force_software_renderer);
 
     M_DrawCrispnessSeparator(crispness_sep_visual, "Visual");

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -122,6 +122,12 @@ static boolean          joypadSave = false; // was the save action initiated by 
 // old save description before edit
 char			saveOldString[SAVESTRINGSIZE];  
 
+// [crispy] for entering numeric values
+#define NUMERIC_ENTRY_NUMDIGITS 3
+boolean numeric_enter;
+static char numeric_entry[NUMERIC_ENTRY_NUMDIGITS + 1];
+static int numeric_entry_index;
+
 boolean			inhelpscreens;
 boolean			menuactive;
 
@@ -147,6 +153,7 @@ extern boolean speedkeydown (void);
 typedef struct
 {
     // 0 = no cursor here, 1 = ok, 2 = arrows ok
+    // [crispy] 3 = arrows ok, enter for numeric entry
     short	status;
     
     char	name[10];
@@ -154,6 +161,8 @@ typedef struct
     // choice = menu item #.
     // if status = 2,
     //   choice=0:leftarrow,1:rightarrow
+    // [crispy] if status = 3,
+    //   choice=0:leftarrow,1:rightarrow,3:enter
     void	(*routine)(int choice);
     
     // hotkey in menu
@@ -456,7 +465,7 @@ static menuitem_t Crispness1Menu[]=
     {2,"",	M_CrispyToggleHires,'h'},
     {2,"",	M_CrispyToggleWidescreen,'w'},
     {2,"",	M_CrispyToggleUncapped,'u'},
-    {2,"",	M_CrispyToggleFpsLimit,'f'},
+    {3,"",	M_CrispyToggleFpsLimit,'f'},
     {2,"",	M_CrispyToggleVsync,'v'},
     {2,"",	M_CrispyToggleSmoothScaling,'s'},
     {-1,"",0,'\0'},
@@ -1488,13 +1497,22 @@ static void M_DrawCrispnessMultiItem(int y, const char *item, multiitem_t *multi
 
 static void M_DrawCrispnessNumericItem(int y, const char *item, int feat, const char *zero, boolean cond, const char *disabled)
 {
-    char number[6];
-    M_snprintf(number, 6, "%d", feat);
+    const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
+    char number[size];
+
+    if (numeric_enter)
+    {
+        M_snprintf(number, size, "%s_", numeric_entry);
+    }
+    else
+    {
+        M_snprintf(number, size, "%d", feat);
+    }
 
     M_snprintf(crispy_menu_text, sizeof(crispy_menu_text),
                "%s%s: %s%s", cond ? crstr[CR_NONE] : crstr[CR_DARK], item,
-               cond ? (feat ? crstr[CR_GREEN] : crstr[CR_DARK]) : crstr[CR_DARK],
-               cond ? (feat ? number : zero) : disabled);
+               cond ? (feat || numeric_enter ? crstr[CR_GREEN] : crstr[CR_DARK]) : crstr[CR_DARK],
+               cond ? (feat || numeric_enter ? number : zero) : disabled);
     M_WriteText(currentMenu->x, currentMenu->y + CRISPY_LINEHEIGHT * y, crispy_menu_text);
 }
 static void M_DrawCrispnessGoto(int y, const char *item)
@@ -2513,6 +2531,62 @@ boolean M_Responder (event_t* ev)
 	return true;
     }
 
+    // [crispy] Enter numeric value
+    if (numeric_enter)
+    {
+        switch(key)
+        {
+            case KEY_BACKSPACE:
+                if (numeric_entry_index > 0)
+                {
+                    numeric_entry_index--;
+                    numeric_entry[numeric_entry_index] = '\0';
+                }
+                break;
+            case KEY_ESCAPE:
+                numeric_enter = false;
+                I_StopTextInput();
+                break;
+            case KEY_ENTER:
+                if (numeric_entry[0] != '\0')
+                {
+                    currentMenu->menuitems[itemOn].routine(atoi(numeric_entry));
+                }
+                else
+                {
+                    numeric_enter = false;
+                    I_StopTextInput();
+                }
+                break;
+            default:
+                if (ev->type != ev_keydown)
+                {
+                    break;
+                }
+
+                if (vanilla_keyboard_mapping)
+                {
+                    ch = ev->data1;
+                }
+                else
+                {
+                    ch = ev->data3;
+                }
+
+                if (ch >= '0' && ch <= '9' &&
+                        numeric_entry_index < NUMERIC_ENTRY_NUMDIGITS)
+                {
+                    numeric_entry[numeric_entry_index++] = ch;
+                    numeric_entry[numeric_entry_index] = '\0';
+                }
+                else
+                {
+                    break;
+                }
+        }
+        return true;
+    }
+
     // Take care of any messages that need input
     if (messageToPrint)
     {
@@ -2724,7 +2798,7 @@ boolean M_Responder (event_t* ev)
         // Slide slider left
 
 	if (currentMenu->menuitems[itemOn].routine &&
-	    currentMenu->menuitems[itemOn].status == 2)
+	    currentMenu->menuitems[itemOn].status >= 2)
 	{
 	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    currentMenu->menuitems[itemOn].routine(0);
@@ -2736,7 +2810,7 @@ boolean M_Responder (event_t* ev)
         // Slide slider right
 
 	if (currentMenu->menuitems[itemOn].routine &&
-	    currentMenu->menuitems[itemOn].status == 2)
+	    currentMenu->menuitems[itemOn].status >= 2)
 	{
 	    S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    currentMenu->menuitems[itemOn].routine(1);
@@ -2756,6 +2830,13 @@ boolean M_Responder (event_t* ev)
 		currentMenu->menuitems[itemOn].routine(1);      // right arrow
 		S_StartSoundOptional(NULL, sfx_mnusli, sfx_stnmov); // [NS] Optional menu sounds.
 	    }
+            else if (currentMenu->menuitems[itemOn].status == 3) // [crispy]
+            {
+                currentMenu->menuitems[itemOn].routine(2); // enter key
+                numeric_entry_index = 0;
+                numeric_entry[0] = '\0';
+                S_StartSoundOptional(NULL, sfx_mnuact, sfx_pistol);
+            }
 	    else
 	    {
 		currentMenu->menuitems[itemOn].routine(itemOn);

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -60,5 +60,6 @@ extern int screenblocks;
 extern boolean inhelpscreens;
 extern int showMessages;
 
+extern boolean numeric_enter; // [crispy]
 
 #endif

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -60,6 +60,8 @@ extern int screenblocks;
 extern boolean inhelpscreens;
 extern int showMessages;
 
-extern boolean numeric_enter; // [crispy]
+// [crispy] Numeric entry
+extern boolean numeric_enter;
+extern int numeric_entry;
 
 #endif

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -40,6 +40,7 @@
 
 #define LEFT_DIR 0
 #define RIGHT_DIR 1
+#define ENTER_NUMBER 2
 #define ITEM_HEIGHT 20
 #define SELECTOR_XOFFSET (-28)
 #define SELECTOR_YOFFSET (-1)
@@ -54,6 +55,7 @@ typedef enum
     ITT_EFUNC,
     ITT_LRFUNC,
     ITT_SETMENU,
+    ITT_NUMFUNC,
     ITT_INERT
 } ItemType_t;
 
@@ -132,6 +134,7 @@ static boolean CrispyFreelook(int option);
 static boolean CrispyMouselook(int option);
 static boolean CrispyDefaultskill(int option);
 static boolean CrispyUncapped(int option);
+static boolean CrispyFpsLimit(int option);
 static boolean CrispyVsync(int option);
 static boolean CrispyNextPage(int option);
 static boolean CrispyPrevPage(int option);
@@ -186,6 +189,13 @@ static int slotptr;
 static int currentSlot;
 static int quicksave;
 static int quickload;
+
+// [crispy] for entering numeric values
+#define NUMERIC_ENTRY_NUMDIGITS 3
+static boolean numeric_enter;
+static int numeric_entry;
+static char numeric_entry_str[NUMERIC_ENTRY_NUMDIGITS + 1];
+static int numeric_entry_index;
 
 static MenuItem_t MainItems[] = {
     {ITT_EFUNC, "NEW GAME", SCNetCheck, 1, MENU_EPISODE},
@@ -343,6 +353,7 @@ static MenuItem_t Crispness1Items[] = {
     {ITT_LRFUNC, "ASPECT RATIO:", CrispyToggleWidescreen, 0, MENU_NONE},
     {ITT_LRFUNC, "SMOOTH PIXEL SCALING:", CrispySmoothing, 0, MENU_NONE},
     {ITT_LRFUNC, "UNCAPPED FRAMERATE:", CrispyUncapped, 0, MENU_NONE},
+    {ITT_NUMFUNC, "FPS LIMIT:", CrispyFpsLimit, 0, MENU_NONE},
     {ITT_LRFUNC, "ENABLE VSYNC:", CrispyVsync, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
@@ -351,8 +362,6 @@ static MenuItem_t Crispness1Items[] = {
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC, "SHOW LEVEL STATS:", CrispyAutomapStats, 0, MENU_NONE},
     {ITT_LRFUNC, "SHOW LEVEL TIME:", CrispyLevelTime, 0, MENU_NONE},
-    {ITT_LRFUNC, "SHOW PLAYER COORDS:", CrispyPlayerCoords, 0, MENU_NONE},
-    {ITT_LRFUNC, "REPORT REVEALED SECRETS:", CrispySecretMessage, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EFUNC, "NEXT PAGE", CrispyNextPage, 0, MENU_NONE},
 };
@@ -360,12 +369,16 @@ static MenuItem_t Crispness1Items[] = {
 static Menu_t Crispness1Menu = {
     68, 35,
     DrawCrispness,
-    16, Crispness1Items,
+    15, Crispness1Items,
     0,
     MENU_OPTIONS
 };
 
 static MenuItem_t Crispness2Items[] = {
+    {ITT_LRFUNC, "SHOW PLAYER COORDS:", CrispyPlayerCoords, 0, MENU_NONE},
+    {ITT_LRFUNC, "REPORT REVEALED SECRETS:", CrispySecretMessage, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC, "FREELOOK MODE:", CrispyFreelook, 0, MENU_NONE},
     {ITT_LRFUNC, "PERMANENT MOUSELOOK:", CrispyMouselook, 0, MENU_NONE},
     {ITT_LRFUNC, "DEFAULT DIFFICULTY:", CrispyDefaultskill, 0, MENU_NONE},
@@ -376,7 +389,7 @@ static MenuItem_t Crispness2Items[] = {
 static Menu_t Crispness2Menu = {
     68, 35,
     DrawCrispness,
-    5, Crispness2Items,
+    9, Crispness2Items,
     0,
     MENU_OPTIONS
 };
@@ -1466,6 +1479,54 @@ static boolean CrispyUncapped(int option)
     return true;
 }
 
+static boolean CrispyFpsLimit(int option)
+{
+    if (!crispy->uncapped)
+    {
+        return true;
+    }
+
+    if (option == LEFT_DIR)
+    {
+        crispy->fpslimit--;
+
+        if (crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+        {
+            crispy->fpslimit = 0;
+        }
+    }
+    else if (option == RIGHT_DIR)
+    {
+        crispy->fpslimit++;
+    }
+    else if (option == ENTER_NUMBER)
+    {
+        if (numeric_enter)
+        {
+            crispy->fpslimit = numeric_entry;
+            numeric_enter = false;
+            I_StopTextInput();
+        }
+        else
+        {
+            numeric_enter = true;
+            I_StartTextInput(0, 0, 0, 0);
+            return true;
+        }
+    }
+
+    if (crispy->fpslimit && crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MIN;
+    }
+    else if (crispy->fpslimit > CRISPY_FPSLIMIT_MAX)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MAX;
+    }
+
+    return true;
+}
+
 static void CrispyVsyncHook(void)
 {
     crispy->vsync = !crispy->vsync;
@@ -1932,7 +1993,7 @@ boolean MN_Responder(event_t * event)
         }
         return (false);
     }
-    if (!FileMenuKeySteal)
+    if (!FileMenuKeySteal && !numeric_enter)
     {
         item = &CurrentMenu->items[CurrentItPos];
 
@@ -1972,7 +2033,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_left)       // Slider left
         {
-            if (item->type == ITT_LRFUNC && item->func != NULL)
+            if ((item->type == ITT_LRFUNC || item->type == ITT_NUMFUNC) &&
+                    item->func != NULL)
             {
                 item->func(LEFT_DIR);
                 S_StartSound(NULL, sfx_keyup);
@@ -1981,7 +2043,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_right)      // Slider right
         {
-            if (item->type == ITT_LRFUNC && item->func != NULL)
+            if ((item->type == ITT_LRFUNC || item->type == ITT_NUMFUNC) &&
+                    item->func != NULL)
             {
                 item->func(RIGHT_DIR);
                 S_StartSound(NULL, sfx_keyup);
@@ -2010,6 +2073,12 @@ boolean MN_Responder(event_t * event)
                             SetMenu(item->menu);
                         }
                     }
+                }
+                else if (item->type == ITT_NUMFUNC && item->func != NULL)
+                {
+                    item->func(ENTER_NUMBER);
+                    numeric_entry_index = 0;
+                    numeric_entry_str[0] = '\0';
                 }
             }
             S_StartSound(NULL, sfx_dorcls);
@@ -2111,7 +2180,7 @@ boolean MN_Responder(event_t * event)
 
         return (false);
     }
-    else
+    else if (FileMenuKeySteal)
     {
         // Editing file names
         // When typing a savegame name, we use the fully shifted and
@@ -2172,6 +2241,50 @@ boolean MN_Responder(event_t * event)
                 slotptr++;
                 return (true);
             }
+        }
+        return (true);
+    }
+    else if (numeric_enter)
+    {
+        switch(key)
+        {
+            case KEY_BACKSPACE:
+                if (numeric_entry_index > 0)
+                {
+                    numeric_entry_index--;
+                    numeric_entry_str[numeric_entry_index] = '\0';
+                }
+                break;
+            case KEY_ESCAPE:
+                numeric_enter = false;
+                I_StopTextInput();
+                break;
+            case KEY_ENTER:
+                if (numeric_entry_str[0] != '\0')
+                {
+                    numeric_entry = atoi(numeric_entry_str);
+                    item = &CurrentMenu->items[CurrentItPos];
+                    item->func(ENTER_NUMBER);
+                }
+                else
+                {
+                    numeric_enter = false;
+                    I_StopTextInput();
+                }
+                break;
+            default:
+                charTyped = event->data3;
+
+                if (charTyped >= '0' && charTyped <= '9' &&
+                        numeric_entry_index < NUMERIC_ENTRY_NUMDIGITS)
+                {
+                    numeric_entry_str[numeric_entry_index++] = charTyped;
+                    numeric_entry_str[numeric_entry_index] = '\0';
+                }
+                else
+                {
+                    break;
+                }
         }
         return (true);
     }
@@ -2426,6 +2539,38 @@ static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *mu
     MN_DrTextA(multi[item].name, x, y);
 }
 
+static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
+        boolean cond, const char *disabled)
+{
+    const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
+    char number[size];
+
+    if (numeric_enter)
+    {
+        M_snprintf(number, size, "%s%c", numeric_entry_str, ASCII_CURSOR);
+    }
+    else
+    {
+        M_snprintf(number, size, "%d", item);
+    }
+
+    dp_translation = cond ? cr[CR_DARK] :
+                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_GRAY];
+
+    if (cond)
+    {
+        MN_DrTextA(disabled, x, y);
+    }
+    else if (item || numeric_enter)
+    {
+        MN_DrTextA(number, x, y);
+    }
+    else
+    {
+        MN_DrTextA(zero, x, y);
+    }
+}
+
 static void DrawCrispness1(void)
 {
     DrawCrispnessSubheader("RENDERING", 25);
@@ -2442,39 +2587,44 @@ static void DrawCrispness1(void)
     // Uncapped framerate
     DrawCrispnessItem(crispy->uncapped, 217, 65);
 
-    // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 75);
+    // FPS limit
+    DrawCrispnessNumericItem(crispy->fpslimit, 134, 75, "NONE", !crispy->uncapped, "35");
 
-    DrawCrispnessSubheader("VISUAL", 95);
+    // Vsync
+    DrawCrispnessItem(crispy->vsync, 167, 85);
+
+    DrawCrispnessSubheader("VISUAL", 105);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 213, 105, multiitem_brightmaps);
+    DrawCrispnessMultiItem(crispy->brightmaps, 213, 115, multiitem_brightmaps);
 
-    DrawCrispnessSubheader("NAVIGATIONAL", 125);
+    DrawCrispnessSubheader("NAVIGATIONAL", 135);
 
     // Show level stats
-    DrawCrispnessMultiItem(crispy->automapstats, 190, 135, multiitem_widgets);
+    DrawCrispnessMultiItem(crispy->automapstats, 190, 145, multiitem_widgets);
 
     // Show level time
-    DrawCrispnessMultiItem(crispy->leveltime, 179, 145, multiitem_widgets);
-
-    // Show player coords
-    DrawCrispnessMultiItem(crispy->playercoords, 211, 155, multiitem_widgets);
-
-    // Show secret message
-    DrawCrispnessMultiItem(crispy->secretmessage, 250, 165, multiitem_secretmessage);
+    DrawCrispnessMultiItem(crispy->leveltime, 179, 155, multiitem_widgets);
 }
 
 static void DrawCrispness2(void)
 {
-    DrawCrispnessSubheader("TACTICAL", 25);
+    DrawCrispnessSubheader("NAVIGATIONAL CONT.", 25);
+
+    // Show player coords
+    DrawCrispnessMultiItem(crispy->playercoords, 211, 35, multiitem_widgets);
+
+    // Show secret message
+    DrawCrispnessMultiItem(crispy->secretmessage, 250, 45, multiitem_secretmessage);
+
+    DrawCrispnessSubheader("TACTICAL", 65);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 35, multiitem_freelook_hh);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 75, multiitem_freelook_hh);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 45);
+    DrawCrispnessItem(crispy->mouselook, 220, 85);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 55, multiitem_difficulties);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 95, multiitem_difficulties);
 }

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -40,7 +40,7 @@
 
 #define LEFT_DIR 0
 #define RIGHT_DIR 1
-#define ENTER_NUMBER 2
+#define ENTER_NUMBER 2 // [crispy] numeric entry
 #define ITEM_HEIGHT 20
 #define SELECTOR_XOFFSET (-28)
 #define SELECTOR_YOFFSET (-1)
@@ -55,7 +55,7 @@ typedef enum
     ITT_EFUNC,
     ITT_LRFUNC,
     ITT_SETMENU,
-    ITT_NUMFUNC,
+    ITT_NUMFUNC, // [crispy] numeric entry
     ITT_INERT
 } ItemType_t;
 
@@ -2074,6 +2074,7 @@ boolean MN_Responder(event_t * event)
                         }
                     }
                 }
+                // [crispy] numeric entry
                 else if (item->type == ITT_NUMFUNC && item->func != NULL)
                 {
                     item->func(ENTER_NUMBER);
@@ -2244,7 +2245,7 @@ boolean MN_Responder(event_t * event)
         }
         return (true);
     }
-    else if (numeric_enter)
+    else if (numeric_enter) // [crispy] numeric entry
     {
         switch(key)
         {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2464,7 +2464,7 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
     }
 
     dp_translation = cond ? cr[CR_DARK] :
-                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_GRAY];
+                    (item || numeric_enter) ? cr[CR_GOLD] : cr[CR_GRAY];
 
     if (cond)
     {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -39,6 +39,7 @@
 
 #define LEFT_DIR 0
 #define RIGHT_DIR 1
+#define ENTER_NUMBER 2 // [crispy] numeric entry
 #define ITEM_HEIGHT 20
 #define SELECTOR_XOFFSET (-28)
 #define SELECTOR_YOFFSET (-1)
@@ -53,6 +54,7 @@ typedef enum
     ITT_EFUNC,
     ITT_LRFUNC,
     ITT_SETMENU,
+    ITT_NUMFUNC, // [crispy] numeric entry
     ITT_INERT
 } ItemType_t;
 
@@ -125,6 +127,7 @@ static void CrispyHires(int option);
 static void CrispyToggleWidescreen(int option);
 static void CrispySmoothing(int option);
 static void CrispyUncapped(int option);
+static void CrispyFpsLimit(int option);
 static void CrispyVsync(int option);
 static void CrispyBrightmaps(int option);
 static void CrispyFreelook(int option);
@@ -184,6 +187,13 @@ static int slotptr;
 static int currentSlot;
 static int quicksave;
 static int quickload;
+
+// [crispy] for entering numeric values
+#define NUMERIC_ENTRY_NUMDIGITS 3
+static boolean numeric_enter;
+static int numeric_entry;
+static char numeric_entry_str[NUMERIC_ENTRY_NUMDIGITS + 1];
+static int numeric_entry_index;
 
 static MenuItem_t MainItems[] = {
     {ITT_SETMENU, "NEW GAME", SCNetCheck2, 1, MENU_CLASS},
@@ -333,6 +343,7 @@ static MenuItem_t CrispnessItems[] = {
     {ITT_LRFUNC, "ASPECT RATIO:", CrispyToggleWidescreen, 0, MENU_NONE},
     {ITT_LRFUNC, "SMOOTH PIXEL SCALING:", CrispySmoothing, 0, MENU_NONE},
     {ITT_LRFUNC, "UNCAPPED FRAMERATE:", CrispyUncapped, 0, MENU_NONE},
+    {ITT_NUMFUNC, "FPS LIMIT:", CrispyFpsLimit, 0, MENU_NONE},
     {ITT_LRFUNC, "ENABLE VSYNC:", CrispyVsync, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
@@ -347,7 +358,7 @@ static MenuItem_t CrispnessItems[] = {
 static Menu_t CrispnessMenu = {
     68, 40,
     DrawCrispnessMenu,
-    13, CrispnessItems,
+    14, CrispnessItems,
     0,
     MENU_OPTIONS
 };
@@ -1461,6 +1472,52 @@ static void CrispyUncapped(int option)
     crispy->uncapped = !crispy->uncapped;
 }
 
+static void CrispyFpsLimit(int option)
+{
+    if (!crispy->uncapped)
+    {
+        return;
+    }
+
+    if (option == LEFT_DIR)
+    {
+        crispy->fpslimit--;
+
+        if (crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+        {
+            crispy->fpslimit = 0;
+        }
+    }
+    else if (option == RIGHT_DIR)
+    {
+        crispy->fpslimit++;
+    }
+    else if (option == ENTER_NUMBER)
+    {
+        if (numeric_enter)
+        {
+            crispy->fpslimit = numeric_entry;
+            numeric_enter = false;
+            I_StopTextInput();
+        }
+        else
+        {
+            numeric_enter = true;
+            I_StartTextInput(0, 0, 0, 0);
+            return;
+        }
+    }
+
+    if (crispy->fpslimit && crispy->fpslimit < CRISPY_FPSLIMIT_MIN)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MIN;
+    }
+    else if (crispy->fpslimit > CRISPY_FPSLIMIT_MAX)
+    {
+        crispy->fpslimit = CRISPY_FPSLIMIT_MAX;
+    }
+}
+
 static void CrispyVsyncHook(void)
 {
     crispy->vsync = !crispy->vsync;
@@ -1899,7 +1956,7 @@ boolean MN_Responder(event_t * event)
         }
         return (false);
     }
-    if (!FileMenuKeySteal)
+    if (!FileMenuKeySteal && !numeric_enter)
     {
         item = &CurrentMenu->items[CurrentItPos];
 
@@ -1939,7 +1996,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_left)           // Slider left
         {
-            if (item->type == ITT_LRFUNC && item->func != NULL)
+            if ((item->type == ITT_LRFUNC || item->type == ITT_NUMFUNC) &&
+                    item->func != NULL)
             {
                 item->func(LEFT_DIR);
                 S_StartSound(NULL, SFX_PICKUP_KEY);
@@ -1948,7 +2006,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_right)          // Slider right
         {
-            if (item->type == ITT_LRFUNC && item->func != NULL)
+            if ((item->type == ITT_LRFUNC || item->type == ITT_NUMFUNC)
+                    && item->func != NULL)
             {
                 item->func(RIGHT_DIR);
                 S_StartSound(NULL, SFX_PICKUP_KEY);
@@ -1975,6 +2034,13 @@ boolean MN_Responder(event_t * event)
                 else if (item->type == ITT_EFUNC)
                 {
                     item->func(item->option);
+                }
+                // [crispy] numeric entry
+                else if (item->type == ITT_NUMFUNC && item->func != NULL)
+                {
+                    item->func(ENTER_NUMBER);
+                    numeric_entry_index = 0;
+                    numeric_entry_str[0] = '\0';
                 }
             }
             S_StartSound(NULL, SFX_DOOR_LIGHT_CLOSE);
@@ -2062,7 +2128,7 @@ boolean MN_Responder(event_t * event)
         }
         return (false);
     }
-    else
+    else if (FileMenuKeySteal)
     {
         // Editing file names
         // When typing a savegame name, we use the fully shifted and
@@ -2121,6 +2187,50 @@ boolean MN_Responder(event_t * event)
                 slotptr++;
                 return (true);
             }
+        }
+        return (true);
+    }
+    else if (numeric_enter) // [crispy] numeric entry
+    {
+        switch(key)
+        {
+            case KEY_BACKSPACE:
+                if (numeric_entry_index > 0)
+                {
+                    numeric_entry_index--;
+                    numeric_entry_str[numeric_entry_index] = '\0';
+                }
+                break;
+            case KEY_ESCAPE:
+                numeric_enter = false;
+                I_StopTextInput();
+                break;
+            case KEY_ENTER:
+                if (numeric_entry_str[0] != '\0')
+                {
+                    numeric_entry = atoi(numeric_entry_str);
+                    item = &CurrentMenu->items[CurrentItPos];
+                    item->func(ENTER_NUMBER);
+                }
+                else
+                {
+                    numeric_enter = false;
+                    I_StopTextInput();
+                }
+                break;
+            default:
+                charTyped = event->data3;
+
+                if (charTyped >= '0' && charTyped <= '9' &&
+                        numeric_entry_index < NUMERIC_ENTRY_NUMDIGITS)
+                {
+                    numeric_entry_str[numeric_entry_index++] = charTyped;
+                    numeric_entry_str[numeric_entry_index] = '\0';
+                }
+                else
+                {
+                    break;
+                }
         }
         return (true);
     }
@@ -2338,6 +2448,38 @@ static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *mu
     MN_DrTextA(multi[item].name, x, y);
 }
 
+static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
+        boolean cond, const char *disabled)
+{
+    const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
+    char number[size];
+
+    if (numeric_enter)
+    {
+        M_snprintf(number, size, "%s%c", numeric_entry_str, ASCII_CURSOR);
+    }
+    else
+    {
+        M_snprintf(number, size, "%d", item);
+    }
+
+    dp_translation = cond ? cr[CR_DARK] :
+                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_GRAY];
+
+    if (cond)
+    {
+        MN_DrTextA(disabled, x, y);
+    }
+    else if (item || numeric_enter)
+    {
+        MN_DrTextA(number, x, y);
+    }
+    else
+    {
+        MN_DrTextA(zero, x, y);
+    }
+}
+
 static void DrawCrispnessMenu(void)
 {
     static const char *title;
@@ -2363,24 +2505,27 @@ static void DrawCrispnessMenu(void)
     // Uncapped framerate
     DrawCrispnessItem(crispy->uncapped, 217, 70);
 
-    // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 80);
+    // FPS limit
+    DrawCrispnessNumericItem(crispy->fpslimit, 134, 80, "NONE", !crispy->uncapped, "35");
 
-    DrawCrispnessSubheader("VISUAL", 100);
+    // Vsync
+    DrawCrispnessItem(crispy->vsync, 167, 90);
+
+    DrawCrispnessSubheader("VISUAL", 110);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 150, 110, multiitem_brightmaps);
+    DrawCrispnessMultiItem(crispy->brightmaps, 150, 120, multiitem_brightmaps);
 
-    DrawCrispnessSubheader("TACTICAL", 130);
+    DrawCrispnessSubheader("TACTICAL", 140);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 140, multiitem_freelook_hh);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 150, multiitem_freelook_hh);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 150);
+    DrawCrispnessItem(crispy->mouselook, 220, 160);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 160, multiitem_difficulties);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 170, multiitem_difficulties);
 
     dp_translation = NULL;
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -226,9 +226,6 @@ static const unsigned int *icon_data;
 static int icon_w;
 static int icon_h;
 
-// If true, we limit the framerate when running uncapped.
-static boolean limit_framerate = false;
-
 static boolean MouseShouldBeGrabbed()
 {
     // never grab the mouse when in screensaver mode
@@ -900,7 +897,7 @@ void I_FinishUpdate (void)
     if (crispy->uncapped)
     {
         // Limit framerate
-        if (limit_framerate)
+        if (crispy->fpslimit > 0)
         {
             static uint64_t last_frame;
             uint64_t current_frame;
@@ -1433,10 +1430,6 @@ static void SetVideoMode(void)
         {
             renderer_flags |= SDL_RENDERER_PRESENTVSYNC;
         }
-        else if (crispy->fpslimit > 0)
-        {
-            limit_framerate = true;
-        }
     }
 
     if (force_software_renderer)
@@ -1444,7 +1437,6 @@ static void SetVideoMode(void)
         renderer_flags |= SDL_RENDERER_SOFTWARE;
         renderer_flags &= ~SDL_RENDERER_PRESENTVSYNC;
         crispy->vsync = false;
-        limit_framerate = (crispy->fpslimit > 0);
     }
 
     if (renderer != NULL)
@@ -1818,12 +1810,10 @@ void I_ReInitGraphics (int reinit)
 		if (crispy->vsync && !(flags & SDL_RENDERER_SOFTWARE))
 		{
 			flags |= SDL_RENDERER_PRESENTVSYNC;
-			limit_framerate = false;
 		}
 		else
 		{
 			flags &= ~SDL_RENDERER_PRESENTVSYNC;
-			limit_framerate = (crispy->fpslimit > 0);
 		}
 
 		SDL_DestroyRenderer(renderer);


### PR DESCRIPTION
Here's a first go at adding this to Doom. To fit the new item in, I opted to move everything up. Objections to this approach are welcome. :smiley:

Before:
<img src="https://user-images.githubusercontent.com/43701387/210280149-d97fd976-89c2-41c8-a787-af9087050a84.png" width=50% height=50%>

After:
<img src="https://user-images.githubusercontent.com/43701387/210280007-3e0a93ae-cdb8-4bbb-9203-2c116d8ef20b.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/43701387/210279999-70ea3600-43a4-4708-8516-7e6d4c885e4f.png" width=50% height=50%>

I think it is prudent to disable the option when Uncapped Framerate is off, so I have done so here.

Once everyone's happy with the base implementation I'll port it over to the Raven games and un-draft the PR.

Fixes #979.