### PR TITLE
Fix MSVC compiler error (C2057)

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1498,8 +1498,8 @@ static void M_DrawCrispnessMultiItem(int y, const char *item, multiitem_t *multi
 
 static void M_DrawCrispnessNumericItem(int y, const char *item, int feat, const char *zero, boolean cond, const char *disabled)
 {
+    char number[NUMERIC_ENTRY_NUMDIGITS + 2];
     const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
-    char number[size];
 
     if (numeric_enter)
     {

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2543,8 +2543,8 @@ static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *mu
 static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
         boolean cond, const char *disabled)
 {
+    char number[NUMERIC_ENTRY_NUMDIGITS + 2];
     const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
-    char number[size];
 
     if (numeric_enter)
     {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2451,8 +2451,8 @@ static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *mu
 static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
         boolean cond, const char *disabled)
 {
+    char number[NUMERIC_ENTRY_NUMDIGITS + 2];
     const int size = NUMERIC_ENTRY_NUMDIGITS + 2;
-    char number[size];
 
     if (numeric_enter)
     {


### PR DESCRIPTION
For some reason MSVC doesn't like `const` variables for array size, see [C2057](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2057?view=msvc-170) (C section)