### PR TITLE
Add command line param for setting display number

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1247,6 +1247,22 @@ void I_GraphicsCheckCommandLine(void)
     {
         SetScaleFactor(3);
     }
+
+
+    //!
+    // @category video
+    // @arg <x>
+    //
+    // Specify the display number on which to show the screen.
+    //
+
+    i = M_CheckParmWithArgs("-display", 1);
+    if (i > 0)
+    {
+        int display = atoi(myargv[i + 1]);
+        if (display >= 0)
+            video_display = display;
+    }
 }
 
 // Check if we have been invoked as a screensaver by xscreensaver.


### PR DESCRIPTION
I've got a setup with multiple monitors (laptop and external) and I found that it would be useful to have a command parameter for setting display number when starting crispy-doom. Not sure if any error handling is needed, since this will already work even if you input wrong number (it falls back to 0th display).