### PR TITLE
Raven: Make Crispness menu appearance more like Doom's

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2499,27 +2499,20 @@ static void M_DrawCrispnessBackground(void)
 
 static void DrawCrispness(void)
 {
-    static const char *title;
-    char menupage[6];
-
     SetMenu(CrispnessMenus[crispnessmenupage]);
 
     // Background
     M_DrawCrispnessBackground();
 
-    // Title
-    title = DEH_String("CRISPNESS");
-    MN_DrTextB(title, 160 - MN_TextBWidth(title) / 2, 2);
-
-    // Page number
-    dp_translation = cr[CR_GREEN];
-    M_snprintf(menupage, sizeof(menupage), "%d / %d", crispnessmenupage + 1,
-                NUM_CRISPNESS_MENUS);
-    MN_DrTextA(menupage, 320 - MN_TextAWidth(menupage) - 20, 10);
-
     (*CrispnessMenuDrawers[crispnessmenupage])();
 
     dp_translation = NULL;
+}
+
+static void DrawCrispnessHeader(const char *item)
+{
+    dp_translation = cr[CR_GOLD];
+    MN_DrTextA(item, 160 - MN_TextAWidth(item) / 2, 6);
 }
 
 static void DrawCrispnessSubheader(const char *name, int y)
@@ -2530,13 +2523,13 @@ static void DrawCrispnessSubheader(const char *name, int y)
 
 static void DrawCrispnessItem(boolean item, int x, int y)
 {
-    dp_translation = item ? cr[CR_GREEN] : cr[CR_GRAY];
+    dp_translation = item ? cr[CR_GREEN] : cr[CR_DARK];
     MN_DrTextA(item ? "ON" : "OFF", x, y);
 }
 
 static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *multi)
 {
-    dp_translation = item ? cr[CR_GREEN] : cr[CR_GRAY];
+    dp_translation = item ? cr[CR_GREEN] : cr[CR_DARK];
     MN_DrTextA(multi[item].name, x, y);
 }
 
@@ -2555,8 +2548,8 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
         M_snprintf(number, size, "%d", item);
     }
 
-    dp_translation = cond ? cr[CR_DARK] :
-                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_GRAY];
+    dp_translation = cond ? cr[CR_GRAY] :
+                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_DARK];
 
     if (cond)
     {
@@ -2574,6 +2567,8 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispness1(void)
 {
+    DrawCrispnessHeader("CRISPNESS 1/2");
+
     DrawCrispnessSubheader("RENDERING", 25);
 
     // Hires rendering
@@ -2610,6 +2605,8 @@ static void DrawCrispness1(void)
 
 static void DrawCrispness2(void)
 {
+    DrawCrispnessHeader("CRISPNESS 2/2");
+
     DrawCrispnessSubheader("NAVIGATIONAL CONT.", 25);
 
     // Show player coords

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -356,7 +356,7 @@ static MenuItem_t CrispnessItems[] = {
 };
 
 static Menu_t CrispnessMenu = {
-    68, 40,
+    68, 35,
     DrawCrispnessMenu,
     14, CrispnessItems,
     0,
@@ -2430,21 +2430,27 @@ static void M_DrawCrispnessBackground(void)
     SB_state = -1;
 }
 
+static void DrawCrispnessHeader(const char *item)
+{
+    dp_translation = cr[CR_GOLD];
+    MN_DrTextA(item, 160 - MN_TextAWidth(item) / 2, 6);
+}
+
 static void DrawCrispnessSubheader(const char *name, int y)
 {
-    dp_translation = cr[CR_GREEN];
+    dp_translation = cr[CR_GOLD];
     MN_DrTextA(name, 63, y);
 }
 
 static void DrawCrispnessItem(boolean item, int x, int y)
 {
-    dp_translation = item ? cr[CR_GOLD] : cr[CR_GRAY];
+    dp_translation = item ? cr[CR_GREEN] : cr[CR_DARK];
     MN_DrTextA(item ? "ON" : "OFF", x, y);
 }
 
 static void DrawCrispnessMultiItem(int item, int x, int y, const multiitem_t *multi)
 {
-    dp_translation = item ? cr[CR_GOLD] : cr[CR_GRAY];
+    dp_translation = item ? cr[CR_GREEN] : cr[CR_DARK];
     MN_DrTextA(multi[item].name, x, y);
 }
 
@@ -2463,8 +2469,8 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
         M_snprintf(number, size, "%d", item);
     }
 
-    dp_translation = cond ? cr[CR_DARK] :
-                    (item || numeric_enter) ? cr[CR_GOLD] : cr[CR_GRAY];
+    dp_translation = cond ? cr[CR_GRAY] :
+                    (item || numeric_enter) ? cr[CR_GREEN] : cr[CR_DARK];
 
     if (cond)
     {
@@ -2482,50 +2488,46 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispnessMenu(void)
 {
-    static const char *title;
-
     // Background
     M_DrawCrispnessBackground();
 
-    // Title
-    title = "CRISPNESS";
-    MN_DrTextB(title, 160 - MN_TextBWidth(title) / 2, 6);
+    DrawCrispnessHeader("CRISPNESS");
 
-    DrawCrispnessSubheader("RENDERING", 30);
+    DrawCrispnessSubheader("RENDERING", 25);
 
     // Hires rendering
-    DrawCrispnessItem(crispy->hires, 254, 40);
+    DrawCrispnessItem(crispy->hires, 254, 35);
 
     // Widescreen
-    DrawCrispnessMultiItem(crispy->widescreen, 164, 50, multiitem_widescreen);
+    DrawCrispnessMultiItem(crispy->widescreen, 164, 45, multiitem_widescreen);
 
     // Smooth pixel scaling
-    DrawCrispnessItem(crispy->smoothscaling, 216, 60);
+    DrawCrispnessItem(crispy->smoothscaling, 216, 55);
 
     // Uncapped framerate
-    DrawCrispnessItem(crispy->uncapped, 217, 70);
+    DrawCrispnessItem(crispy->uncapped, 217, 65);
 
     // FPS limit
-    DrawCrispnessNumericItem(crispy->fpslimit, 134, 80, "NONE", !crispy->uncapped, "35");
+    DrawCrispnessNumericItem(crispy->fpslimit, 134, 75, "NONE", !crispy->uncapped, "35");
 
     // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 90);
+    DrawCrispnessItem(crispy->vsync, 167, 85);
 
-    DrawCrispnessSubheader("VISUAL", 110);
+    DrawCrispnessSubheader("VISUAL", 105);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 150, 120, multiitem_brightmaps);
+    DrawCrispnessMultiItem(crispy->brightmaps, 150, 115, multiitem_brightmaps);
 
-    DrawCrispnessSubheader("TACTICAL", 140);
+    DrawCrispnessSubheader("TACTICAL", 135);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 150, multiitem_freelook_hh);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 145, multiitem_freelook_hh);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 160);
+    DrawCrispnessItem(crispy->mouselook, 220, 155);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 170, multiitem_difficulties);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 165, multiitem_difficulties);
 
     dp_translation = NULL;
 }


### PR DESCRIPTION
Not sure if this is an improvement or not, but I wanted to get it out there for comment.

Heretic before/after:
<img src=https://user-images.githubusercontent.com/43701387/215273058-33a171fd-2b31-440d-828a-c97c7e9d2e96.png width=75% height=75%>
<img src=https://user-images.githubusercontent.com/43701387/215273045-5aae4ec0-2bd5-4070-a7b2-78b275b69d01.png width=75% height=75%>

Hexen before/after:
<img src=https://user-images.githubusercontent.com/43701387/215273099-01a431b4-d27b-444d-a60d-98200bd922de.png width=75% height=75%>
<img src=https://user-images.githubusercontent.com/43701387/215273104-e4047d48-5516-42d3-8093-0f48013d8b7d.png width=75% height=75%>


