### PR TITLE
doom: Always interpolate idle weapon bob with uncapped FPS

### DIFF
--- a/src/doom/p_pspr.c
+++ b/src/doom/p_pspr.c
@@ -997,7 +997,7 @@ void P_MovePsprites (player_t* player)
     psp = &player->psprites[0];
     psp->sx2 = psp->sx;
     psp->sy2 = psp->sy;
-    if (psp->state && (crispy->bobfactor || crispy->centerweapon))
+    if (psp->state && (crispy->bobfactor || crispy->centerweapon || crispy->uncapped))
     {
 	// [crispy] don't center vertically during lowering and raising states
 	if (psp->state->misc1 ||


### PR DESCRIPTION
This is easy to test with the chainsaw. The "choppy" vanilla behavior is preserved when not using an uncapped framerate. Example:

```
crispy_bobfactor              0
crispy_centerweapon           0
crispy_fpslimit               0
crispy_uncapped               0 (left side of video)
crispy_uncapped               1 (right side of video)
```

https://user-images.githubusercontent.com/56656010/216466247-42000322-173e-4c71-8d15-dc7ffee84364.mp4

[Doomworld post with more details](https://www.doomworld.com/forum/topic/121183-which-of-these-chainsaw-animations-is-the-correct-one/?tab=comments#comment-2292505)