### PR TITLE
Heretic & Hexen: Fixes and enhancements for vertical mouse look

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -719,15 +719,19 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         if (demorecording || lowres_turn)
         {
-            // [crispy] Map mouse movement to look variable when recording
-            look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
-                                        : mousey / MLOOKUNITLOWRES;
+            // [Dasperal] Skip mouse look if it is TOCENTER cmd
+            if (look != TOCENTER)
+            {
+                // [crispy] Map mouse movement to look variable when recording
+                look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
+                                       :  mousey / MLOOKUNITLOWRES;
 
-            // [crispy] Limit to max speed of keyboard look up/down
-            if (look > 2)
-                look = 2;
-            else if (look < -2)
-                look = -2;
+                // [crispy] Limit to max speed of keyboard look up/down
+                if (look > 2)
+                    look = 2;
+                else if (look < -2)
+                    look = -2;
+            }
         }
         else
         {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -736,7 +736,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         else
         {
             cmd->lookdir = mouse_y_invert ? -mousey : mousey;
-            cmd->lookdir /= MLOOKUNIT;
+            // [Dasperal] Allow precise vertical look with near 0 mouse movement
+            if (cmd->lookdir > 0)
+                cmd->lookdir = (cmd->lookdir + MLOOKUNIT - 1) / MLOOKUNIT;
+            else
+                cmd->lookdir = (cmd->lookdir - MLOOKUNIT + 1) / MLOOKUNIT;
         }
     }
     else if (!novert)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -656,15 +656,19 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         if (demorecording || lowres_turn)
         {
-            // [crispy] Map mouse movement to look variable when recording
-            look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
-                                        : mousey / MLOOKUNITLOWRES;
+            // [Dasperal] Skip mouse look if it is TOCENTER cmd
+            if (look != TOCENTER)
+            {
+                // [crispy] Map mouse movement to look variable when recording
+                look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
+                                       :  mousey / MLOOKUNITLOWRES;
 
-            // [crispy] Limit to max speed of keyboard look up/down
-            if (look > 2)
-                look = 2;
-            else if (look < -2)
-                look = -2;
+                // [crispy] Limit to max speed of keyboard look up/down
+                if (look > 2)
+                    look = 2;
+                else if (look < -2)
+                    look = -2;
+            }
         }
         else
         {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -673,7 +673,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         else
         {
             cmd->lookdir = mouse_y_invert ? -mousey : mousey;
-            cmd->lookdir /= MLOOKUNIT;
+            // [Dasperal] Allow precise vertical look with near 0 mouse movement
+            if (cmd->lookdir > 0)
+                cmd->lookdir = (cmd->lookdir + MLOOKUNIT - 1) / MLOOKUNIT;
+            else
+                cmd->lookdir = (cmd->lookdir - MLOOKUNIT + 1) / MLOOKUNIT;
         }
     }
     else if (!novert)


### PR DESCRIPTION
* Fixes "Look forward" button not working properly while recording a demo. `TOCENTER` command uses -8 value of look variable, so in `demorecording` mode it was always overwritten with -2 by the `look < -2` check.
* Due to `cmd->lookdir /= MLOOKUNIT` there was a dead zone in vertical mouse movement around 0 value. This dead zone can be eliminated by using `ceilf()` and `floorf()` resulting in identical behavior and feeling of vertical and horizontal mouse look.