### PR TITLE
Colored blood setting to change in both directions

### DIFF
--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -221,8 +221,7 @@ void M_CrispyToggleColoredblood(int choice)
 	return;
     }
 
-    choice = 0;
-    crispy->coloredblood = (crispy->coloredblood + 1) % NUM_COLOREDBLOOD;
+    ChangeSettingEnum(&crispy->coloredblood, choice, NUM_COLOREDBLOOD);
 
     // [crispy] switch NOBLOOD flag for Lost Souls
     for (th = thinkercap.next; th && th != &thinkercap; th = th->next)


### PR DESCRIPTION
Applied `ChangeSettingEnum()` to `M_CrispyToggleColoredblood` so that the settings can be changed in both directions.