### PR TITLE
strife: Don't show cursor on help screens

### DIFF
--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2982,6 +2982,8 @@ void M_Drawer (void)
     
     // haleyjd 08/27/10: [STRIFE] Adjust to draw spinning Sigil
     // DRAW SIGIL
+    // [crispy] Show ">" cursor in Crispness menu; don't show Sigil cursor on
+    // help screens
     if (currentMenu == CrispnessMenus[crispness_cur])
     {
         char item[4];
@@ -2989,11 +2991,13 @@ void M_Drawer (void)
         M_WriteText(currentMenu->x - 8, currentMenu->y + CRISPY_LINEHEIGHT * itemOn, item);
         dp_translation = NULL;
     }
-    else
+    else if (currentMenu != &ReadDef1 && currentMenu != &ReadDef2 &&
+             currentMenu != &ReadDef3)
+    {
     V_DrawPatchDirect(x + CURSORXOFF, currentMenu->y - 5 + itemOn*LINEHEIGHT,
                       W_CacheLumpName(DEH_String(cursorName[whichCursor]),
                                       PU_CACHE));
-
+    }
 }
 
 


### PR DESCRIPTION
In order to support widescreen graphics mods, `patchclip_callback` checks were bypassed in https://github.com/fabiangreffrath/crispy-doom/commit/96dbc26339ad9416e9386c17b7b42446d23d3417. I went through every `V_Draw*()` function call where this applies and the only regression is the Sigil cursor (this is the skull in Doom) showing in the help screen when it shouldn't. This PR hides the cursor to match vanilla behavior. Normally, the cursor is positioned on the help screens in a way that would cause Strife to ignore the draw request since it's partially offscreen. Now the draw calls are skipped in `M_Drawer()`.

![cursor](https://user-images.githubusercontent.com/56656010/220255826-659aee29-93ed-4718-ac11-982baf4ed809.png)