### PR TITLE
strife: Crosshair and targeter adjustments

### DIFF
--- a/src/strife/hu_stuff.c
+++ b/src/strife/hu_stuff.c
@@ -326,13 +326,14 @@ static byte *R_CrosshairColor (void)
             return cr[CR_GREEN];
     }
 
-	return NULL;
+    return NULL;
 }
 
 // [crispy] static, non-projected crosshair
 static void HU_DrawCrosshair (void)
 {
     if (plr->playerstate != PST_LIVE ||
+        plr->powers[pw_targeter] ||
         automapactive ||
         menuactive ||
         menupause ||
@@ -344,8 +345,10 @@ static void HU_DrawCrosshair (void)
     else
     {
         patch_t *const patch = W_CacheLumpName("TRGTA0", PU_STATIC);
-        const int x = ORIGWIDTH / 2 - 3;
-        const int y = ORIGHEIGHT / 2 - 3 - ((screenblocks < 11) ? (ST_HEIGHT / 2) : 0);
+        const int x = ORIGWIDTH / 2 - SHORT(patch->width) / 2 +
+                      SHORT(patch->leftoffset);
+        const int y = (ORIGHEIGHT - (screenblocks < 11 ? ST_HEIGHT : 0)) / 2 -
+                      SHORT(patch->height) / 2 + SHORT(patch->topoffset);
 
         dp_translation = R_CrosshairColor();
         V_DrawPatch(x, y, patch);

--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -363,11 +363,10 @@ boolean P_GivePower(player_t* player, powertype_t power)
         P_SetPsprite(player, ps_targleft,   S_TRGT_01); // 11
         P_SetPsprite(player, ps_targright,  S_TRGT_02); // 12
 
-        // [crispy] targeter offset correction
-        player->psprites[ps_targcenter].sx  = (160 - 3) * FRACUNIT;
-        player->psprites[ps_targleft  ].sy  = (100 - 3) * FRACUNIT;
-        player->psprites[ps_targcenter].sy  = (100 - 3) * FRACUNIT;
-        player->psprites[ps_targright ].sy  = (100 - 3) * FRACUNIT;
+        player->psprites[ps_targcenter].sx  = (160*FRACUNIT);
+        player->psprites[ps_targleft  ].sy  = (100*FRACUNIT);
+        player->psprites[ps_targcenter].sy  = (100*FRACUNIT);
+        player->psprites[ps_targright ].sy  = (100*FRACUNIT);
 
         // [crispy] update targeter position
         player->psprites[ps_targcenter].sx2 = player->psprites[ps_targcenter].sx;

--- a/src/strife/p_pspr.c
+++ b/src/strife/p_pspr.c
@@ -993,12 +993,11 @@ void P_MovePsprites (player_t* player)
     player->psprites[ps_flash].sy = player->psprites[ps_weapon].sy;
 
     // villsa [STRIFE] extra stuff for targeter
-    // [crispy] targeter offset correction
     player->psprites[ps_targleft].sx =
-        (160 * FRACUNIT) - ((100 + 4 - player->accuracy) << FRACBITS);
+        (160*FRACUNIT) - ((100 - player->accuracy) << FRACBITS);
 
     player->psprites[ps_targright].sx =
-        ((100 - 4 - player->accuracy) << FRACBITS) + ((160 + 1) * FRACUNIT);
+        ((100 - player->accuracy) << FRACBITS) + (160*FRACUNIT);
 
     // [crispy] update targeter position
     player->psprites[ps_targleft].sx2 = player->psprites[ps_targleft].sx;

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -725,7 +725,7 @@ void R_AddSprites (sector_t* sec)
 
 boolean pspr_interp = true; // [crispy] interpolate weapon bobbing
 
-void R_DrawPSprite (pspdef_t* psp)
+void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
 {
     fixed_t		tx;
     int			x1;
@@ -838,8 +838,8 @@ void R_DrawPSprite (pspdef_t* psp)
         vis->colormap = colormaps + INVERSECOLORMAP * 256 * sizeof(lighttable_t);
     }
 
-    // [crispy] interpolate weapon bobbing
-    if (crispy->uncapped)
+    // [crispy] interpolate weapon bobbing; don't interpolate targeter
+    if (crispy->uncapped && psprnum < ps_targcenter)
     {
         static int     oldx1, x1_saved;
         static fixed_t oldtexturemid, texturemid_saved;
@@ -909,7 +909,7 @@ void R_DrawPlayerSprites (void)
 	 i++,psp++)
     {
 	if (psp->state)
-	    R_DrawPSprite (psp);
+	    R_DrawPSprite (psp, i); // [crispy] pass psprnum
     }
 }
 


### PR DESCRIPTION
1. Revert adjustments to targeter positioning from https://github.com/fabiangreffrath/crispy-doom/commit/066ae50952e3ca699ebddd71a6d3327219f5d02a. I don't want to interfere with modders who change the targeter sprites and their offsets.
2. Don't show Crispy crosshair when targeter is active.
3. Don't interpolate targeter sprites.