### PR TITLE
doom/strife: Fix free look judder

### DIFF
--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -1045,9 +1045,6 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
 	vis->startfrac = 0;
     }
     
-    // [crispy] free look
-    vis->texturemid += FixedMul(((centery - viewheight / 2) << FRACBITS), pspriteiscale) >> detailshift;
-
     if (vis->x1 > x1)
 	vis->startfrac += vis->xiscale*(vis->x1-x1);
 
@@ -1120,6 +1117,9 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
             pspr_interp = true;
         }
     }
+
+    // [crispy] free look
+    vis->texturemid += FixedMul(((centery - viewheight / 2) << FRACBITS), pspriteiscale) >> detailshift;
 
     R_DrawVisSprite (vis, vis->x1, vis->x2);
 }

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -792,9 +792,9 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
     }
 
     // villsa [STRIFE] calculate y offset with view pitch
-    // [crispy] weapons drawn 1 pixel too high when player is idle
-    vis->texturemid = ((BASEYCENTER<<FRACBITS)+FRACUNIT/4)-(psp->sy2-spritetopoffset[lump])
-        + FixedMul(vis->xiscale, (centery-viewheight/2)<<FRACBITS);
+    // [crispy] weapons drawn 1 pixel too high when player is idle; moved free
+    // look to end of function after interpolation
+    vis->texturemid = ((BASEYCENTER<<FRACBITS)+FRACUNIT/4)-(psp->sy2-spritetopoffset[lump]);
 
     if (vis->x1 > x1)
         vis->startfrac += vis->xiscale*(vis->x1-x1);
@@ -872,6 +872,9 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
             pspr_interp = true;
         }
     }
+
+    // [crispy] free look
+    vis->texturemid += FixedMul(vis->xiscale, (centery - viewheight / 2) << FRACBITS);
 
     R_DrawVisSprite (vis, vis->x1, vis->x2);
 }


### PR DESCRIPTION
Moved the free look calculation to after interpolation. This is also the approach used by Woof. Heretic and Hexen are similar as well. Reported by OpenRift.

https://user-images.githubusercontent.com/56656010/220836366-00636894-b824-4ab2-8132-ab2e4d585ff2.mp4
