### PR TITLE
doom: apply "specal treatment" to Nerve_demo.wad

### DIFF
--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -194,8 +194,10 @@ static boolean CheckNerveLoaded (void)
 
 	if ((i = W_GetNumForName("MAP01")) != -1 &&
 	    (j = W_GetNumForName("MAP09")) != -1 &&
-	    !strcasecmp(W_WadNameForLump(lumpinfo[i]), "NERVE.WAD") &&
-	    !strcasecmp(W_WadNameForLump(lumpinfo[j]), "NERVE.WAD"))
+	    (!strcasecmp(W_WadNameForLump(lumpinfo[i]), "NERVE.WAD") ||
+	     !strcasecmp(W_WadNameForLump(lumpinfo[i]), "Nerve_demo.wad")) &&
+	    (!strcasecmp(W_WadNameForLump(lumpinfo[j]), "NERVE.WAD") ||
+	     !strcasecmp(W_WadNameForLump(lumpinfo[j]), "Nerve_demo.wad")))
 	{
 		gamemission = pack_nerve;
 
@@ -203,7 +205,8 @@ static boolean CheckNerveLoaded (void)
 		i = W_GetNumForName("INTERPIC");
 		j = W_GetNumForName("TITLEPIC");
 		if (W_IsIWADLump(lumpinfo[i]) &&
-		    strcasecmp(W_WadNameForLump(lumpinfo[j]), "NERVE.WAD"))
+		    strcasecmp(W_WadNameForLump(lumpinfo[j]), "NERVE.WAD") &&
+		    strcasecmp(W_WadNameForLump(lumpinfo[j]), "Nerve_demo.wad"))
 		{
 			DEH_AddStringReplacement ("TITLEPIC", "INTERPIC");
 		}
@@ -218,8 +221,13 @@ static boolean CheckNerveLoaded (void)
 static void CheckLoadNerve (void)
 {
 	const char *nerve_basename;
-	char *autoload_dir;
+	char *dirname, *autoload_dir;
 	int i, j;
+
+	const char *const nerve_wads[] = {
+		"NERVE.WAD",
+		"Nerve_demo.wad"
+	};
 
 	static const struct {
 		const char *name;
@@ -236,23 +244,26 @@ static void CheckLoadNerve (void)
 		return;
 	}
 
-	if (strrchr(iwadfile, DIR_SEPARATOR) != NULL)
+	// [crispy] load NERVE.WAD
+	dirname = M_DirName(iwadfile);
+	for (i = 0; i < arrlen(nerve_wads); i++)
 	{
-		char *dir;
-		dir = M_DirName(iwadfile);
-		crispy->havenerve = M_StringJoin(dir, DIR_SEPARATOR_S, "NERVE.WAD", NULL);
-		free(dir);
-	}
-	else
-	{
-		crispy->havenerve = M_StringDuplicate("NERVE.WAD");
-	}
+		crispy->havenerve = M_StringJoin(dirname, DIR_SEPARATOR_S, nerve_wads[i], NULL);
 
-	if (!M_FileExists(crispy->havenerve))
-	{
+		if (M_FileExists(crispy->havenerve))
+		{
+			break;
+		}
+
 		free(crispy->havenerve);
-		crispy->havenerve = D_FindWADByName("NERVE.WAD");
+		crispy->havenerve = D_FindWADByName(nerve_wads[i]);
+
+		if (crispy->havenerve)
+		{
+			break;
+		}
 	}
+	free(dirname);
 
 	if (crispy->havenerve == NULL)
 	{


### PR DESCRIPTION
If you obtain NRFTL (No Rest for the Living) by extracting the wad from the Xbox Live Arcade release of Doom II for the Xbox 360 (which was the original release of NRFTL), you end up with a file called `Nerve_demo.wad`. Most other users seem to be using a file originally extracted from Doom 3: BFG Edition, which is called `NERVE.WAD`. Only the names differ; the file contents themselves are identical. (This is all explained on the [Doom Wiki](https://doomwiki.org/wiki/NERVE.WAD) if you don't believe me.)

Because the developers of the XBLA release of Doom II did some things in a non-standard way, this WAD requires some quirks/fixups to play properly, particularly w/ regard to the music and title screen. Crispy applies these fixes whenever a WAD called `NERVE.WAD` has been loaded. This patch also applies the fixes if the WAD is called `Nerve_demo.wad`.

I adapted some code from `D_LoadSigilWad` to do this, and in general I think [`d_pwad.c`](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/doom/d_pwad.c) could use some refactoring, especially now that I've added some more duplicated code. I'm happy to do that to get this change accepted. This here patch just takes the path of least resistance.