### PR TITLE
heretic: add ANIMATED and swirl support from crispy doom 

### DIFF
--- a/src/heretic/Makefile.am
+++ b/src/heretic/Makefile.am
@@ -61,6 +61,7 @@ r_draw.c                                             \
 r_main.c                                             \
 r_plane.c                                            \
 r_segs.c                                             \
+r_swirl.c               r_swirl.h                      \
 r_things.c                                           \
 sb_bar.c                                             \
 sounds.c               sounds.h                      \

--- a/src/heretic/p_spec.h
+++ b/src/heretic/p_spec.h
@@ -19,48 +19,15 @@
 /*
 ===============================================================================
 
-							P_SPEC
+                                                        P_SPEC
 
 ===============================================================================
 */
 
-//
-//      Animating textures and planes
-//
-typedef struct
-{
-    boolean istexture;
-    int picnum;
-    int basepic;
-    int numpics;
-    int speed;
-} anim_t;
-
-//
-//      source animation definition
-//
-typedef struct
-{
-    int istexture;          // if false, it's a flat
-    char endname[9];
-    char startname[9];
-    int speed;
-} animdef_t;
-
-#define	MAXANIMS		32
-
-extern anim_t anims[MAXANIMS], *lastanim;
 extern int *TerrainTypes;
 
-//
-//      Animating line specials
-//
-#define	MAXLINEANIMS		64*256
-extern short numlinespecials;
-extern line_t *linespeciallist[MAXLINEANIMS];
-
 //      Define values for map objects
-#define	MO_TELEPORTMAN		14
+#define MO_TELEPORTMAN          14
 
 // at game start
 void P_InitPicAnims(void);
@@ -103,7 +70,7 @@ int EV_DoDonut(line_t * line);
 /*
 ===============================================================================
 
-							P_LIGHTS
+                                                        P_LIGHTS
 
 ===============================================================================
 */
@@ -138,10 +105,10 @@ typedef struct
     int direction;
 } glow_t;
 
-#define GLOWSPEED		8
-#define	STROBEBRIGHT	5
-#define	FASTDARK		15
-#define	SLOWDARK		35
+#define GLOWSPEED               8
+#define STROBEBRIGHT    5
+#define FASTDARK                15
+#define SLOWDARK                35
 
 void T_LightFlash(thinker_t *thinker);
 void P_SpawnLightFlash(sector_t * sector);
@@ -156,7 +123,7 @@ void P_SpawnGlowingLight(sector_t * sector);
 /*
 ===============================================================================
 
-							P_SWITCH
+                                                        P_SWITCH
 
 ===============================================================================
 */
@@ -183,9 +150,9 @@ typedef struct
     void *soundorg;
 } button_t;
 
-#define	MAXSWITCHES	50      // max # of wall switches in a level
-#define	MAXBUTTONS	16      // 4 players, 4 buttons each at once, max.
-#define BUTTONTIME	35      // 1 second
+#define MAXSWITCHES     50      // max # of wall switches in a level
+#define MAXBUTTONS      16      // 4 players, 4 buttons each at once, max.
+#define BUTTONTIME      35      // 1 second
 
 extern button_t buttonlist[MAXBUTTONS];
 
@@ -195,7 +162,7 @@ void P_InitSwitchList(void);
 /*
 ===============================================================================
 
-							P_PLATS
+                                                        P_PLATS
 
 ===============================================================================
 */
@@ -231,9 +198,9 @@ typedef struct
     plattype_e type;
 } plat_t;
 
-#define	PLATWAIT	3
-#define	PLATSPEED	FRACUNIT
-#define	MAXPLATS	30*256
+#define PLATWAIT        3
+#define PLATSPEED       FRACUNIT
+#define MAXPLATS        30*256
 
 extern plat_t *activeplats[MAXPLATS];
 
@@ -247,7 +214,7 @@ void P_ActivateInStasis(int tag);
 /*
 ===============================================================================
 
-							P_DOORS
+                                                        P_DOORS
 
 ===============================================================================
 */
@@ -273,8 +240,8 @@ typedef struct
     int topcountdown;           // when it reaches 0, start going down
 } vldoor_t;
 
-#define	VDOORSPEED	FRACUNIT*2
-#define	VDOORWAIT		150
+#define VDOORSPEED      FRACUNIT*2
+#define VDOORWAIT               150
 
 void EV_VerticalDoor(line_t * line, mobj_t * thing);
 int EV_DoDoor(line_t * line, vldoor_e type, fixed_t speed);
@@ -285,7 +252,7 @@ void P_SpawnDoorRaiseIn5Mins(sector_t * sec, int secnum);
 /*
 ===============================================================================
 
-							P_CEILNG
+                                                        P_CEILNG
 
 ===============================================================================
 */
@@ -311,9 +278,9 @@ typedef struct
     int olddirection;
 } ceiling_t;
 
-#define	CEILSPEED		FRACUNIT
-#define	CEILWAIT		150
-#define MAXCEILINGS		30
+#define CEILSPEED               FRACUNIT
+#define CEILWAIT                150
+#define MAXCEILINGS             30
 
 extern ceiling_t *activeceilings[MAXCEILINGS];
 
@@ -327,7 +294,7 @@ void P_ActivateInStasisCeiling(line_t * line);
 /*
 ===============================================================================
 
-							P_FLOOR
+                                                        P_FLOOR
 
 ===============================================================================
 */
@@ -361,7 +328,7 @@ typedef struct
     fixed_t speed;
 } floormove_t;
 
-#define	FLOORSPEED	FRACUNIT
+#define FLOORSPEED      FRACUNIT
 
 typedef enum
 {
@@ -381,7 +348,7 @@ void T_MoveFloor(thinker_t *thinker);
 /*
 ===============================================================================
 
-							P_TELEPT
+                                                        P_TELEPT
 
 ===============================================================================
 */

--- a/src/heretic/r_swirl.c
+++ b/src/heretic/r_swirl.c
@@ -1,0 +1,136 @@
+//
+// Copyright(C) 1993-1996 Id Software, Inc.
+// Copyright(C) 2000, 2005-2014 Simon Howard
+// Copyright(C) 2019 Fabian Greffrath
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      [crispy] add support for SMMU swirling flats
+//
+
+// [crispy] adapted from smmu/r_ripple.c, by Simon Howard
+
+#include <tables.h>
+
+#include <i_system.h>
+#include <w_wad.h>
+#include <z_zone.h>
+
+//#include "doomstat.h"
+#include "doomdef.h"
+
+// swirl factors determine the number of waves per flat width
+
+// 1 cycle per 64 units
+#define swirlfactor (8192/64)
+
+// 1 cycle per 32 units (2 in 64)
+#define swirlfactor2 (8192/32)
+
+#define SEQUENCE 1024
+#define FLATSIZE (64 * 64)
+
+static int *offsets;
+static int *offset;
+
+#define AMP 2
+#define AMP2 2
+#define SPEED 40
+
+//W_LumpLength
+
+void R_InitDistortedFlats()
+{
+        if (!offsets)
+        {
+                int i;
+
+                offsets = I_Realloc(NULL, SEQUENCE * FLATSIZE * sizeof(*offsets));
+                offset = offsets;
+
+                for (i = 0; i < SEQUENCE; i++)
+                {
+                        int x, y;
+
+                        for (x = 0; x < 64; x++)
+                        {
+                                for (y = 0; y < 64; y++)
+                                {
+                                        int x1, y1;
+                                        int sinvalue, sinvalue2;
+
+                                        sinvalue = (y * swirlfactor + i * SPEED * 5 + 900) & 8191;
+                                        sinvalue2 = (x * swirlfactor2 + i * SPEED * 4 + 300) & 8191;
+                                        x1 = x + 128
+                                           + ((finesine[sinvalue] * AMP) >> FRACBITS)
+                                           + ((finesine[sinvalue2] * AMP2) >> FRACBITS);
+
+                                        sinvalue = (x * swirlfactor + i * SPEED * 3 + 700) & 8191;
+                                        sinvalue2 = (y * swirlfactor2 + i * SPEED * 4 + 1200) & 8191;
+                                        y1 = y + 128
+                                           + ((finesine[sinvalue] * AMP) >> FRACBITS)
+                                           + ((finesine[sinvalue2] * AMP2) >> FRACBITS);
+
+                                        x1 &= 63;
+                                        y1 &= 63;
+
+                                        offset[(y << 6) + x] = (y1 << 6) + x1;
+                                }
+                        }
+
+                        offset += FLATSIZE;
+                }
+        }
+}
+
+char *R_DistortedFlat(int flatnum)
+{
+        static int swirltic = -1;
+        static int swirlflat = -1;
+        static char distortedflat[FLATSIZE];
+
+
+        if (swirltic != leveltime)
+        {
+                offset = offsets + ((leveltime & (SEQUENCE - 1)) * FLATSIZE);
+
+                swirltic = leveltime;
+                swirlflat = -1;
+        }
+
+        if (swirlflat != flatnum)
+        {
+                char *normalflat;
+                int i;
+                int leng;
+
+                //[crispy] [SM] adapt Heretic 64x65 flats for swirling
+                leng = W_LumpLength(flatnum);
+                if (leng > FLATSIZE)
+                {
+                    normalflat = Z_Malloc(FLATSIZE, PU_STATIC, NULL);
+                    W_ReadLump(flatnum, normalflat); 
+                    } 
+                else normalflat = W_CacheLumpNum(flatnum, PU_STATIC);
+
+                for (i = 0; i < FLATSIZE; i++)
+                {
+                        distortedflat[i] = normalflat[offset[i]];
+                }
+
+                W_ReleaseLumpNum(flatnum);
+
+                swirlflat = flatnum;
+        }
+
+        return distortedflat;
+}

--- a/src/heretic/r_swirl.h
+++ b/src/heretic/r_swirl.h
@@ -1,0 +1,26 @@
+//
+// Copyright(C) 1993-1996 Id Software, Inc.
+// Copyright(C) 2000, 2005-2014 Simon Howard
+// Copyright(C) 2019 Fabian Greffrath
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	[crispy] add support for SMMU swirling flats
+//
+
+#ifndef __R_SWIRL__
+#define __R_SWIRL__
+
+void R_InitDistortedFlats();
+char *R_DistortedFlat(int flatnum);
+
+#endif


### PR DESCRIPTION
The ongoing limit-removing Heretic project led by Cuppykeks (aka SuperCupcakeTactics) inspired me to implement ANIMATED lump support and swirling flats from crispy doom to crispy heretic (cuz now they're using series of scrolling lines to make custom animating stuff like waterfall dust, portals and fire, it's certainly cool, but resource-intensive I think)
![изображение](https://user-images.githubusercontent.com/40827572/226628842-b201c8d4-79a4-49b9-98fd-e8e99a350d17.png)

Showing it working on water (I created a wad with ANIMATED with Slade 3.1.1.5 to test):
![hereticcrispswirl3](https://user-images.githubusercontent.com/40827572/226626032-c17fc200-c32a-48b0-80de-872a88c56796.gif)


