### PR TITLE
heretic: Introduce a HEHACKED lump for embedded HHE files

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1183,9 +1183,9 @@ void D_DoomMain(void)
         }
     }
 
-    if (W_CheckNumForName("HEREHACK") != -1)
+    if (W_CheckNumForName("HEHACKED") != -1)
     {
-        DEH_LoadLumpByName("HEREHACK", true, true);
+        DEH_LoadLumpByName("HEHACKED", true, true);
     }
 
     //!

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1183,6 +1183,11 @@ void D_DoomMain(void)
         }
     }
 
+    if (W_CheckNumForName("HEREHACK") != -1)
+    {
+        DEH_LoadLumpByName("HEREHACK", true, true);
+    }
+
     //!
     // @arg <demo>
     // @category demo


### PR DESCRIPTION
There is ongoing Heretic project that will probably use the HHE file. Users will be required to use the command line with the `-deh` and `-hhever` options. Much more convenient if there is support for built-in PWAD HHE files.

This can be a very obscure feature only used in one PWAD. To my knowledge, no other Heretic port supports HHE.

We are currently assuming Heretic version 1.0, but maybe set 1.3 as the default for HEREHACK?

