### PR TITLE
Minor HUD fixes

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -437,9 +437,9 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joybspeed = MAX_JOY_BUTTONS;
         }
 
-        M_snprintf(playermessage, sizeof(playermessage), "ALWAYS RUN %s%s",
+        M_snprintf(playermessage, sizeof(playermessage), "ALWAYS RUN %s%s%s",
             crstr[CR_GREEN],
-            (joybspeed >= MAX_JOY_BUTTONS) ? "ON" : "OFF");
+            (joybspeed >= MAX_JOY_BUTTONS) ? "ON" : "OFF", crstr[CR_NONE]);
         player->message = playermessage;
         S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -437,9 +437,9 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joybspeed = MAX_JOY_BUTTONS;
         }
 
-        M_snprintf(playermessage, sizeof(playermessage), "ALWAYS RUN %s%s%s",
+        M_snprintf(playermessage, sizeof(playermessage), "ALWAYS RUN %s%s",
             crstr[CR_GREEN],
-            (joybspeed >= MAX_JOY_BUTTONS) ? "ON" : "OFF", crstr[CR_NONE]);
+            (joybspeed >= MAX_JOY_BUTTONS) ? "ON" : "OFF");
         player->message = playermessage;
         S_StartSoundOptional(NULL, sfx_mnusli, sfx_swtchn); // [NS] Optional menu sounds.
 

--- a/src/doom/hu_lib.c
+++ b/src/doom/hu_lib.c
@@ -157,6 +157,8 @@ HUlib_drawTextLine
     {
 	V_DrawPatchDirect(x, y, l->f['_' - l->sc]);
     }
+
+    dp_translation = NULL;
 }
 
 

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -789,7 +789,7 @@ static void HU_DrawCrosshair (void)
 
     if (weaponinfo[plr->readyweapon].ammo == am_noammo ||
         plr->playerstate != PST_LIVE ||
-        automapactive ||
+        (automapactive && !crispy->automapoverlay) ||
         menuactive ||
         paused ||
         secret_on)
@@ -1017,6 +1017,8 @@ void HU_Ticker(void)
 
     } // else message_on = false;
 
+	w_kills.y = HU_MSGY + 1 * 8;
+
     // check for incoming chat characters
     if (netgame)
     {
@@ -1107,8 +1109,6 @@ void HU_Ticker(void)
     if ((crispy->automapstats & WIDGETS_ALWAYS) || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
-
-	w_kills.y = HU_MSGY + 1 * 8;
 
 	crispy_statsline(str, sizeof(str), kills, plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -1017,7 +1017,7 @@ void HU_Ticker(void)
 
     } // else message_on = false;
 
-	w_kills.y = HU_MSGY + 1 * 8;
+    w_kills.y = HU_MSGY + 1 * 8;
 
     // check for incoming chat characters
     if (netgame)


### PR DESCRIPTION
This pull request fixes some HUD issues:

1) static crosshair not drawn in case of automap overlay;
2) kills string not moved down when multiplayer chat line is active;
3) chat string getting colored after toggling always run.

![DOOM0014](https://user-images.githubusercontent.com/15119473/227967902-fb4e8f82-28ce-49d6-b593-d6f789329cd4.png)
![DOOM0015](https://user-images.githubusercontent.com/15119473/227967912-d70b83ec-6eab-4785-9ec3-f8e7585f7a7c.png)
![DOOM0016](https://user-images.githubusercontent.com/15119473/227967917-831275c3-4bb3-4df4-951f-dfb46e04d109.png)
