### PR TITLE
Don't calculate `fractionaltic` and don't cap FPS in `-timedemo`

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -894,7 +894,7 @@ void I_FinishUpdate (void)
 
     SDL_RenderPresent(renderer);
 
-    if (crispy->uncapped)
+    if (crispy->uncapped && !singletics)
     {
         // Limit framerate
         if (crispy->fpslimit >= TICRATE)


### PR DESCRIPTION
This will allow `-timedemo` to run with full available power. Please correct me if I'm wrong.