### PR TITLE
Allow netplay with sideloaded WADs

### DIFF
--- a/src/d_mode.c
+++ b/src/d_mode.c
@@ -33,8 +33,8 @@ static struct
     { pack_chex, retail,     1, 5 },
     { doom,      shareware,  1, 9 },
     { doom,      registered, 3, 9 },
-    { doom,      retail,     4, 9 },
-    { doom2,     commercial, 1, 32 },
+    { doom,      retail,     5, 9 }, // [crispy] extended for Sigil
+    { doom2,     commercial, 3, 32 }, // [crispy] extended for NRFTL / The Master Levels
     { pack_tnt,  commercial, 1, 32 },
     { pack_plut, commercial, 1, 32 },
     { pack_hacx, commercial, 1, 32 },


### PR DESCRIPTION
`NET_SV_ParseGameStart` checks that episode and map are in the correct range. This prevented the episode 5 version of Sigil, as well as sideloaded NRFTL and Master Levels from working in netgames.

This is fixed by changing the number of episodes in the `valid_modes` table.  As a side effect, setup program will now allow warping to E5Mx for the Ultimate Doom IWAD. Outside of Heretic, the `valid_modes` table is only used for these two things (netgame validation and setup warp UI).

Note that if you try to start a netgame with a non-existent map, the client will simply exit with a `W_GetNumForName` error.