### PR TITLE
always set "logical size" for render

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1504,12 +1504,7 @@ static void SetVideoMode(void)
     // time this also defines the aspect ratio that is preserved while scaling
     // and stretching the texture into the window.
 
-    if (aspect_ratio_correct || integer_scaling)
-    {
-        SDL_RenderSetLogicalSize(renderer,
-                                 SCREENWIDTH,
-                                 actualheight);
-    }
+    SDL_RenderSetLogicalSize(renderer, SCREENWIDTH, actualheight);
 
     // Force integer scales for resolution-independent rendering.
 


### PR DESCRIPTION
This fixes screen stretching if `aspect_ratio_correct == 0`.

Before: 
![DOOM0005](https://user-images.githubusercontent.com/5077629/231459917-d910d9ea-d1c5-45bd-a5bf-bda69fe5e66c.png)
After:
![DOOM0004](https://user-images.githubusercontent.com/5077629/231459959-0fcfdabc-8ee7-48be-b12d-8aee2d06db6f.png)

The size of the window in windowed mode is not corrected, should we change it too?