### PR TITLE
Make demo footer compatible with PrBoom+/DSDA-Doom demo autoplay

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1288,22 +1288,6 @@ void PrintGameVersion(void)
     }
 }
 
-const char *D_GetGameVersionCmd(void)
-{
-    int i;
-
-    for (i = 0; gameversions[i].description; ++i)
-    {
-        if (gameversions[i].version == gameversion)
-        {
-            return gameversions[i].cmdline;
-            break;
-        }
-    }
-
-    return NULL;
-}
-
 // Function called at exit to display the ENDOOM screen
 
 static void D_Endoom(void)

--- a/src/doom/d_main.h
+++ b/src/doom/d_main.h
@@ -48,8 +48,5 @@ extern boolean advancedemo;
 
 extern const char *pagename;
 
-// [crispy] Get game version command line for demo footer.
-const char *D_GetGameVersionCmd(void);
-
 #endif
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3194,6 +3194,8 @@ static size_t WriteCmdLineLump(MEMFILE *stream)
         case exe_final:
             mem_fputs(" -complevel 4", stream);
             break;
+        default:
+            break;
     }
 
     if (M_CheckParm("-solo-net"))

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3131,24 +3131,19 @@ void G_TimeDemo (char* name)
 } 
  
 #define DEMO_FOOTER_SEPARATOR "\n"
+#define NUM_DEMO_FOOTER_LUMPS 4
 
-static void G_AddDemoFooter(void)
+static size_t WriteCmdLineLump(MEMFILE *stream)
 {
     int i;
-    size_t len = 0;
+    long pos;
     char *tmp, **filenames;
-
-    MEMFILE *stream = mem_fopen_write();
 
     filenames = W_GetWADFileNames();
 
-    if (!filenames)
-    {
-        return;
-    }
+    pos = mem_ftell(stream);
 
-    tmp = M_StringJoin(PACKAGE_STRING, DEMO_FOOTER_SEPARATOR,
-            "-iwad \"", M_BaseName(filenames[0]), "\"", NULL);
+    tmp = M_StringJoin("-iwad \"", M_BaseName(filenames[0]), "\"", NULL);
     mem_fputs(tmp, stream);
     free(tmp);
 
@@ -3178,26 +3173,90 @@ static void G_AddDemoFooter(void)
         }
     }
 
-    tmp = M_StringJoin(" -gameversion ", D_GetGameVersionCmd(), NULL);
-    mem_fputs(tmp, stream);
-    free(tmp);
+    switch (gameversion)
+    {
+        case exe_doom_1_2:
+            mem_fputs(" -complevel 0", stream);
+            break;
+        case exe_doom_1_666:
+            mem_fputs(" -complevel 1", stream);
+            break;
+        case exe_doom_1_9:
+            if (gamemode == commercial)
+            {
+                mem_fputs(" -complevel 2", stream);
+            }
+            else
+            {
+                mem_fputs(" -complevel 3", stream);
+            }
+            break;
+        case exe_final:
+            mem_fputs(" -complevel 4", stream);
+            break;
+    }
 
     if (M_CheckParm("-solo-net"))
     {
         mem_fputs(" -solo-net", stream);
     }
 
+    return mem_ftell(stream) - pos;
+}
+
+static void WriteFileInfo(const char *name, size_t size, MEMFILE *stream)
+{
+    filelump_t fileinfo = { 0 };
+    static long filepos = sizeof(wadinfo_t);
+
+    fileinfo.filepos = LONG(filepos);
+    fileinfo.size = LONG(size);
+
+    if (name)
+    {
+        strncpy(fileinfo.name, name, 8);
+    }
+
+    mem_fwrite(&fileinfo, 1, sizeof(fileinfo), stream);
+
+    filepos += size;
+}
+
+static void G_AddDemoFooter(void)
+{
+    byte *data;
+    size_t size;
+
+    MEMFILE *stream = mem_fopen_write();
+
+    wadinfo_t header = { "PWAD" };
+    header.numlumps = LONG(NUM_DEMO_FOOTER_LUMPS);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+
+    mem_fputs(PACKAGE_STRING, stream);
+    mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
+    size = WriteCmdLineLump(stream);
     mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
 
-    mem_get_buf(stream, (void **)&tmp, &len);
+    header.infotableofs = LONG(mem_ftell(stream));
+    mem_fseek(stream, 0, MEM_SEEK_SET);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+    mem_fseek(stream, 0, MEM_SEEK_END);
 
-    while (demo_p > demoend - len)
+    WriteFileInfo("PORTNAME", strlen(PACKAGE_STRING), stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+    WriteFileInfo("CMDLINE", size, stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+
+    mem_get_buf(stream, (void **)&data, &size);
+
+    while (demo_p > demoend - size)
     {
         IncreaseDemoBuffer();
     }
 
-    memcpy(demo_p, tmp, len);
-    demo_p += len;
+    memcpy(demo_p, data, size);
+    demo_p += size;
 
     mem_fclose(stream);
 }

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3216,7 +3216,12 @@ static void WriteFileInfo(const char *name, size_t size, MEMFILE *stream)
 
     if (name)
     {
-        strncpy(fileinfo.name, name, 8);
+        size_t len = strnlen(name, 8);
+        if (len < 8)
+        {
+            len++;
+        }
+        memcpy(fileinfo.name, name, len);
     }
 
     mem_fwrite(&fileinfo, 1, sizeof(fileinfo), stream);

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2435,7 +2435,12 @@ static void WriteFileInfo(const char *name, size_t size, MEMFILE *stream)
 
     if (name)
     {
-        strncpy(fileinfo.name, name, 8);
+        size_t len = strnlen(name, 8);
+        if (len < 8)
+        {
+            len++;
+        }
+        memcpy(fileinfo.name, name, len);
     }
 
     mem_fwrite(&fileinfo, 1, sizeof(fileinfo), stream);

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -25,6 +25,7 @@
 #include "i_input.h"
 #include "i_timer.h"
 #include "i_system.h"
+#include "i_swap.h"
 #include "m_argv.h"
 #include "m_controls.h"
 #include "m_misc.h"
@@ -2372,29 +2373,21 @@ void G_TimeDemo(char *name)
 }
 
 #define DEMO_FOOTER_SEPARATOR "\n"
+#define NUM_DEMO_FOOTER_LUMPS 4
 
-static void G_AddDemoFooter(void)
+static size_t WriteCmdLineLump(MEMFILE *stream)
 {
     int i;
-    size_t len = 0;
+    long pos;
     char *tmp, **filenames;
-
-    MEMFILE *stream = mem_fopen_write();
 
     filenames = W_GetWADFileNames();
 
-    if (!filenames)
-    {
-        return;
-    }
+    pos = mem_ftell(stream);
 
-    tmp = M_StringReplace(PACKAGE_STRING, "Doom", "Heretic");
+    tmp = M_StringJoin("-iwad \"", M_BaseName(filenames[0]), "\"", NULL);
     mem_fputs(tmp, stream);
-    free(tmp);
-
-    tmp = M_StringJoin(DEMO_FOOTER_SEPARATOR, "-iwad \"",
-        M_BaseName(filenames[0]), "\"", NULL);
-    mem_fputs(tmp, stream);
+    printf("tmp: %s\n", tmp);
     free(tmp);
 
     if (filenames[1])
@@ -2423,23 +2416,74 @@ static void G_AddDemoFooter(void)
         }
     }
 
+    mem_fputs(" -complevel 0", stream);
+
     if (M_CheckParm("-solo-net"))
     {
         mem_fputs(" -solo-net", stream);
     }
 
+    return mem_ftell(stream) - pos;
+}
+
+static void WriteFileInfo(const char *name, size_t size, MEMFILE *stream)
+{
+    filelump_t fileinfo = { 0 };
+    static long filepos = sizeof(wadinfo_t);
+
+    fileinfo.filepos = LONG(filepos);
+    fileinfo.size = LONG(size);
+
+    if (name)
+    {
+        strncpy(fileinfo.name, name, 8);
+    }
+
+    mem_fwrite(&fileinfo, 1, sizeof(fileinfo), stream);
+
+    filepos += size;
+}
+
+static void G_AddDemoFooter(void)
+{
+    byte *data;
+    size_t size;
+    char *project_string;
+
+    MEMFILE *stream = mem_fopen_write();
+
+    wadinfo_t header = { "PWAD" };
+    header.numlumps = LONG(NUM_DEMO_FOOTER_LUMPS);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+
+    project_string = M_StringReplace(PACKAGE_STRING, "Doom", "Heretic");
+
+    mem_fputs(project_string, stream);
+    mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
+    size = WriteCmdLineLump(stream);
     mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
 
-    mem_get_buf(stream, (void **)&tmp, &len);
+    header.infotableofs = LONG(mem_ftell(stream));
+    mem_fseek(stream, 0, MEM_SEEK_SET);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+    mem_fseek(stream, 0, MEM_SEEK_END);
 
-    while (demo_p > demoend - len)
+    WriteFileInfo("PORTNAME", strlen(project_string), stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+    WriteFileInfo("CMDLINE", size, stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+
+    mem_get_buf(stream, (void **)&data, &size);
+
+    while (demo_p > demoend - size)
     {
         IncreaseDemoBuffer();
     }
 
-    memcpy(demo_p, tmp, len);
-    demo_p += len;
+    memcpy(demo_p, data, size);
+    demo_p += size;
 
+    free(project_string);
     mem_fclose(stream);
 }
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2387,7 +2387,6 @@ static size_t WriteCmdLineLump(MEMFILE *stream)
 
     tmp = M_StringJoin("-iwad \"", M_BaseName(filenames[0]), "\"", NULL);
     mem_fputs(tmp, stream);
-    printf("tmp: %s\n", tmp);
     free(tmp);
 
     if (filenames[1])

--- a/src/memio.c
+++ b/src/memio.c
@@ -192,7 +192,10 @@ int mem_fseek(MEMFILE *stream, signed long position, mem_rel_t whence)
 			return -1;
 	}
 
-	if (newpos < stream->buflen)
+	// We should allow seeking to the end of a MEMFILE with MEM_SEEK_END to
+	// match stdio.h behavior.
+
+	if (newpos <= stream->buflen)
 	{
 		stream->position = newpos;
 		return 0;

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -35,22 +35,6 @@
 
 #include "w_wad.h"
 
-typedef PACKED_STRUCT (
-{
-    // Should be "IWAD" or "PWAD".
-    char		identification[4];
-    int			numlumps;
-    int			infotableofs;
-}) wadinfo_t;
-
-
-typedef PACKED_STRUCT (
-{
-    int			filepos;
-    int			size;
-    char		name[8];
-}) filelump_t;
-
 //
 // GLOBALS
 //

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -30,6 +30,22 @@
 // TYPES
 //
 
+typedef PACKED_STRUCT (
+{
+    // Should be "IWAD" or "PWAD".
+    char        identification[4];
+    int         numlumps;
+    int         infotableofs;
+}) wadinfo_t;
+
+
+typedef PACKED_STRUCT (
+{
+    int         filepos;
+    int         size;
+    char        name[8];
+}) filelump_t;
+
 //
 // WADFILE I/O related stuff.
 //


### PR DESCRIPTION
Petition to developers: [[doomworld]](https://www.doomworld.com/forum/topic/134189-petition-to-all-developers-of-demo-compatible-ports-about-lmp-footer/)

There is potential issue with sideloading, e.g. "NERVE.WAD" appears in demo footer wad list but not used.