### PR TITLE
Status bar level stats alignment matching HUD width

### DIFF
--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -36,7 +36,7 @@
 #include "m_menu.h"
 #include "w_wad.h"
 #include "m_argv.h" // [crispy] M_ParmExists()
-#include "st_stuff.h" // [crispy] ST_HEIGHT
+#include "st_stuff.h" // [crispy] ST_HEIGHT, ST_WIDESCREENDELTA
 #include "p_setup.h" // maplumpinfo
 
 #include "s_sound.h"
@@ -1086,6 +1086,8 @@ void HU_Ticker(void)
     if (crispy->automapstats == WIDGETS_STBAR && (!automapactive || w_title.y != HU_TITLEY))
     {
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
+
+	w_kills.x = - ST_WIDESCREENDELTA;
 
 	w_kills.y = HU_TITLEY;
 

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -140,9 +140,6 @@ extern boolean inhelpscreens; // [crispy] prevent palette changes
 //       into a buffer,
 //       or into the frame buffer?
 
-// [crispy] in non-widescreen mode WIDESCREENDELTA is 0 anyway
-#define ST_WIDESCREENDELTA ((screenblocks >= CRISPY_HUD + 3 && (!automapactive || crispy->automapoverlay)) ? WIDESCREENDELTA : 0)
-
 // AMMO number pos.
 #define ST_AMMOWIDTH		3	
 #define ST_AMMOX			(44 - ST_WIDESCREENDELTA)

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -31,6 +31,9 @@
 #define ST_WIDTH	ORIGWIDTH
 #define ST_Y		(ORIGHEIGHT - ST_HEIGHT)
 
+// [crispy] in non-widescreen mode WIDESCREENDELTA is 0 anyway
+#define ST_WIDESCREENDELTA ((screenblocks >= CRISPY_HUD + 3 && (!automapactive || crispy->automapoverlay)) ? WIDESCREENDELTA : 0)
+
 #define CRISPY_HUD 12
 
 // [crispy] Demo Timer widget


### PR DESCRIPTION
Another minor fix that appears logical to me
![DOOM0001](https://github.com/fabiangreffrath/crispy-doom/assets/15119473/b2717410-6e99-4e76-8457-797512e11ad1)
![DOOM0002](https://github.com/fabiangreffrath/crispy-doom/assets/15119473/2c76b8fa-b6a8-423a-9695-42877db65510)
