### PR TITLE
Fixed Kills line position when switching level stats display from Status bar to a different option

### DIFF
--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -1111,9 +1111,9 @@ void HU_Ticker(void)
     if ((crispy->automapstats & WIDGETS_ALWAYS) || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
     {
 
-	w_kills.x = HU_TITLEX; // to handle switching from Status bar to Always and Automap kills line options
-
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
+
+	w_kills.x = HU_TITLEX; // to handle switching from Status bar to Always and Automap kills line options
 
 	crispy_statsline(str, sizeof(str), kills, plr->killcount, totalkills, extrakills);
 	HUlib_clearTextLine(&w_kills);

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -1110,6 +1110,9 @@ void HU_Ticker(void)
     else
     if ((crispy->automapstats & WIDGETS_ALWAYS) || (automapactive && crispy->automapstats == WIDGETS_AUTOMAP))
     {
+
+	w_kills.x = HU_TITLEX; // to handle switching from Status bar to Always and Automap kills line options
+
 	crispy_statsline_func_t crispy_statsline = crispy_statslines[crispy->statsformat];
 
 	crispy_statsline(str, sizeof(str), kills, plr->killcount, totalkills, extrakills);


### PR DESCRIPTION
Fix for this bug
![DOOM0003](https://github.com/fabiangreffrath/crispy-doom/assets/15119473/8dfcc7a4-a663-459c-95c1-4da360ba4ee2)
