### PR TITLE
Fix door interpolation in Doom 2 MAP19

### DIFF
--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -53,9 +53,12 @@ T_MovePlane
     fixed_t	lastpos;
 	
     // [AM] Store old sector heights for interpolation.
-    sector->oldfloorheight = sector->floorheight;
-    sector->oldceilingheight = sector->ceilingheight;
-    sector->oldgametic = gametic;
+    if (sector->oldgametic != gametic)
+    {
+        sector->oldfloorheight = sector->floorheight;
+        sector->oldceilingheight = sector->ceilingheight;
+        sector->oldgametic = gametic;
+    }
 
     switch(floorOrCeiling)
     {


### PR DESCRIPTION
Demo: [door.zip](https://github.com/fabiangreffrath/crispy-doom/files/11730464/door.zip)

Thanks to @JNechaevsky for bug report and demo.