### PR TITLE
Use `GREENONLY1` brightmap for Armor Bonus

### DIFF
--- a/src/doom/r_bmaps.c
+++ b/src/doom/r_bmaps.c
@@ -705,6 +705,10 @@ static const byte *R_BrightmapForSprite_Doom (const int type)
 		{
 			// Armor Bonus
 			case SPR_BON2:
+			{
+				return greenonly1;
+				break;
+			}
 			// Cell Charge
 			case SPR_CELL:
 			{


### PR DESCRIPTION
Details and testing map: https://github.com/JNechaevsky/international-doom/commit/92e4e71e34a569fc38983c08ebb0401fd9e34cf1.