### PR TITLE
Always use critical struct for freeaim and jump

### DIFF
--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -1330,7 +1330,7 @@ P_LineLaser
     if ((crispy->crosshair & ~CROSSHAIR_INTERCEPT) == CROSSHAIR_PROJECTED)
     {
 	// [crispy] don't aim at Spectres
-	if (linetarget && !(linetarget->flags & MF_SHADOW) && (crispy->freeaim != FREEAIM_DIRECT))
+	if (linetarget && !(linetarget->flags & MF_SHADOW) && (critical->freeaim != FREEAIM_DIRECT))
 		P_LineAttack(t1, angle, distance, aimslope, INT_MIN);
 	else
 		// [crispy] double the auto aim distance

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -380,7 +380,7 @@ void P_PlayerThink (player_t* player)
             !player->jumpTics)
         {
             // [crispy] Hexen sets 9; Strife adds 8
-            player->mo->momz = (7 + crispy->jump) * FRACUNIT;
+            player->mo->momz = (7 + critical->jump) * FRACUNIT;
             player->jumpTics = 18;
             // [NS] Jump sound.
             S_StartSoundOptional(player->mo, sfx_pljump, -1);


### PR DESCRIPTION
While cleaning up my amateur mistakes to prepare the new release of So Doom I noticed that Crispy code looks to contain flaws that may be seldom triggered.
The physical gameplay tweaks that affect demo sync and netplay should be set up as `crispy->criticalfield` in 4 files only:
`compatibility.c`, `d_main.c`, `m_crispy.c` and `m_menu.c`.
In all other files the `critical` structure pointer should be used instead of `crispy`, `critical` points to `crispy_s` struct in singleplayer (non-demo, non-netgame) and to the all-zeros-initialized `critical_s` otherwise.

I cleaned out what looks to me like the wrong use of `crispy->` instead of `critical->`.