### PR TITLE
Clarified MF_TRANSSHIFT purpose comment in Doom

### DIFF
--- a/src/doom/p_mobj.h
+++ b/src/doom/p_mobj.h
@@ -191,7 +191,7 @@ typedef enum
     // If 0x4 0x8 or 0xc,
     //  use a translation table for player colormaps
     MF_TRANSLATION  	= 0xc000000,
-    // Hmm ???.
+    // Turns MF_TRANSLATION into player index and vice versa
     MF_TRANSSHIFT	= 26,
 
     // [NS] Beta projectile bouncing.


### PR DESCRIPTION
For Heretic, Hexen and Strife the meaningful comments are present.