### PR TITLE
Move green color translation formula one step away from cyan

### DIFF
--- a/src/v_trans.c
+++ b/src/v_trans.c
@@ -284,7 +284,7 @@ byte V_Colorize (byte *playpal, int cr, byte source, boolean keepgray109)
 	if (cr == CR_GREEN)
 	{
 //	    hsv.x = 135./360.;
-	    hsv.x = (145. * hsv.z + 120. * (1. - hsv.z))/360.;
+	    hsv.x = (144. * hsv.z + 120. * (1. - hsv.z))/360.;
 	}
 	else
 	if (cr == CR_GOLD)


### PR DESCRIPTION
Same problem, described by @liPillON happens in Crispy Doom as well, though it's less noticeable because of `CR_GREEN` formula is slightly different from Woof. Anyways, result with D2TWID.wad loaded:

Before:
![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/56e4cad9-7c4b-40f4-8bcb-ff37883de362)

After:
![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/0b51e2a7-9edd-49d0-a9d5-b3a676198571)

Original commit from Woof: https://github.com/fabiangreffrath/woof/commit/62cd1e29a2159f881c236c26edc9bf1da70757af