### PR TITLE
IDDQD: fix reviving if god mode was already enabled

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -771,6 +771,11 @@ ST_Responder (event_t* ev)
 	    an = plyr->mo->angle >> ANGLETOFINESHIFT;
 	    P_SpawnMobj(plyr->mo->x+20*finecosine[an], plyr->mo->y+20*finesine[an], plyr->mo->z, MT_TFOG);
 	    S_StartSound(plyr, sfx_slop);
+
+	    // Fix reviving as "zombie" if god mode was already enabled
+	    if (plyr->mo)
+	        plyr->mo->health = deh_god_mode_health;
+	    plyr->health = deh_god_mode_health;
 	}
 
 	plyr->cheats ^= CF_GODMODE;


### PR DESCRIPTION
Currently, if the player enables god mode through the IDDQD cheat, dies, and then enters the cheat again to respawn, they'll respawn in a "zombie" state (which I assume is not intentional), similar to [this](https://youtu.be/0XKIB8mkYMs?si=to9z-rFo5-uFGMcg&t=154), because health is not reset from 0. This is unlikely to happen because the player shouldn't die in god mode, but it's possible in some cases, like telefragging.

This PR forces the player's health to that of god mode when respawning through IDDQD, regardless of whether god mode is being enabled or disabled, which doesn't change anything for the former case, and fixes respawning for the latter.