### PR TITLE
strife: Add flipped weapon sprites

### DIFF
--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1694,10 +1694,10 @@ void D_DoomMain (void)
     // @category obscure
     // @vanilla
     //
-    // Flip player gun sprites (broken).
+    // Flip player gun sprites.
     //
 
-    flipparm = M_CheckParm ("-flip");
+    flipparm = M_CheckParm("-flip") || M_CheckParm("-flipweapons"); // [crispy]
 
     //!
     // @category game

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -759,7 +759,8 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
     // calculate edges of the shape
     tx = psp->sx2-(ORIGWIDTH/2)*FRACUNIT;
 
-    tx -= spriteoffset[lump];	
+    // [crispy] fix sprite offsets for mirrored sprites
+    tx -= flip ? 2 * tx - spriteoffset[lump] + spritewidth[lump] : spriteoffset[lump];
     x1 = (centerxfrac + FixedMul (tx,pspritescale) ) >>FRACBITS;
 
     // off the right side
@@ -874,7 +875,7 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
     }
 
     // [crispy] free look
-    vis->texturemid += FixedMul(vis->xiscale, (centery - viewheight / 2) << FRACBITS);
+    vis->texturemid += FixedMul(pspriteiscale, (centery - viewheight / 2) << FRACBITS);
 
     R_DrawVisSprite (vis, vis->x1, vis->x2);
 }


### PR DESCRIPTION
The command line parameter `-flip` is a partially broken and undocumented [vanilla Strife feature](https://doomwiki.org/wiki/Parameter#-flip). This is now fixed for Crispy Strife. There is a similar feature in Crispy Doom, `-flipweapons`, so this has been added as an alias. Requested by @eggman07 on the Chocolate Discord.