### PR TITLE
Heretic: add true color support

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1172,12 +1172,10 @@ void R_InitColormaps (void)
 	byte *playpal;
 	int c, i, j = 0;
 	byte r, g, b;
-	extern byte **gamma2table;
 
 	// [crispy] intermediate gamma levels
 	if (!gamma2table)
 	{
-		extern void I_SetGammaTable (void);
 		I_SetGammaTable();
 	}
 

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -33,6 +33,9 @@
 vertex_t KeyPoints[NUM_KEY_TYPES];
 
 #define NUMALIAS 3              // Number of antialiased lines.
+// [crispy] precalculated color LUT for antialiased line drawing using COLORMAP
+#define NUMSHADES 8
+static pixel_t color_shades[NUMSHADES * 256];
 
 const char *LevelNames[] = {
     // EPISODE 1 - THE CITY OF THE DAMNED
@@ -102,7 +105,7 @@ static int finit_height;// = SCREENHEIGHT - (42 << crispy->hires);
 static int f_x, f_y;            // location of window on screen
 static int f_w, f_h;            // size of window on screen
 static int lightlev;            // used for funky strobing effect
-static byte *fb;                // pseudo-frame buffer
+static pixel_t *fb;             // pseudo-frame buffer
 static int amclock;
 
 static mpoint_t m_paninc;       // how far the window pans each tic (map coords)
@@ -155,20 +158,20 @@ static char cheat_amap[] = { 'r', 'a', 'v', 'm', 'a', 'p' };
 static byte cheatcount = 0;
 
 // [crispy] gradient table for map normal mode
-static byte antialias_normal[NUMALIAS][8] = {
+static pixel_t antialias_normal[NUMALIAS][8] = {
     {96, 97, 98, 99, 100, 101, 102, 103},
     {110, 109, 108, 107, 106, 105, 104, 103},
     {75, 76, 77, 78, 79, 80, 81, 103}
 };
 
 // [crispy] gradient table for map overlay mode
-static byte antialias_overlay[NUMALIAS][8] = {
+static pixel_t antialias_overlay[NUMALIAS][8] = {
     {100, 99, 98, 97, 96, 95, 95, 95},
     {110, 109, 108, 105, 102, 99, 97, 95},
     {75, 74, 73, 72, 71, 70, 69, 95}
 };
 
-static byte (*antialias)[NUMALIAS][8]; // [crispy]
+static pixel_t (*antialias)[NUMALIAS][8]; // [crispy]
 /*
 static byte *aliasmax[NUMALIAS] = {
 	&antialias[0][7], &antialias[1][7], &antialias[2][7]
@@ -199,7 +202,7 @@ extern fixed_t          fractionaltic;
 
 // Functions
 
-void DrawWuLine(int X0, int Y0, int X1, int Y1, byte * BaseColor,
+void DrawWuLine(int X0, int Y0, int X1, int Y1, int Color,
                 int NumLevels, unsigned short IntensityBits);
 
 // Calculates the slope and slope according to the x-axis of a line
@@ -545,6 +548,8 @@ void AM_LevelInit(boolean reinit)
 {
     // [crispy] Used for reinit
     static int f_h_old;
+    // [crispy] Only need to precalculate color lookup tables once
+    static boolean precalc_once;
 
     leveljuststarted = 0;
 
@@ -578,6 +583,26 @@ void AM_LevelInit(boolean reinit)
     scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
 
     f_h_old = f_h;
+
+    // [crispy] Precalculate color lookup tables for antialiased line drawing using COLORMAP
+    if (!precalc_once)
+    {
+        precalc_once = true;
+        for (int color = 0; color < 256; ++color)
+        {
+#define REINDEX(I) (color + I * 256)
+            // Pick a range of shades for a steep gradient to keep lines thin
+            int shade_index[NUMSHADES] =
+            {
+                REINDEX(0), REINDEX(1), REINDEX(2), REINDEX(3), REINDEX(4), REINDEX(5), REINDEX(6), REINDEX(7),
+            };
+#undef REINDEX
+            for (int shade = 0; shade < NUMSHADES; ++shade)
+            {
+                color_shades[color * NUMSHADES + shade] = colormaps[shade_index[shade]];
+            }
+        }
+    }
 }
 
 static boolean stopped = true;
@@ -1231,15 +1256,15 @@ void AM_drawFline(fline_t * fl, int color)
     switch (color)
     {
         case WALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, &(*antialias)[0][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[0][0],
                        8, 3);
             break;
         case FDWALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, &(*antialias)[1][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[1][0],
                        8, 3);
             break;
         case CDWALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, &(*antialias)[2][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[2][0],
                        8, 3);
             break;
         default:
@@ -1254,7 +1279,11 @@ void AM_drawFline(fline_t * fl, int color)
                     return;
                 }
 
+#ifndef CRISPY_TRUECOLOR
 #define DOT(xx,yy,cc) fb[(yy)*f_w+(xx)]=(cc)    //the MACRO!
+#else
+#define DOT(xx,yy,cc) fb[(yy)*f_w+(xx)]=(colormaps[cc])
+#endif
 
                 dx = fl->b.x - fl->a.x;
                 ax = 2 * (dx < 0 ? -dx : dx);
@@ -1314,11 +1343,11 @@ void AM_drawFline(fline_t * fl, int color)
  * IntensityBits = log base 2 of NumLevels; the # of bits used to describe
  *          the intensity of the drawing color. 2**IntensityBits==NumLevels
  */
-void PUTDOT(short xx, short yy, byte * cc, byte * cm)
+void PUTDOT(short xx, short yy, pixel_t * cc, pixel_t * cm)
 {
     static int oldyy;
     static int oldyyshifted;
-    byte *oldcc = cc;
+    pixel_t *oldcc = cc;
 
     if (xx < 32)
         cc += 7 - (xx >> 2);
@@ -1358,12 +1387,13 @@ void PUTDOT(short xx, short yy, byte * cc, byte * cm)
 //      fb[(yy)*f_w+(xx)]=*(cc);
 }
 
-void DrawWuLine(int X0, int Y0, int X1, int Y1, byte * BaseColor,
+void DrawWuLine(int X0, int Y0, int X1, int Y1, int Color,
                 int NumLevels, unsigned short IntensityBits)
 {
     unsigned short IntensityShift, ErrorAdj, ErrorAcc;
     unsigned short ErrorAccTemp, Weighting, WeightingComplementMask;
     short DeltaX, DeltaY, Temp, XDir;
+    pixel_t *BaseColor = &color_shades[Color * NUMSHADES];
 
     /* Make sure the line runs top to bottom */
     if (Y0 > Y1)

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -1118,6 +1118,7 @@ void AM_clearFB(int color)
 
     for (i = 0; i < finit_height; i++)
     {
+#ifndef CRISPY_TRUECOLOR
         memcpy(I_VideoBuffer + i * finit_width,
                maplump + j + (MAPBGROUNDWIDTH << crispy->hires) - x3, x3);
 
@@ -1126,7 +1127,30 @@ void AM_clearFB(int color)
 
         memcpy(I_VideoBuffer + i * finit_width + x2 + x3,
                maplump + j, x1);
+#else
+        int z;
+        pixel_t *dest = I_VideoBuffer + i * finit_width;
+        byte *src = maplump + j + (MAPBGROUNDWIDTH << crispy->hires) - x3;
 
+        for (z = 0; z < x3; z++)
+        {
+            dest[z] = colormaps[src[z]];
+        }
+
+        dest += x3;
+        src += x3 - x2;
+        for (z = 0; z < x2; z++)
+        {
+            dest[z] = colormaps[src[z]];
+        }
+
+        dest += x2;
+        src = maplump + j;
+        for (z = 0; z < x1; z++)
+        {
+            dest[z] = colormaps[src[z]];
+        }
+#endif
         j += MAPBGROUNDWIDTH << crispy->hires;
         if (j >= MAPBGROUNDHEIGHT * MAPBGROUNDWIDTH)
             j = 0;

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -157,21 +157,17 @@ static char cheat_amap[] = { 'r', 'a', 'v', 'm', 'a', 'p' };
 
 static byte cheatcount = 0;
 
-// [crispy] gradient table for map normal mode
-static pixel_t antialias_normal[NUMALIAS][8] = {
-    {96, 97, 98, 99, 100, 101, 102, 103},
-    {110, 109, 108, 107, 106, 105, 104, 103},
-    {75, 76, 77, 78, 79, 80, 81, 103}
+// [crispy] line colors for map normal mode
+static byte antialias_normal[NUMALIAS] = {
+    96, 110, 75
 };
 
-// [crispy] gradient table for map overlay mode
-static pixel_t antialias_overlay[NUMALIAS][8] = {
-    {100, 99, 98, 97, 96, 95, 95, 95},
-    {110, 109, 108, 105, 102, 99, 97, 95},
-    {75, 74, 73, 72, 71, 70, 69, 95}
+// [crispy] line colors for map overlay mode
+static byte antialias_overlay[NUMALIAS] = {
+    100, 110, 75
 };
 
-static pixel_t (*antialias)[NUMALIAS][8]; // [crispy]
+static byte (*antialias)[NUMALIAS]; // [crispy]
 /*
 static byte *aliasmax[NUMALIAS] = {
 	&antialias[0][7], &antialias[1][7], &antialias[2][7]
@@ -1280,15 +1276,15 @@ void AM_drawFline(fline_t * fl, int color)
     switch (color)
     {
         case WALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[0][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[0],
                        8, 3);
             break;
         case FDWALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[1][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[1],
                        8, 3);
             break;
         case CDWALLCOLORS:
-            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[2][0],
+            DrawWuLine(fl->a.x, fl->a.y, fl->b.x, fl->b.y, (*antialias)[2],
                        8, 3);
             break;
         default:

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -874,6 +874,9 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
     M_BindIntVariable("crispy_secretmessage",   &crispy->secretmessage);
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
+#ifdef CRISPY_TRUECOLOR
+    M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+#endif
     M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);
     M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -149,7 +149,8 @@ void F_Ticker(void)
 
 void F_TextWrite(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
     int x, y;
     int count;
     const char *ch;
@@ -164,6 +165,7 @@ void F_TextWrite(void)
     dest = I_VideoBuffer;
     for (y = 0; y < SCREENHEIGHT; y++)
     {
+#ifndef CRISPY_TRUECOLOR
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
@@ -174,6 +176,12 @@ void F_TextWrite(void)
             memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
             dest += (SCREENWIDTH & 63);
         }
+#else
+        for (x = 0; x < SCREENWIDTH; x++)
+        {
+            *dest++ = colormaps[src[((y & 63) << 6) + (x & 63)]];
+        }
+#endif
     }
 
 //      V_MarkRect (0, 0, SCREENWIDTH, SCREENHEIGHT);
@@ -220,7 +228,8 @@ void F_TextWrite(void)
 void F_DrawPatchCol(int x, patch_t * patch, int col)
 {
     column_t *column;
-    byte *source, *dest, *desttop;
+    byte *source;
+    pixel_t *dest, *desttop;
     int count;
 
     column = (column_t *) ((byte *) patch + LONG(patch->columnofs[col]));
@@ -325,8 +334,10 @@ void F_DemonScroll(void)
 void F_DrawUnderwater(void)
 {
     static boolean underwawa = false;
+#ifndef CRISPY_TRUECOLOR
     const char *lumpname;
     byte *palette;
+#endif
 
     // The underwater screen has its own palette, which is rather annoying.
     // The palette doesn't correspond to the normal palette. Because of
@@ -340,10 +351,15 @@ void F_DrawUnderwater(void)
             {
                 underwawa = true;
                 V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
+#ifndef CRISPY_TRUECOLOR
                 lumpname = DEH_String("E2PAL");
                 palette = W_CacheLumpName(lumpname, PU_STATIC);
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
+#else
+                // [JN] TODO - E2END using different palette
+                I_SetPalette(0);
+#endif
                 V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("E2END")));
             }
             paused = false;
@@ -354,10 +370,15 @@ void F_DrawUnderwater(void)
         case 2:
             if (underwawa)
             {
+#ifndef CRISPY_TRUECOLOR
                 lumpname = DEH_String("PLAYPAL");
                 palette = W_CacheLumpName(lumpname, PU_STATIC);
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
+#else
+                // [JN] TODO - E2END using different palette
+                I_SetPalette(0);
+#endif
                 underwawa = false;
             }
             V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("TITLE")));

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -334,10 +334,8 @@ void F_DemonScroll(void)
 void F_DrawUnderwater(void)
 {
     static boolean underwawa = false;
-#ifndef CRISPY_TRUECOLOR
     const char *lumpname;
     byte *palette;
-#endif
 
     // The underwater screen has its own palette, which is rather annoying.
     // The palette doesn't correspond to the normal palette. Because of
@@ -351,14 +349,14 @@ void F_DrawUnderwater(void)
             {
                 underwawa = true;
                 V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
-#ifndef CRISPY_TRUECOLOR
                 lumpname = DEH_String("E2PAL");
                 palette = W_CacheLumpName(lumpname, PU_STATIC);
+#ifndef CRISPY_TRUECOLOR
                 I_SetPalette(palette);
-                W_ReleaseLumpName(lumpname);
 #else
-                R_SetUnderwaterPalette();
+                R_SetUnderwaterPalette(palette);
 #endif
+                W_ReleaseLumpName(lumpname);
                 V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("E2END")));
             }
             paused = false;

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -357,10 +357,7 @@ void F_DrawUnderwater(void)
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
 #else
-                {
-                extern void R_SetUnderwaterPalette(void);
                 R_SetUnderwaterPalette();
-                }
 #endif
                 V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("E2END")));
             }
@@ -378,10 +375,7 @@ void F_DrawUnderwater(void)
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
 #else
-                {
-                extern void R_InitColormaps(void);
                 R_InitColormaps();
-                }
 #endif
                 underwawa = false;
             }

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -357,8 +357,10 @@ void F_DrawUnderwater(void)
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
 #else
-                // [JN] TODO - E2END using different palette
-                I_SetPalette(0);
+                {
+                extern void R_SetUnderwaterPalette(void);
+                R_SetUnderwaterPalette();
+                }
 #endif
                 V_DrawFullscreenRawOrPatch(W_GetNumForName(DEH_String("E2END")));
             }
@@ -376,8 +378,10 @@ void F_DrawUnderwater(void)
                 I_SetPalette(palette);
                 W_ReleaseLumpName(lumpname);
 #else
-                // [JN] TODO - E2END using different palette
-                I_SetPalette(0);
+                {
+                extern void R_InitColormaps(void);
+                R_InitColormaps();
+                }
 #endif
                 underwawa = false;
             }

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -177,7 +177,11 @@ static const char *NameForMap(int map)
 
 void IN_Start(void)
 {
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE));
+#else
+    I_SetPalette(0);
+#endif
     IN_LoadPics();
     IN_InitStats();
     intermission = true;
@@ -618,13 +622,14 @@ void IN_DrawStatBack(void)
     int y;
 
     byte *src;
-    byte *dest;
+    pixel_t *dest;
 
     src = W_CacheLumpName(DEH_String("FLOOR16"), PU_CACHE);
     dest = I_VideoBuffer;
 
     for (y = 0; y < SCREENHEIGHT; y++)
     {
+#ifndef CRISPY_TRUECOLOR
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
@@ -635,6 +640,12 @@ void IN_DrawStatBack(void)
             memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
             dest += (SCREENWIDTH & 63);
         }
+#else
+        for (x = 0; x < SCREENWIDTH; x++)
+        {
+            *dest++ = colormaps[src[((y & 63) << 6) + (x & 63)]];
+        }
+#endif
     }
 }
 

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1792,8 +1792,12 @@ boolean MN_Responder(event_t * event)
                     //set the msg to be cleared
                     players[consoleplayer].message = NULL;
                     paused = false;
+#ifndef CRISPY_TRUECOLOR
                     I_SetPalette(W_CacheLumpName
                                  ("PLAYPAL", PU_CACHE));
+#else
+                    I_SetPalette (0);
+#endif
                     D_StartTitle();     // go to intro/demo mode.
                     break;
 
@@ -2028,7 +2032,17 @@ boolean MN_Responder(event_t * event)
             {
                 usegamma = 0;
             }
+#ifndef CRISPY_TRUECOLOR
             I_SetPalette((byte *) W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+            {
+            extern void R_InitColormaps (void);
+            I_SetPalette (0);
+            R_InitColormaps();
+            setsizeneeded = true;
+            //viewactive = false; // [JN] Needed?
+            }
+#endif
             return true;
         }
         // [crispy] those two can be considered as shortcuts for the ENGAGE cheat
@@ -2438,7 +2452,11 @@ void MN_DrawInfo(void)
 {
     lumpindex_t lumpindex; // [crispy]
 
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+    I_SetPalette (0);
+#endif
 
     // [crispy] Refactor to allow for use of V_DrawFullscreenRawOrPatch
 
@@ -2543,7 +2561,8 @@ static void DrawMouseMenu(void)
 
 static void M_DrawCrispnessBackground(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
     int x, y;
 
     if (gamemode == shareware)
@@ -2558,6 +2577,7 @@ static void M_DrawCrispnessBackground(void)
 
     for (y = 0; y < SCREENHEIGHT; y++)
     {
+#ifndef CRISPY_TRUECOLOR
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
@@ -2568,6 +2588,12 @@ static void M_DrawCrispnessBackground(void)
             memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
             dest += (SCREENWIDTH & 63);
         }
+#else
+        for (x = 0; x < SCREENWIDTH; x++)
+        {
+            *dest++ = colormaps[src[(y & 63) * 64 + (x & 63)]];
+        }
+#endif
     }
 
     SB_state = -1;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1796,7 +1796,7 @@ boolean MN_Responder(event_t * event)
                     I_SetPalette(W_CacheLumpName
                                  ("PLAYPAL", PU_CACHE));
 #else
-                    I_SetPalette (0);
+                    I_SetPalette(0);
 #endif
                     D_StartTitle();     // go to intro/demo mode.
                     break;
@@ -2037,10 +2037,10 @@ boolean MN_Responder(event_t * event)
 #else
             {
             extern void R_InitColormaps (void);
-            I_SetPalette (0);
+            I_SetPalette(0);
             R_InitColormaps();
-            setsizeneeded = true;
-            //viewactive = false; // [JN] Needed?
+            BorderNeedRefresh = true;
+            SB_state = -1;
             }
 #endif
             return true;
@@ -2455,7 +2455,7 @@ void MN_DrawInfo(void)
 #ifndef CRISPY_TRUECOLOR
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
 #else
-    I_SetPalette (0);
+    I_SetPalette(0);
 #endif
 
     // [crispy] Refactor to allow for use of V_DrawFullscreenRawOrPatch

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2035,13 +2035,10 @@ boolean MN_Responder(event_t * event)
 #ifndef CRISPY_TRUECOLOR
             I_SetPalette((byte *) W_CacheLumpName("PLAYPAL", PU_CACHE));
 #else
-            {
-            extern void R_InitColormaps (void);
             I_SetPalette(0);
             R_InitColormaps();
             BorderNeedRefresh = true;
             SB_state = -1;
-            }
 #endif
             return true;
         }

--- a/src/heretic/p_user.c
+++ b/src/heretic/p_user.c
@@ -399,7 +399,11 @@ void P_DeathThink(player_t * player)
     {
         if (player == &players[consoleplayer])
         {
+#ifndef CRISPY_TRUECOLOR
             I_SetPalette(W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE));
+#else
+            I_SetPalette(0);
+#endif
             inv_ptr = 0;
             curpos = 0;
             newtorch = 0;

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -516,6 +516,7 @@ void R_InitSpriteLumps(void)
 =
 =================
 */
+extern byte **gamma2table;
 
 void R_InitColormaps(void)
 {
@@ -534,7 +535,6 @@ void R_InitColormaps(void)
 	byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 	int c, i, j = 0;
 	byte r, g, b;
-	extern byte **gamma2table;
 
 	// [crispy] intermediate gamma levels
 	if (!gamma2table)
@@ -618,6 +618,31 @@ void R_InitColormaps(void)
 	W_ReleaseLumpName("PLAYPAL");
     }
 }
+
+#ifdef CRISPY_TRUECOLOR
+// [crispy] Changes palette to E2PAL. Used exclusively in true color rendering
+// for proper drawing of E2END pic in F_DrawUnderwater. Changing palette back to
+// original PLAYPAL for restoring proper colors will be done in R_InitColormaps.
+void R_SetUnderwaterPalette(void)
+{
+    int i, j = 0;
+    byte r, g, b;
+    byte *playpal;
+
+    playpal = W_CacheLumpName("E2PAL", PU_STATIC);
+
+    for (i = 0; i < 256; i++)
+    {
+        r = gamma2table[usegamma][playpal[3 * i + 0]] + gamma2table[usegamma][0];
+        g = gamma2table[usegamma][playpal[3 * i + 1]] + gamma2table[usegamma][0];
+        b = gamma2table[usegamma][playpal[3 * i + 2]] + gamma2table[usegamma][0];
+
+        colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+    }
+
+    W_ReleaseLumpName("E2PAL");
+}
+#endif
 
 
 /*

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -565,20 +565,10 @@ void R_InitColormaps(void)
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
 		}
-
-		// [crispy] Invulnerability (c == COLORMAPS), generated from COLORMAP lump
-		for (i = 0; i < 256; i++)
-		{
-			r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
-			g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
-			b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
-
-			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
-		}
 	}
 	else
 	{
-		for (c = 0; c <= NUMCOLORMAPS; c++)
+		for (c = 0; c < NUMCOLORMAPS; c++)
 		{
 			for (i = 0; i < 256; i++)
 			{
@@ -589,6 +579,16 @@ void R_InitColormaps(void)
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
 		}
+	}
+
+	// [crispy] Invulnerability (c == COLORMAPS), generated from COLORMAP lump
+	for (i = 0; i < 256; i++)
+	{
+		r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+		g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+		b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
+
+		colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 	}
 
 	W_ReleaseLumpName("COLORMAP");

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -531,6 +531,7 @@ void R_InitColormaps(void)
     W_ReadLump(lump, colormaps);
 #else
 	byte *playpal;
+	byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 	int c, i, j = 0;
 	byte r, g, b;
 	extern byte **gamma2table;
@@ -565,24 +566,18 @@ void R_InitColormaps(void)
 			}
 		}
 
-		// [crispy] Invulnerability (c == COLORMAPS)
-		// [JN] TODO - inacurate, should be fine-tuned
+		// [crispy] Invulnerability (c == COLORMAPS), generated from COLORMAP lump
 		for (i = 0; i < 256; i++)
 		{
-			const byte gold =
-			     (byte) (0.500 * playpal[3 * i + 0] +
-			             0.500 * playpal[3 * i + 1]);
-			r = g = gamma2table[usegamma][gold];
-			// [JN] Decrease green channel intensity
-			g /= 1.500;
+			r = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+			g = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+			b = gamma2table[usegamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
 
-			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8);
+			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 		}
 	}
 	else
 	{
-		byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
-
 		for (c = 0; c <= NUMCOLORMAPS; c++)
 		{
 			for (i = 0; i < 256; i++)
@@ -594,9 +589,9 @@ void R_InitColormaps(void)
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
 		}
-
-		W_ReleaseLumpName("COLORMAP");
 	}
+
+	W_ReleaseLumpName("COLORMAP");
 #endif
 
     // [crispy] initialize color translation and color string tables

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -516,7 +516,6 @@ void R_InitSpriteLumps(void)
 =
 =================
 */
-extern byte **gamma2table;
 
 void R_InitColormaps(void)
 {
@@ -539,7 +538,6 @@ void R_InitColormaps(void)
 	// [crispy] intermediate gamma levels
 	if (!gamma2table)
 	{
-		extern void I_SetGammaTable (void);
 		I_SetGammaTable();
 	}
 

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -618,27 +618,22 @@ void R_InitColormaps(void)
 }
 
 #ifdef CRISPY_TRUECOLOR
-// [crispy] Changes palette to E2PAL. Used exclusively in true color rendering
+// [crispy] Changes palette to given one. Used exclusively in true color rendering
 // for proper drawing of E2END pic in F_DrawUnderwater. Changing palette back to
 // original PLAYPAL for restoring proper colors will be done in R_InitColormaps.
-void R_SetUnderwaterPalette(void)
+void R_SetUnderwaterPalette(byte *palette)
 {
     int i, j = 0;
     byte r, g, b;
-    byte *playpal;
-
-    playpal = W_CacheLumpName("E2PAL", PU_STATIC);
 
     for (i = 0; i < 256; i++)
     {
-        r = gamma2table[usegamma][playpal[3 * i + 0]] + gamma2table[usegamma][0];
-        g = gamma2table[usegamma][playpal[3 * i + 1]] + gamma2table[usegamma][0];
-        b = gamma2table[usegamma][playpal[3 * i + 2]] + gamma2table[usegamma][0];
+        r = gamma2table[usegamma][palette[3 * i + 0]] + gamma2table[usegamma][0];
+        g = gamma2table[usegamma][palette[3 * i + 1]] + gamma2table[usegamma][0];
+        b = gamma2table[usegamma][palette[3 * i + 2]] + gamma2table[usegamma][0];
 
         colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
     }
-
-    W_ReleaseLumpName("E2PAL");
 }
 #endif
 

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -311,7 +311,7 @@ void R_DrawTranslatedTLColumn(void)
                           dc_colormap[0][dc_translation
                                       [dc_source[frac >> FRACBITS]]]];
 #else
-        const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+        const pixel_t destrgb = dc_colormap[0][dc_translation[dc_source[frac>>FRACBITS]]];
         *dest = blendfunc(*dest, destrgb);
 #endif
         dest += SCREENWIDTH;

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -30,7 +30,7 @@ files only know about ccordinates, not the architecture of the frame buffer.
 
 byte *viewimage;
 int viewwidth, scaledviewwidth, viewheight, viewwindowx, viewwindowy;
-byte *ylookup[MAXHEIGHT];
+pixel_t *ylookup[MAXHEIGHT];
 int columnofs[MAXWIDTH];
 byte translations[3][256];      // color tables for different players
 
@@ -58,7 +58,7 @@ int dccount;                    // just for profiling
 void R_DrawColumn(void)
 {
     int count;
-    byte *dest;
+    pixel_t *dest;
     fixed_t frac, fracstep;
     int heightmask = dc_texheight - 1;
 
@@ -114,7 +114,7 @@ void R_DrawColumn(void)
 void R_DrawColumnLow(void)
 {
     int count;
-    byte *dest;
+    pixel_t *dest;
     fixed_t frac, fracstep;
     int heightmask = dc_texheight - 1; // [crispy]
 
@@ -173,7 +173,7 @@ void R_DrawColumnLow(void)
 void R_DrawTLColumn(void)
 {
     int count;
-    byte *dest;
+    pixel_t *dest;
     fixed_t frac, fracstep;
     int heightmask = dc_texheight - 1; // [crispy]
 
@@ -246,7 +246,7 @@ byte *translationtables;
 void R_DrawTranslatedColumn(void)
 {
     int count;
-    byte *dest;
+    pixel_t *dest;
     fixed_t frac, fracstep;
 
     count = dc_yh - dc_yl;
@@ -275,7 +275,7 @@ void R_DrawTranslatedColumn(void)
 void R_DrawTranslatedTLColumn(void)
 {
     int count;
-    byte *dest;
+    pixel_t *dest;
     fixed_t frac, fracstep;
 
     count = dc_yh - dc_yl;
@@ -360,7 +360,7 @@ int dscount;                    // just for profiling
 void R_DrawSpan(void)
 {
     fixed_t xfrac, yfrac;
-    byte *dest;
+    pixel_t *dest;
     int count, spot;
 
 #ifdef RANGECHECK
@@ -390,7 +390,7 @@ void R_DrawSpan(void)
 void R_DrawSpanLow(void)
 {
     fixed_t xfrac, yfrac;
-    byte *dest;
+    pixel_t *dest;
     int count, spot;
 
 #ifdef RANGECHECK
@@ -458,7 +458,8 @@ boolean BorderNeedRefresh;
 
 void R_DrawViewBorder(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
     int x, y;
 
     if (scaledviewwidth == SCREENWIDTH)
@@ -476,6 +477,7 @@ void R_DrawViewBorder(void)
 
     for (y = 0; y < SCREENHEIGHT - SBARHEIGHT; y++)
     {
+#ifndef CRISPY_TRUECOLOR
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
@@ -486,6 +488,12 @@ void R_DrawViewBorder(void)
             memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
             dest += (SCREENWIDTH & 63);
         }
+#else
+        for (x = 0; x < SCREENWIDTH; x++)
+        {
+            *dest++ = colormaps[src[((y & 63) << 6) + (x & 63)]];
+        }
+#endif
     }
     for (x = (viewwindowx >> crispy->hires); x < (viewwindowx + viewwidth) >> crispy->hires; x += 16)
     {
@@ -528,7 +536,8 @@ boolean BorderTopRefresh;
 
 void R_DrawTopBorder(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
     int x, y;
 
     if (scaledviewwidth == SCREENWIDTH)
@@ -546,6 +555,7 @@ void R_DrawTopBorder(void)
 
     for (y = 0; y < (30 << crispy->hires); y++)
     {
+#ifndef CRISPY_TRUECOLOR
         for (x = 0; x < SCREENWIDTH / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
@@ -556,6 +566,12 @@ void R_DrawTopBorder(void)
             memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
             dest += (SCREENWIDTH & 63);
         }
+#else
+        for (x = 0; x < SCREENWIDTH; x++)
+        {
+            *dest++ = colormaps[src[((y & 63) << 6) + (x & 63)]];
+        }
+#endif
     }
     if ((viewwindowy >> crispy->hires) < 25)
     {

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -330,7 +330,9 @@ void R_InitTranslationTables(void)
 {
     int i;
 
+#ifndef CRISPY_TRUECOLOR
     V_LoadTintTable();
+#endif
 
     // Allocate translation tables
     translationtables = Z_Malloc(256 * 3, PU_STATIC, 0);

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -20,6 +20,7 @@
 #include "r_local.h"
 #include "i_video.h"
 #include "v_video.h"
+#include "v_trans.h" // [crispy] blending functions
 
 /*
 
@@ -209,9 +210,14 @@ void R_DrawTLColumn(void)
 
         do
         {
+#ifndef CRISPY_TRUECOLOR
             *dest =
                 tinttable[((*dest) << 8) +
                           dc_colormap[0][dc_source[frac >> FRACBITS]]];
+#else
+            const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+            *dest = blendfunc(*dest, destrgb);
+#endif
             dest += SCREENWIDTH;
             if ((frac += fracstep) >= heightmask)
                 frac -= heightmask;
@@ -221,9 +227,14 @@ void R_DrawTLColumn(void)
     {
         do
         {
+#ifndef CRISPY_TRUECOLOR
             *dest =
                 tinttable[((*dest) << 8) +
                           dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]]];
+#else
+            const pixel_t destrgb = dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]];
+            *dest = blendfunc(*dest, destrgb);
+#endif
 
             dest += SCREENWIDTH;
             frac += fracstep;
@@ -294,10 +305,15 @@ void R_DrawTranslatedTLColumn(void)
 
     do
     {
+#ifndef CRISPY_TRUECOLOR
         *dest = tinttable[((*dest) << 8)
                           +
                           dc_colormap[0][dc_translation
                                       [dc_source[frac >> FRACBITS]]]];
+#else
+        const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+        *dest = blendfunc(*dest, destrgb);
+#endif
         dest += SCREENWIDTH;
         frac += fracstep;
     }

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -215,7 +215,7 @@ void R_DrawTLColumn(void)
                 tinttable[((*dest) << 8) +
                           dc_colormap[0][dc_source[frac >> FRACBITS]]];
 #else
-            const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+            const pixel_t destrgb = dc_colormap[0][dc_source[frac >> FRACBITS]];
             *dest = blendfunc(*dest, destrgb);
 #endif
             dest += SCREENWIDTH;
@@ -311,7 +311,7 @@ void R_DrawTranslatedTLColumn(void)
                           dc_colormap[0][dc_translation
                                       [dc_source[frac >> FRACBITS]]]];
 #else
-        const pixel_t destrgb = dc_colormap[0][dc_translation[dc_source[frac>>FRACBITS]]];
+        const pixel_t destrgb = dc_colormap[0][dc_translation[dc_source[frac >> FRACBITS]]];
         *dest = blendfunc(*dest, destrgb);
 #endif
         dest += SCREENWIDTH;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -48,12 +48,7 @@
 #define	MAXLIGHTZ			128
 #define	LIGHTZSHIFT			20
 #define	NUMCOLORMAPS		32      // number of diminishing
-#ifndef CRISPY_TRUECOLOR
 #define	INVERSECOLORMAP		32
-#else
-#define	INVERSECOLORMAP		8
-#endif
-    
 
 #define LOOKDIRMIN 110 // [crispy] -110, actually
 #define LOOKDIRMAX 90

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -462,6 +462,10 @@ byte *R_GetColumn(int tex, int col);
 void R_InitData(void);
 void R_PrecacheLevel(void);
 
+extern void R_InitColormaps(void);
+#ifdef CRISPY_TRUECOLOR
+extern void R_SetUnderwaterPalette(void);
+#endif
 
 //
 // R_things.c

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -48,7 +48,12 @@
 #define	MAXLIGHTZ			128
 #define	LIGHTZSHIFT			20
 #define	NUMCOLORMAPS		32      // number of diminishing
+#ifndef CRISPY_TRUECOLOR
 #define	INVERSECOLORMAP		32
+#else
+#define	INVERSECOLORMAP		8
+#endif
+    
 
 #define LOOKDIRMIN 110 // [crispy] -110, actually
 #define LOOKDIRMAX 90
@@ -190,7 +195,7 @@ typedef struct
 ==============================================================================
 */
 
-typedef byte lighttable_t;      // this could be wider for >8 bit display
+typedef pixel_t lighttable_t;      // this could be wider for >8 bit display
 
 #define	MAXVISPLANES	128
 #define	MAXOPENINGS		MAXWIDTH*64*4
@@ -511,7 +516,7 @@ extern fixed_t dc_texturemid;
 extern int dc_texheight;
 extern byte *dc_source;         // first pixel in a column
 extern const byte *dc_brightmap;  // [crispy] brightmaps
-extern byte *ylookup[MAXHEIGHT];
+extern pixel_t *ylookup[MAXHEIGHT];
 
 void R_DrawColumn(void);
 void R_DrawColumnLow(void);

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -249,6 +249,9 @@ typedef struct vissprite_s
     int mobjflags;              // for color translation and shadow draw
     boolean psprite;            // true if psprite
     fixed_t footclip;           // foot clipping
+#ifdef CRISPY_TRUECOLOR
+    const pixel_t (*blendfunc)(const pixel_t fg, const pixel_t bg);
+#endif
 } vissprite_t;
 
 

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -464,7 +464,7 @@ void R_PrecacheLevel(void);
 
 extern void R_InitColormaps(void);
 #ifdef CRISPY_TRUECOLOR
-extern void R_SetUnderwaterPalette(void);
+extern void R_SetUnderwaterPalette(byte *palette);
 #endif
 
 //

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -879,7 +879,9 @@ void R_SetupFrame(player_t * player)
     if (player->fixedcolormap)
     {
         fixedcolormap = colormaps + player->fixedcolormap
-            * 256;
+            // [crispy] sizeof(lighttable_t) not needed in paletted render
+            // and breaks invulnerability colormap index in true color render
+            * 256 /* * sizeof(lighttable_t)*/;
         walllights = scalelightfixed;
         for (i = 0; i < MAXLIGHTSCALE; i++)
         {

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -879,7 +879,7 @@ void R_SetupFrame(player_t * player)
     if (player->fixedcolormap)
     {
         fixedcolormap = colormaps + player->fixedcolormap
-            * 256 * sizeof(lighttable_t);
+            * 256;
         walllights = scalelightfixed;
         for (i = 0; i < MAXLIGHTSCALE; i++)
         {

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -879,8 +879,6 @@ void R_SetupFrame(player_t * player)
     if (player->fixedcolormap)
     {
         fixedcolormap = colormaps + player->fixedcolormap
-            // [crispy] sizeof(lighttable_t) not needed in paletted render
-            // and breaks invulnerability colormap index in true color render
             * 256 /* * sizeof(lighttable_t)*/;
         walllights = scalelightfixed;
         for (i = 0; i < MAXLIGHTSCALE; i++)

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -421,7 +421,7 @@ void R_DrawPlanes(void)
     int angle;
     byte *tempSource;
 
-    byte *dest;
+    pixel_t *dest;
     int count;
     fixed_t frac, fracstep;
     int heightmask; // [crispy]
@@ -508,7 +508,11 @@ void R_DrawPlanes(void)
                                 frac -= heightmask;
                         do
                         {
+#ifndef CRISPY_TRUECOLOR
                             *dest = dc_source[frac >> FRACBITS];
+#else
+                            *dest = colormaps[dc_source[frac >> FRACBITS]];
+#endif
                             dest += SCREENWIDTH;
 
                             if ((frac += fracstep) >= heightmask)
@@ -524,7 +528,11 @@ void R_DrawPlanes(void)
                     {
                         do
                         {
+#ifndef CRISPY_TRUECOLOR
                             *dest = dc_source[(frac >> FRACBITS) & heightmask];
+#else
+                            *dest = colormaps[dc_source[(frac >> FRACBITS) & heightmask]];
+#endif
                             dest += SCREENWIDTH;
                             frac += fracstep;
                         } while (count--);

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -671,7 +671,9 @@ void R_ProjectSprite(mobj_t * thing)
 #ifdef CRISPY_TRUECOLOR
     if (thing->flags & MF_SHADOW)
     {
-        vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAdd : I_BlendOver;
+        // [crispy] not using additive blending (I_BlendAdd) here 
+        // to preserve look & feel of original Heretic's translucency
+        vis->blendfunc = I_BlendOverTinttab;
     }
 #endif
 }

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -478,7 +478,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOver;
+    blendfunc = I_BlendOverTinttab;
 #endif
 }
 
@@ -828,7 +828,7 @@ void R_DrawPSprite(pspdef_t * psp)
         vis->colormap[0] = vis->colormap[1] = spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-        vis->blendfunc = I_BlendOver;
+        vis->blendfunc = I_BlendOverTinttab;
 #endif
     }
     else if (fixedcolormap)

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -22,6 +22,7 @@
 #include "i_system.h"
 #include "r_bmaps.h"
 #include "r_local.h"
+#include "v_trans.h" // [crispy] blending functions
 
 typedef struct
 {
@@ -424,6 +425,9 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
         {                       // Draw using shadow column function
             colfunc = tlcolfunc;
         }
+#ifdef CRISPY_TRUECOLOR
+        blendfunc = vis->blendfunc;
+#endif
     }
     else if (vis->mobjflags & MF_TRANSLATION)
     {
@@ -473,6 +477,9 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
     }
 
     colfunc = basecolfunc;
+#ifdef CRISPY_TRUECOLOR
+    blendfunc = I_BlendOver;
+#endif
 }
 
 
@@ -660,6 +667,13 @@ void R_ProjectSprite(mobj_t * thing)
     }
 
     vis->brightmap = R_BrightmapForSprite(thing->state - states);
+
+#ifdef CRISPY_TRUECOLOR
+    if (thing->flags & MF_SHADOW)
+    {
+        vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAdd : I_BlendOver;
+    }
+#endif
 }
 
 
@@ -811,6 +825,9 @@ void R_DrawPSprite(pspdef_t * psp)
         // Invisibility
         vis->colormap[0] = vis->colormap[1] = spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
+#ifdef CRISPY_TRUECOLOR
+        vis->blendfunc = I_BlendOver;
+#endif
     }
     else if (fixedcolormap)
     {

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -434,6 +434,7 @@ static void DrSmallNumber(int val, int x, int y)
 
 static void ShadeLine(int x, int y, int height, int shade)
 {
+#ifndef CRISPY_TRUECOLOR
     byte *dest;
     byte *shades;
 
@@ -450,6 +451,9 @@ static void ShadeLine(int x, int y, int height, int shade)
         *(dest) = *(shades + *dest);
         dest += SCREENWIDTH;
     }
+#else
+    // [JN] TODO - chain shading
+#endif
 }
 
 //---------------------------------------------------------------------------
@@ -606,7 +610,11 @@ static void RefreshBackground()
         {
             for (x = 0; x < SCREENWIDTH; x++)
             {
+#ifndef CRISPY_TRUECOLOR
                 *dest++ = src[((y & 63) << 6) + (x & 63)];
+#else
+                *dest++ = colormaps[src[((y & 63) << 6) + (x & 63)]];
+#endif
             }
         }
 
@@ -802,7 +810,9 @@ void SB_PaletteFlash(void)
 {
     static int sb_palette = 0;
     int palette;
+#ifndef CRISPY_TRUECOLOR
     byte *pal;
+#endif
 
     CPlayer = &players[consoleplayer];
 
@@ -831,8 +841,12 @@ void SB_PaletteFlash(void)
     if (palette != sb_palette)
     {
         sb_palette = palette;
+#ifndef CRISPY_TRUECOLOR
         pal = (byte *) W_CacheLumpNum(playpalette, PU_CACHE) + palette * 768;
         I_SetPalette(pal);
+#else
+        I_SetPalette(palette);
+#endif
     }
 }
 

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -27,6 +27,9 @@
 #include "s_sound.h"
 #include "v_video.h"
 #include "am_map.h"
+#ifdef CRISPY_TRUECOLOR
+#include "v_trans.h" // [crispy] I_BlendDark()
+#endif
 
 // Types
 
@@ -434,26 +437,33 @@ static void DrSmallNumber(int val, int x, int y)
 
 static void ShadeLine(int x, int y, int height, int shade)
 {
+    pixel_t *dest;
 #ifndef CRISPY_TRUECOLOR
-    byte *dest;
     byte *shades;
+#endif
 
     x <<= crispy->hires;
     y <<= crispy->hires;
     height <<= crispy->hires;
 
+#ifndef CRISPY_TRUECOLOR
     shades = colormaps + 9 * 256 + shade * 2 * 256;
+#else
+    shade = 0xFF - (((9 + shade * 2) << 8) / NUMCOLORMAPS);
+#endif
     dest = I_VideoBuffer + y * SCREENWIDTH + x + (WIDESCREENDELTA << crispy->hires);
     while (height--)
     {
         if (crispy->hires)
+#ifndef CRISPY_TRUECOLOR
             *(dest + 1) = *(shades + *dest);
         *(dest) = *(shades + *dest);
+#else
+            *(dest + 1) = I_BlendDark(*dest, shade);
+        *(dest) = I_BlendDark(*dest, shade);
+#endif
         dest += SCREENWIDTH;
     }
-#else
-    // [JN] TODO - chain shading
-#endif
 }
 
 //---------------------------------------------------------------------------

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -99,6 +99,7 @@ static SDL_Texture *grnpane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
+static const uint8_t blend_alpha_tinttab = 0x60;
 extern pixel_t* colormaps; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
@@ -2047,6 +2048,16 @@ const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg)
 	const uint32_t r = ((blend_alpha * (fg & rmask) + (0xff - blend_alpha) * (bg & rmask)) >> 8) & rmask;
 	const uint32_t g = ((blend_alpha * (fg & gmask) + (0xff - blend_alpha) * (bg & gmask)) >> 8) & gmask;
 	const uint32_t b = ((blend_alpha * (fg & bmask) + (0xff - blend_alpha) * (bg & bmask)) >> 8) & bmask;
+
+	return amask | r | g | b;
+}
+
+// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
+const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg)
+{
+	const uint32_t r = ((blend_alpha_tinttab * (fg & rmask) + (0xff - blend_alpha_tinttab) * (bg & rmask)) >> 8) & rmask;
+	const uint32_t g = ((blend_alpha_tinttab * (fg & gmask) + (0xff - blend_alpha_tinttab) * (bg & gmask)) >> 8) & gmask;
+	const uint32_t b = ((blend_alpha_tinttab * (fg & bmask) + (0xff - blend_alpha_tinttab) * (bg & bmask)) >> 8) & bmask;
 
 	return amask | r | g | b;
 }

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -65,6 +65,9 @@ void I_SetPalette (int palette);
 extern const pixel_t I_MapRGB (const uint8_t r, const uint8_t g, const uint8_t b);
 #endif
 
+extern byte **gamma2table;
+void I_SetGammaTable (void);
+
 void I_UpdateNoBlit (void);
 void I_FinishUpdate (void);
 

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -63,6 +63,7 @@ extern const pixel_t (*blendfunc) (const pixel_t fg, const pixel_t bg);
 extern const pixel_t I_BlendAdd (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendDark (const pixel_t bg, const int d);
 extern const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg);
 #endif
 
 int V_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -846,11 +846,7 @@ void V_DrawBox(int x, int y, int w, int h, int c)
 // to the screen)
 //
 
-#ifndef CRISPY_TRUECOLOR
-void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size)
-#else
 void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size)
-#endif
 {
     int i, j, index;
 
@@ -904,11 +900,7 @@ void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size)
     }
 }
  
-#ifndef CRISPY_TRUECOLOR
-void V_DrawRawScreen(pixel_t *raw)
-#else
 void V_DrawRawScreen(byte *raw)
-#endif
 {
     V_CopyScaledBuffer(dest_screen, raw, ORIGWIDTH * ORIGHEIGHT);
 }
@@ -924,11 +916,7 @@ void V_DrawFullscreenRawOrPatch(lumpindex_t index)
 
     if (W_LumpLength(index) == ORIGWIDTH * ORIGHEIGHT)
     {
-#ifndef CRISPY_TRUECOLOR
-        V_DrawRawScreen((pixel_t*)patch);
-#else
         V_DrawRawScreen((byte*)patch);
-#endif
     }
     else if ((SHORT(patch->height) == 200) && (SHORT(patch->width) >= 320))
     {

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -193,18 +193,17 @@ static const inline pixel_t drawpatchpx11 (const pixel_t dest, const pixel_t sou
 #else
 {return I_BlendOver(dest, colormaps[dp_translation[source]]);}
 #endif
-// (5) the shadow of the patch
-static const inline pixel_t drawshadow (const pixel_t dest, const pixel_t source)
+// TINTTAB rendering function
+static const inline pixel_t drawtinttab (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tinttable[(dest<<8)];}
 #else
-{return I_BlendDark(dest, 0x80);} // [crispy] 128 (50%) of 256 full translucency
-                                  // [JN] TODO - inaccurate, shadow should be less intensive
+{return I_BlendDark(dest, 0xB4);}
 #endif
 // [crispy] array of function pointers holding the different rendering functions
 typedef const pixel_t drawpatchpx_t (const pixel_t dest, const pixel_t source);
 static drawpatchpx_t *const drawpatchpx_a[2][2] = {{drawpatchpx11, drawpatchpx10}, {drawpatchpx01, drawpatchpx00}};
-static drawpatchpx_t *const drawshadow_a = drawshadow;
+static drawpatchpx_t *const drawtinttab_a = drawtinttab;
 
 static fixed_t dx, dxi, dy, dyi;
 
@@ -654,7 +653,7 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
     // [crispy] patch itself: opaque, can be colored
     drawpatchpx_t *const drawpatchpx = drawpatchpx_a[!dp_translucent][!dp_translation];
     // [crispy] translucent shadow, no coloring used
-    drawpatchpx_t *const drawpatchpx2 = drawshadow_a;
+    drawpatchpx_t *const drawpatchpx2 = drawtinttab_a;
 
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -924,7 +924,11 @@ void V_DrawFullscreenRawOrPatch(lumpindex_t index)
 
     if (W_LumpLength(index) == ORIGWIDTH * ORIGHEIGHT)
     {
+#ifndef CRISPY_TRUECOLOR
         V_DrawRawScreen((pixel_t*)patch);
+#else
+        V_DrawRawScreen((byte*)patch);
+#endif
     }
     else if ((SHORT(patch->height) == 200) && (SHORT(patch->width) >= 320))
     {

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -833,7 +833,11 @@ void V_DrawBox(int x, int y, int w, int h, int c)
 // to the screen)
 //
 
+#ifndef CRISPY_TRUECOLOR
 void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size)
+#else
+void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size)
+#endif
 {
     int i, j, index;
 
@@ -871,7 +875,11 @@ void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size)
         {
             for (j = 0; j <= crispy->hires; j++)
             {
+#ifndef CRISPY_TRUECOLOR
                 *(dest + index - (j * SCREENWIDTH) - i) = *(src + size);
+#else
+                *(dest + index - (j * SCREENWIDTH) - i) = colormaps[src[size]];
+#endif
             }
         }
         if (size % ORIGWIDTH == 0)
@@ -883,7 +891,11 @@ void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size)
     }
 }
  
+#ifndef CRISPY_TRUECOLOR
 void V_DrawRawScreen(pixel_t *raw)
+#else
+void V_DrawRawScreen(byte *raw)
+#endif
 {
     V_CopyScaledBuffer(dest_screen, raw, ORIGWIDTH * ORIGHEIGHT);
 }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -199,7 +199,7 @@ static const inline pixel_t drawtinttab0 (const pixel_t dest, const pixel_t sour
 #ifndef CRISPY_TRUECOLOR
 {return tinttable[(dest<<8)+source];}
 #else
-{return I_BlendOver(dest, colormaps[source]);}
+{return I_BlendOverTinttab(dest, colormaps[source]);}
 #endif
 // (2) translucent shadow only
 static const inline pixel_t drawtinttab1 (const pixel_t dest, const pixel_t source)

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -78,19 +78,11 @@ void V_DrawFilledBox(int x, int y, int w, int h, int c);
 void V_DrawHorizLine(int x, int y, int w, int c);
 void V_DrawVertLine(int x, int y, int h, int c);
 void V_DrawBox(int x, int y, int w, int h, int c);
-#ifndef CRISPY_TRUECOLOR
-void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size);
-#else
 void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size);
-#endif
 
 // Draw a raw screen lump
 
-#ifndef CRISPY_TRUECOLOR
-void V_DrawRawScreen(pixel_t *raw);
-#else
 void V_DrawRawScreen(byte *raw);
-#endif
 
 // Temporarily switch to using a different buffer to draw graphics, etc.
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -78,11 +78,19 @@ void V_DrawFilledBox(int x, int y, int w, int h, int c);
 void V_DrawHorizLine(int x, int y, int w, int c);
 void V_DrawVertLine(int x, int y, int h, int c);
 void V_DrawBox(int x, int y, int w, int h, int c);
+#ifndef CRISPY_TRUECOLOR
 void V_CopyScaledBuffer(pixel_t *dest, pixel_t *src, size_t size);
+#else
+void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size);
+#endif
 
 // Draw a raw screen lump
 
+#ifndef CRISPY_TRUECOLOR
 void V_DrawRawScreen(pixel_t *raw);
+#else
+void V_DrawRawScreen(byte *raw);
+#endif
 
 // Temporarily switch to using a different buffer to draw graphics, etc.
 


### PR DESCRIPTION
Pretty much same to Doom, except much more strict with translucency effects - we **must** keep original look & feel as much as possible, so there is no additive blending.

I wasn't able to resolve two small remaining problems:
1. [Chain shading](https://github.com/fabiangreffrath/crispy-doom/blob/truecolor_heretic/src/heretic/sb_bar.c#L435). No idea what to do, simple replacement of `byte` to `pixel_t` doesn't work. Something must be wrong with either `dest =` declaring, or inside `while` loop.
2. [Automap background drawing/parallaxing](https://github.com/fabiangreffrath/crispy-doom/blob/truecolor_heretic/src/heretic/am_map.c#L1121-L1128). Since `maplump` is a 320x158 raw screen, we can't use `memcpy` here. In theory, we can draw it same way as common 64x64 flat tiles, but how to achieve that dang parallax effect then - no idea. 

Any help is highly appreciated! ❤️