### PR TITLE
Heretic: small visual improvements

### DIFF
--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -183,10 +183,7 @@ void R_DrawTLColumn(void)
     if (!dc_yl)
         dc_yl = 1;
     if (dc_yh == viewheight - 1)
-    {
         dc_yh = viewheight - 2;
-        cutoff = true;
-    }
     */
 
     count = dc_yh - dc_yl;

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -177,8 +177,9 @@ void R_DrawTLColumn(void)
     pixel_t *dest;
     fixed_t frac, fracstep;
     int heightmask = dc_texheight - 1; // [crispy]
-    boolean cutoff = false; // [crispy]
 
+    // [crispy] Show transparent lines at top and bottom of screen.
+    /*
     if (!dc_yl)
         dc_yl = 1;
     if (dc_yh == viewheight - 1)
@@ -186,6 +187,7 @@ void R_DrawTLColumn(void)
         dc_yh = viewheight - 2;
         cutoff = true;
     }
+    */
 
     count = dc_yh - dc_yl;
     if (count < 0)
@@ -244,19 +246,6 @@ void R_DrawTLColumn(void)
             frac += fracstep;
         }
         while (count--);
-    }
-
-    // [crispy] if the line at the bottom had to be cut off,
-    // draw one extra line using only pixels of that line and the one above
-    if (cutoff)
-    {
-#ifndef CRISPY_TRUECOLOR
-        *dest = tinttable[((*dest) << 8) +
-                          dc_colormap[0][dc_source[(frac >> FRACBITS) - 1 / 2]]];
-#else
-        const pixel_t destrgb = dc_colormap[0][dc_source[(frac >> FRACBITS) - 1 / 2]];
-        *dest = blendfunc(*dest, destrgb);
-#endif
     }
 }
 

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -177,11 +177,15 @@ void R_DrawTLColumn(void)
     pixel_t *dest;
     fixed_t frac, fracstep;
     int heightmask = dc_texheight - 1; // [crispy]
+    boolean cutoff = false; // [crispy]
 
     if (!dc_yl)
         dc_yl = 1;
     if (dc_yh == viewheight - 1)
+    {
         dc_yh = viewheight - 2;
+        cutoff = true;
+    }
 
     count = dc_yh - dc_yl;
     if (count < 0)
@@ -240,6 +244,19 @@ void R_DrawTLColumn(void)
             frac += fracstep;
         }
         while (count--);
+    }
+
+    // [crispy] if the line at the bottom had to be cut off,
+    // draw one extra line using only pixels of that line and the one above
+    if (cutoff)
+    {
+#ifndef CRISPY_TRUECOLOR
+        *dest = tinttable[((*dest) << 8) +
+                          dc_colormap[0][dc_source[(frac >> FRACBITS) - 1 / 2]]];
+#else
+        const pixel_t destrgb = dc_colormap[0][dc_source[(frac >> FRACBITS) - 1 / 2]];
+        *dest = blendfunc(*dest, destrgb);
+#endif
     }
 }
 

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -797,8 +797,9 @@ void R_DrawPSprite(pspdef_t * psp)
     vis->mobjflags = 0;
     vis->psprite = true;
     vis->footclip = 0;
+    // [crispy] weapons drawn 1 pixel too high when player is idle
     vis->texturemid =
-        (BASEYCENTER << FRACBITS) /* + FRACUNIT / 2 */ - (psp->sy2 -
+        (BASEYCENTER << FRACBITS) + FRACUNIT / 4 - (psp->sy2 -
                                                     spritetopoffset[lump]);
     if (viewheight == SCREENHEIGHT)
     {

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -826,7 +826,9 @@ void R_DrawPSprite(pspdef_t * psp)
         viewplayer->powers[pw_invisibility] & 8)
     {
         // Invisibility
-        vis->colormap[0] = vis->colormap[1] = spritelights[MAXLIGHTSCALE - 1];
+        // [crispy] allow translucent weapons to be affected by invulnerability colormap
+        vis->colormap[0] = vis->colormap[1] = fixedcolormap ? fixedcolormap :
+                                              spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
         vis->blendfunc = I_BlendOverTinttab;


### PR DESCRIPTION
This is a small collection of small visual improvements. Nothing critical, until you'll see them or know about them. 🙃 To clarify:

**1.** Weapons drawn 1 pixel too high when player is idle. Fixes notable moving weapon for one pixel down even while small movement/momentum. Formula `FRACUNIT / 4` comes directly from Doom and it's working fine.

**2.** Fix 1px gap between translucent PSPrite and STbar. Fixes missing one pixel line above status bar for translucent columns.
<details>

![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/39d00685-d1ce-40ee-bfef-b749e1798fb1)

</details>

**3.** Allow translucent weapons to be affected by invul colormap. Just a small vanilla oversight, fix does not affect sky of course.
<details>

![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/92c7e888-4b17-4ea9-a024-88bdbc411fb2)

</details>