### PR TITLE
Externalize fractionaltic to i_video.h

### DIFF
--- a/src/doom/r_main.h
+++ b/src/doom/r_main.h
@@ -81,10 +81,6 @@ extern lighttable_t*	fixedcolormap;
 // There a 0-31, i.e. 32 LUT in the COLORMAP lump.
 #define NUMCOLORMAPS		32
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 // Blocky/low detail mode.
 //B remove this?
 //  0 = high, 1 = low

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -187,10 +187,6 @@ static void AM_rotatePoint(mpoint_t *pt);
 static mpoint_t mapcenter;
 static angle_t mapangle;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 //byte screens[][SCREENWIDTH*SCREENHEIGHT];
 //void V_MarkRect (int x, int y, int width, int height);
 

--- a/src/heretic/p_spec.c
+++ b/src/heretic/p_spec.c
@@ -219,10 +219,6 @@ struct
 
 mobj_t LavaInflictor;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 //----------------------------------------------------------------------------
 //
 // PROC P_InitLava

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -29,10 +29,6 @@ sector_t *frontsector, *backsector;
 drawseg_t *drawsegs = NULL, *ds_p;
 int numdrawsegs = 0;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 void R_StoreWallRange(int start, int stop);
 
 /*

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -64,10 +64,6 @@ lighttable_t *scalelight[LIGHTLEVELS][MAXLIGHTSCALE];
 lighttable_t *scalelightfixed[MAXLIGHTSCALE];
 lighttable_t *zlight[LIGHTLEVELS][MAXLIGHTZ];
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 int extralight;                 // bumped light from gun blasts
 
 void (*colfunc) (void);

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -415,8 +415,6 @@ void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsig
 ================
 */
 
-extern fixed_t fractionaltic; // [crispy]
-
 #define SKYTEXTUREMIDSHIFTED 200 // [crispy]
 
 void R_DrawPlanes(void)

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -46,10 +46,6 @@ fixed_t pspritescale, pspriteiscale;
 
 lighttable_t **spritelights;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 // constant arrays used for psprite clipping and initializing clipping
 int negonearray[MAXWIDTH];       // [crispy] 32-bit integer math
 int screenheightarray[MAXWIDTH]; // [crispy] 32-bit integer math

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -128,10 +128,6 @@ static void AM_rotatePoint(mpoint_t *pt);
 static mpoint_t mapcenter;
 static angle_t mapangle;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 //byte screens[][SCREENWIDTH*SCREENHEIGHT];
 //void V_MarkRect (int x, int y, int width, int height);
 

--- a/src/hexen/p_anim.c
+++ b/src/hexen/p_anim.c
@@ -184,8 +184,6 @@ void P_AnimateSurfaces(void)
     }
 }
 
-extern fixed_t fractionaltic; // [crispy]
-
 // [crispy] smooth texture scrolling
 void R_InterpolateTextureOffsets(void)
 {

--- a/src/hexen/po_man.c
+++ b/src/hexen/po_man.c
@@ -856,8 +856,6 @@ boolean PO_MovePolyobj(int num, int x, int y, boolean interp)
     return true;
 }
 
-extern fixed_t fractionaltic; // [crispy]
-
 // [crispy]
 void PO_InterpolatePolyObjects(void)
 {

--- a/src/hexen/r_bsp.c
+++ b/src/hexen/r_bsp.c
@@ -27,10 +27,6 @@ sector_t *frontsector, *backsector;
 
 drawseg_t drawsegs[MAXDRAWSEGS], *ds_p;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 void R_StoreWallRange(int start, int stop);
 
 /*

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -62,10 +62,6 @@ lighttable_t *scalelight[LIGHTLEVELS][MAXLIGHTSCALE];
 lighttable_t *scalelightfixed[MAXLIGHTSCALE];
 lighttable_t *zlight[LIGHTLEVELS][MAXLIGHTZ];
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 int extralight;                 // bumped light from gun blasts
 
 void (*colfunc) (void);

--- a/src/hexen/r_plane.c
+++ b/src/hexen/r_plane.c
@@ -385,8 +385,6 @@ void R_MakeSpans(int x, unsigned int t1, unsigned int b1, unsigned int t2, unsig
 //
 //==========================================================================
 
-extern fixed_t fractionaltic; // [crispy]
-
 #define SKYTEXTUREMIDSHIFTED 200
 
 void R_DrawPlanes(void)

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -47,10 +47,6 @@ fixed_t pspritescale, pspriteiscale;
 
 lighttable_t **spritelights;
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 // constant arrays used for psprite clipping and initializing clipping
 int negonearray[MAXWIDTH];  // [crispy] 32-bit integer math
 int screenheightarray[MAXWIDTH];  // [crispy] 32-bit integer math

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -21,6 +21,7 @@
 #define __I_VIDEO__
 
 #include "doomtype.h"
+#include "m_fixed.h" // [crispy] fixed_t
 #include "crispy.h"
 
 // Screen width and height.
@@ -67,6 +68,8 @@ extern const pixel_t I_MapRGB (const uint8_t r, const uint8_t g, const uint8_t b
 
 extern byte **gamma2table;
 void I_SetGammaTable (void);
+
+extern fixed_t fractionaltic;
 
 void I_UpdateNoBlit (void);
 void I_FinishUpdate (void);

--- a/src/strife/r_main.h
+++ b/src/strife/r_main.h
@@ -80,10 +80,6 @@ extern lighttable_t*	fixedcolormap;
 // There a 0-31, i.e. 32 LUT in the COLORMAP lump.
 #define NUMCOLORMAPS		32
 
-// [AM] Fractional part of the current tic, in the half-open
-//      range of [0.0, 1.0).  Used for interpolation.
-extern fixed_t          fractionaltic;
-
 // Blocky/low detail mode.
 //B remove this?
 //  0 = high, 1 = low


### PR DESCRIPTION
Keep `fractionaltic` external declaration in i_video.h only since all four games now have uncapped framerate support. Isn't it beautiful? 🤗