### PR TITLE
Invoke ST_doPaletteStuff every game tic, not every frame

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -1587,6 +1587,7 @@ void ST_updateWidgets(void)
 }
 
 static int st_widescreendelta;
+static void ST_doPaletteStuff(void);
 
 void ST_Ticker (void)
 {
@@ -1595,11 +1596,13 @@ void ST_Ticker (void)
     ST_updateWidgets();
     st_oldhealth = plyr->health;
 
+    // Do red-/gold-shifts from damage/items
+    ST_doPaletteStuff();
 }
 
 static int st_palette = 0;
 
-void ST_doPaletteStuff(void)
+static void ST_doPaletteStuff(void)
 {
 
     int		palette;
@@ -1964,9 +1967,6 @@ void ST_Drawer (boolean fullscreen, boolean refresh)
 
     if (crispy->cleanscreenshot == 2)
         return;
-
-    // Do red-/gold-shifts from damage/items
-    ST_doPaletteStuff();
 
     // [crispy] translucent HUD
     if (st_crispyhud && (screenblocks % 3 == 2))

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -911,7 +911,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
     if (player == &players[consoleplayer])
     {
         S_StartSound(NULL, sound);
-        SB_PaletteFlash();
     }
 }
 
@@ -1475,7 +1474,6 @@ void P_DamageMobj
         if (player == &players[consoleplayer])
         {
             I_Tactile(40, 10, 40 + temp * 2);
-            SB_PaletteFlash();
         }
     }
 

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -319,6 +319,7 @@ void SB_Ticker(void)
         }
         HealthMarker += delta;
     }
+    SB_PaletteFlash();
 }
 
 //---------------------------------------------------------------------------
@@ -709,7 +710,6 @@ void SB_Drawer(void)
             SB_state = 1;
         }
     }
-    SB_PaletteFlash();
 
     // Flight icons
     if (CPlayer->powers[pw_flight])

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -4768,10 +4768,6 @@ void A_FreezeDeath(mobj_t *actor, player_t *player, pspdef_t *psp)
         actor->player->damagecount = 0;
         actor->player->poisoncount = 0;
         actor->player->bonuscount = 0;
-        if (actor->player == &players[consoleplayer])
-        {
-            SB_PaletteFlash(false);
-        }
     }
     else if (actor->flags & MF_COUNTKILL && actor->special)
     {

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -290,7 +290,6 @@ static void TryPickupWeapon(player_t * player, pclass_t weaponClass,
     if (player == &players[consoleplayer])
     {
         S_StartSound(NULL, SFX_PICKUP_WEAPON);
-        SB_PaletteFlash(false);
     }
 }
 
@@ -492,10 +491,6 @@ static void TryPickupWeaponPiece(player_t * player, pclass_t matchClass,
         }
     }
     player->bonuscount += BONUSADD;
-    if (player == &players[consoleplayer])
-    {
-        SB_PaletteFlash(false);
-    }
 
     // Check if fourth weapon assembled
     if (checkAssembled)
@@ -1027,7 +1022,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
             if (player == &players[consoleplayer])
             {
                 S_StartSound(NULL, sound);
-                SB_PaletteFlash(false);
             }
             return;
 
@@ -1241,7 +1235,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
     if (player == &players[consoleplayer])
     {
         S_StartSound(NULL, sound);
-        SB_PaletteFlash(false);
     }
 }
 
@@ -1985,7 +1978,6 @@ void P_DamageMobj
         if (player == &players[consoleplayer])
         {
             I_Tactile(40, 10, 40 + temp * 2);
-            SB_PaletteFlash(false);
         }
     }
 

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -428,6 +428,7 @@ void SB_Ticker(void)
         }
         HealthMarker += delta;
     }
+    SB_PaletteFlash(false);
 }
 
 //==========================================================================
@@ -871,7 +872,6 @@ void SB_Drawer(void)
             SB_state = 1;
         }
     }
-    SB_PaletteFlash(false);
     DrawAnimatedIcons();
 }
 

--- a/src/strife/st_stuff.c
+++ b/src/strife/st_stuff.c
@@ -815,6 +815,8 @@ void ST_updateWidgets(void)
 }
 */
 
+static void ST_doPaletteStuff(void);
+
 //
 // ST_Ticker
 //
@@ -864,6 +866,9 @@ void ST_Ticker (void)
         }
     }
 
+    // Do red-/gold-shifts from damage/items
+    ST_doPaletteStuff();
+
     // haleyjd 20100901: [STRIFE] Keys are handled on a popup
     // haleyjd 20100831: [STRIFE] No face widget
     // haleyjd 20100901: [STRIFE] Armor, weapons, frags, etc. handled elsewhere
@@ -883,7 +888,7 @@ static int st_palette = 0;
 // * Changed radsuit palette handling for Strife nukagecount.
 // * All other logic verified to be unmodified.
 //
-void ST_doPaletteStuff(void)
+static void ST_doPaletteStuff(void)
 {
 
     int		palette;
@@ -1203,9 +1208,6 @@ void ST_Drawer (boolean fullscreen, boolean refresh)
 
     // [crispy] Crispy HUD
     st_crispyhud = screenblocks > 11 && (!automapactive || crispy->automapoverlay);
-
-    // Do red-/gold-shifts from damage/items
-    ST_doPaletteStuff();
 
     // If just after ST_Start(), refresh all
     ST_doRefresh();


### PR DESCRIPTION
Same as described and done in https://github.com/fabiangreffrath/woof/pull/1316. Few remarks:
- Heretic have `void SB_PaletteFlash(void)` in p_local.h. Kept it there for smaller diff, so no static declaration.
- Hexen handles `F11` just a very little bit different, so call for `SB_PaletteFlash(true)` is still needed in mn_menu.c
- Maybe add some comments?