### PR TITLE
Heretic: check for sector->special for proper visplanes clipping

### DIFF
--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -312,6 +312,7 @@ void R_AddLine(seg_t * line)
     if (backsector->ceilingpic == frontsector->ceilingpic
         && backsector->floorpic == frontsector->floorpic
         && backsector->lightlevel == frontsector->lightlevel
+        && backsector->special == frontsector->special // [crispy] check for special as well
         && curline->sidedef->midtexture == 0)
         return;
 

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -671,7 +671,8 @@ void R_StoreWallRange(int start, int stop)
 
         if (worldlow != worldbottom
             || backsector->floorpic != frontsector->floorpic
-            || backsector->lightlevel != frontsector->lightlevel)
+            || backsector->lightlevel != frontsector->lightlevel
+            || backsector->special != frontsector->special) // [crispy] check for special as well
             markfloor = true;
         else
             markfloor = false;  // same plane on both sides


### PR DESCRIPTION
This glitch with animated floor attracted my attention (hey, isn't the gamma is beautiful now?):
<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/cefaf847-3e16-4cf2-9277-b2f0afd9b64c

</details>
On a first look it might appear as huge slime trail or broken map nodes, but no, it is much simpler. When sector lowers to nearest floor, following happens in this scene:

- Both sectors have same floor height.
- Both sectors have same ceiling height.
- Both sectors have same lighting level.
- And only sector specials are different: upper is Scroll East, lower is Scroll South (effect is invisible).

This all makes clear explanation: engine thinking that both visplanes can be merged into one for rendering. In fact, it's a small oversight in original Heretic code, and I missed it while working on Crispy Heretic. Later on Hexen, Raven have fixed it ([r_segs.c](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/hexen/r_segs.c#L485) and [r_bsp.c](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/hexen/r_bsp.c#L282)), obliviously because Hexen have a lot of scrolling liquids, which are scrolling in all possible directions.

Why there is only check for floor? In Heretic, only floors are scrolling and not ceilings. There is even no sector->special [check for ceiling](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/heretic/r_bsp.c#L431-L438) in `R_Subsector`.

Now, why I found it's interesting in retrospect. 

Doom also have specials for sectors, right? So, such visplanes are also can be merged? Yes, they does:
<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/4bde120a-8090-4ef7-b4b7-24f073b5bd3b

</details>

Oh no! 😨We have same potential glitch in the Doom render, what shall we do? 😱 

Well, the answer is simple: **nothing**. Due to the way flats are being drawn - and - until their coords are same, nothing is needed. They are always perfectly aligned, matters no are they static, or animated, or even swirling. If we'll do such check, by getting literally nothing we'll just increase visplanes _from one to many_ in such scenes.

Scrolling floors were implemented in Boom, and there is [such check](https://github.com/fabiangreffrath/woof/blob/master/src/r_bsp.c#L447) of course.


