### PR TITLE
Fix non-power-of-two wide sky textures

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -672,6 +672,26 @@ R_GetColumnMod
     return texturecomposite[tex] + ofs;
 }
 
+// [FG] wrapping column getter function for non-power-of-two wide sky textures
+byte*
+R_GetColumnMod2
+( int		tex,
+  int		col )
+{
+    int		ofs;
+
+    while (col < 0)
+	col += texturewidth[tex];
+
+    col %= texturewidth[tex];
+    ofs = texturecolumnofs2[tex][col];
+
+    if (!texturecomposite2[tex])
+	R_GenerateComposite(tex);
+
+    return texturecomposite2[tex] + ofs;
+}
+
 
 static void GenerateTextureHashTable(void)
 {

--- a/src/doom/r_data.h
+++ b/src/doom/r_data.h
@@ -40,6 +40,12 @@ R_GetColumnMod
 ( int		tex,
   int		col );
 
+// [FG] wrapping column getter function for non-power-of-two wide sky textures
+byte*
+R_GetColumnMod2
+( int		tex,
+  int		col );
+
 
 // I/O, setting up the stuff.
 void R_InitData (void);

--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -498,7 +498,7 @@ void R_DrawPlanes (void)
 		{
 		    angle = ((an + xtoviewangle[x])^flip)>>ANGLETOSKYSHIFT;
 		    dc_x = x;
-		    dc_source = R_GetColumn(texture, angle);
+		    dc_source = R_GetColumnMod2(texture, angle);
 		    colfunc ();
 		}
 	    }


### PR DESCRIPTION
Discussion and code: https://github.com/fabiangreffrath/woof/pull/1323
Testing map: [thatsky.zip](https://github.com/fabiangreffrath/crispy-doom/files/13695906/thatsky.zip) (for MAP01 of Doom2).

Few remarks:
- Code style is adopted to existing `R_GetColumnMod`.
- Traditionally, Crispy comments are written as `[crispy]`, but I'm not willing to replace `[FG]` until been told to do this. 🫡
