### PR TITLE
Fix automap marks dissapering near left side of the screen

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -854,7 +854,8 @@ AM_Responder
 	if (!followplayer && (ev->data2 || ev->data3))
 	{
 		// [crispy] mouse sensitivity for strafe
-		m_paninc2.x = FTOM(ev->data2*(mouseSensitivity_x2+5)/(160 >> crispy->hires));
+		const int flip_x = (ev->data2*(mouseSensitivity_x2+5)/(160 >> crispy->hires));
+		m_paninc2.x = crispy->fliplevels ? -FTOM(flip_x) : FTOM(flip_x);
 		m_paninc2.y = FTOM(ev->data3*(mouseSensitivity_x2+5)/(160 >> crispy->hires));
 		rc = true;
 	}

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -2068,10 +2068,10 @@ void AM_drawMarks(void)
 	    {
 		AM_rotatePoint(&pt);
 	    }
-	    fx = (flipscreenwidth[CXMTOF(pt.x)] >> crispy->hires) - 1 - WIDESCREENDELTA;
+	    fx = (flipscreenwidth[CXMTOF(pt.x)] >> crispy->hires) - 1;
 	    fy = (CYMTOF(pt.y) >> crispy->hires) - 2;
 	    if (fx >= f_x && fx <= (f_w >> crispy->hires) - w && fy >= f_y && fy <= (f_h >> crispy->hires) - h)
-		V_DrawPatch(fx, fy, marknums[i]);
+		V_DrawPatch(fx - WIDESCREENDELTA, fy, marknums[i]);
 	}
     }
 

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -2052,6 +2052,7 @@ AM_drawThings
 void AM_drawMarks(void)
 {
     int i, fx, fy, w, h;
+    int fx_flip; // [crispy] support for marks drawing in flipped levels
     mpoint_t pt;
 
     for (i=0;i<AM_NUMMARKPOINTS;i++)
@@ -2069,10 +2070,11 @@ void AM_drawMarks(void)
 	    {
 		AM_rotatePoint(&pt);
 	    }
-	    fx = (flipscreenwidth[CXMTOF(pt.x)] >> crispy->hires) - 1;
+	    fx = (CXMTOF(pt.x) >> crispy->hires) - 1;
 	    fy = (CYMTOF(pt.y) >> crispy->hires) - 2;
+	    fx_flip = (flipscreenwidth[CXMTOF(pt.x)] >> crispy->hires) - 1;
 	    if (fx >= f_x && fx <= (f_w >> crispy->hires) - w && fy >= f_y && fy <= (f_h >> crispy->hires) - h)
-		V_DrawPatch(fx - WIDESCREENDELTA, fy, marknums[i]);
+		V_DrawPatch(fx_flip - WIDESCREENDELTA, fy, marknums[i]);
 	}
     }
 

--- a/src/strife/am_map.c
+++ b/src/strife/am_map.c
@@ -1835,13 +1835,13 @@ void AM_drawMarks(void)
             {
                 AM_rotatePoint(&pt);
             }
-            fx = (CXMTOF(pt.x) >> crispy->hires) - 3 - WIDESCREENDELTA;
+            fx = (CXMTOF(pt.x) >> crispy->hires) - 3;
             fy = (CYMTOF(pt.y) >> crispy->hires) - 3;
             if (fx >= f_x && fx <= (f_w >> crispy->hires) - w && fy >= f_y && fy <= (f_h >> crispy->hires) - h)
             {
                 // villsa [STRIFE]
                 if(i >= mapmarknum)
-                    V_DrawPatch(fx, fy, marknums[i]);
+                    V_DrawPatch(fx - WIDESCREENDELTA, fy, marknums[i]);
             }
         }
     }


### PR DESCRIPTION
Fixes this case in widescreen mode:

<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/aeddba76-b5f5-46c6-a1e5-33cc717bd3a4

</details>

Hovewer! There is a small problem with Doom, caused by `flipscreenwidth`. This is won't happent if just `CXMTOF(pt.x)` will be used. Note how `1` is blinking and appearing when it shouldn't. It was happening even before my fix.

<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/94a81d34-e00f-4fce-9519-4f2cb6dec85d

</details>

Not sure how to fix this blinking, no ideas yet... 🤔