### PR TITLE
Apply brightmaps to translucent and translated columns

### DIFF
--- a/src/doom/r_draw.c
+++ b/src/doom/r_draw.c
@@ -565,7 +565,9 @@ void R_DrawTranslatedColumn (void)
 	//  used with PLAY sprites.
 	// Thus the "green" ramp of the player 0 sprite
 	//  is mapped to gray, red, black/indigo. 
-	*dest = dc_colormap[0][dc_translation[dc_source[frac>>FRACBITS]]];
+	// [crispy] brightmaps
+	const byte source = dc_source[frac>>FRACBITS];
+	*dest = dc_colormap[dc_brightmap[source]][dc_translation[source]];
 	dest += SCREENWIDTH;
 	
 	frac += fracstep; 
@@ -615,8 +617,10 @@ void R_DrawTranslatedColumnLow (void)
 	//  used with PLAY sprites.
 	// Thus the "green" ramp of the player 0 sprite
 	//  is mapped to gray, red, black/indigo. 
-	*dest = dc_colormap[0][dc_translation[dc_source[frac>>FRACBITS]]];
-	*dest2 = dc_colormap[0][dc_translation[dc_source[frac>>FRACBITS]]];
+	// [crispy] brightmaps
+	const byte source = dc_source[frac>>FRACBITS];
+	*dest = dc_colormap[dc_brightmap[source]][dc_translation[source]];
+	*dest2 = dc_colormap[dc_brightmap[source]][dc_translation[source]];
 	dest += SCREENWIDTH;
 	dest2 += SCREENWIDTH;
 	
@@ -652,11 +656,13 @@ void R_DrawTLColumn (void)
 
     do
     {
+        // [crispy] brightmaps
+        const byte source = dc_source[frac>>FRACBITS];
 #ifndef CRISPY_TRUECOLOR
         // actual translucency map lookup taken from boom202s/R_DRAW.C:255
-        *dest = tranmap[(*dest<<8)+dc_colormap[0][dc_source[frac>>FRACBITS]]];
+        *dest = tranmap[(*dest<<8)+dc_colormap[dc_brightmap[source]][source]];
 #else
-        const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+        const pixel_t destrgb = dc_colormap[dc_brightmap[source]][source];
         *dest = blendfunc(*dest, destrgb);
 #endif
 	dest += SCREENWIDTH;
@@ -699,11 +705,13 @@ void R_DrawTLColumnLow (void)
 
     do
     {
+	// [crispy] brightmaps
+	const byte source = dc_source[frac>>FRACBITS];        
 #ifndef CRISPY_TRUECOLOR
-	*dest = tranmap[(*dest<<8)+dc_colormap[0][dc_source[frac>>FRACBITS]]];
-	*dest2 = tranmap[(*dest2<<8)+dc_colormap[0][dc_source[frac>>FRACBITS]]];
+	*dest = tranmap[(*dest<<8)+dc_colormap[dc_brightmap[source]][source]];
+	*dest2 = tranmap[(*dest2<<8)+dc_colormap[dc_brightmap[source]][source]];
 #else
-	const pixel_t destrgb = dc_colormap[0][dc_source[frac>>FRACBITS]];
+	const pixel_t destrgb = dc_colormap[dc_brightmap[source]][source];
 	*dest = blendfunc(*dest, destrgb);
 	*dest2 = blendfunc(*dest2, destrgb);
 #endif

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -213,12 +213,14 @@ void R_DrawTLColumn(void)
 
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[frac >> FRACBITS];
 #ifndef CRISPY_TRUECOLOR
             *dest =
                 tinttable[((*dest) << 8) +
-                          dc_colormap[0][dc_source[frac >> FRACBITS]]];
+                          dc_colormap[dc_brightmap[source]][source]];
 #else
-            const pixel_t destrgb = dc_colormap[0][dc_source[frac >> FRACBITS]];
+            const pixel_t destrgb = dc_colormap[dc_brightmap[source]][source];
             *dest = blendfunc(*dest, destrgb);
 #endif
             dest += SCREENWIDTH;
@@ -230,12 +232,14 @@ void R_DrawTLColumn(void)
     {
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[(frac >> FRACBITS) & heightmask];
 #ifndef CRISPY_TRUECOLOR
             *dest =
                 tinttable[((*dest) << 8) +
-                          dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]]];
+                          dc_colormap[dc_brightmap[source]][source]];
 #else
-            const pixel_t destrgb = dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]];
+            const pixel_t destrgb = dc_colormap[dc_brightmap[source]][source];
             *dest = blendfunc(*dest, destrgb);
 #endif
 
@@ -279,7 +283,9 @@ void R_DrawTranslatedColumn(void)
 
     do
     {
-        *dest = dc_colormap[0][dc_translation[dc_source[frac >> FRACBITS]]];
+        // [crispy] brightmaps
+        const byte source = dc_source[frac>>FRACBITS];
+        *dest = dc_colormap[dc_brightmap[source]][dc_translation[source]];
         dest += SCREENWIDTH;
         frac += fracstep;
     }

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -314,11 +314,12 @@ void R_DrawTranslatedTLColumn(void)
 
     do
     {
+        // [crispy] brightmaps
+        byte src = dc_translation[dc_source[frac >> FRACBITS]];
 #ifndef CRISPY_TRUECOLOR
         *dest = tinttable[((*dest) << 8)
                           +
-                          dc_colormap[0][dc_translation
-                                      [dc_source[frac >> FRACBITS]]]];
+                          dc_colormap[dc_brightmap[src]][src]];
 #else
         const pixel_t destrgb = dc_colormap[0][dc_translation[dc_source[frac >> FRACBITS]]];
         *dest = blendfunc(*dest, destrgb);

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -91,7 +91,7 @@ void R_DrawColumn(void)
     do
     {
 	// [crispy] brightmaps
-	const byte source = dc_source[frac>>FRACBITS];
+	const byte source = dc_source[frac >> FRACBITS];
 	*dest = dc_colormap[dc_brightmap[source]][source];
 	dest += SCREENWIDTH;
 	if ((frac += fracstep) >= heightmask)

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -208,8 +208,10 @@ void R_DrawTLColumn(void)
 
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[frac >> FRACBITS];
             *dest = tinttable[*dest +
-                              (dc_colormap[0][dc_source[frac >> FRACBITS]] <<
+                              (dc_colormap[dc_brightmap[source]][source] <<
                                8)];
             dest += SCREENWIDTH;
             if ((frac += fracstep) >= heightmask)
@@ -220,8 +222,10 @@ void R_DrawTLColumn(void)
     {
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[(frac >> FRACBITS) & heightmask];
             *dest = tinttable[*dest +
-                              (dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]] <<
+                              (dc_colormap[dc_brightmap[source]][source] <<
                                8)];
             dest += SCREENWIDTH;
             frac += fracstep;
@@ -274,8 +278,10 @@ void R_DrawAltTLColumn(void)
 
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[frac >> FRACBITS];
             *dest = tinttable[((*dest) << 8)
-                              + dc_colormap[0][dc_source[frac >> FRACBITS]]];
+                              + dc_colormap[dc_brightmap[source]][source]];
             dest += SCREENWIDTH;
             if ((frac += fracstep) >= heightmask)
                 frac -= heightmask;
@@ -285,8 +291,10 @@ void R_DrawAltTLColumn(void)
     {
         do
         {
+            // [crispy] brightmaps
+            const byte source = dc_source[(frac >> FRACBITS) & heightmask];
             *dest = tinttable[((*dest) << 8)
-                              + dc_colormap[0][dc_source[(frac >> FRACBITS) & heightmask]]];
+                              + dc_colormap[dc_brightmap[source]][source]];
             dest += SCREENWIDTH;
             frac += fracstep;
         } while (count--);
@@ -326,7 +334,9 @@ void R_DrawTranslatedColumn(void)
 
     do
     {
-        *dest = dc_colormap[0][dc_translation[dc_source[frac >> FRACBITS]]];
+        // [crispy] brightmaps
+        const byte source = dc_source[frac >> FRACBITS];
+        *dest = dc_colormap[dc_brightmap[source]][dc_translation[source]];
         dest += SCREENWIDTH;
         frac += fracstep;
     }
@@ -361,10 +371,11 @@ void R_DrawTranslatedTLColumn(void)
 
     do
     {
+        // [crispy] brightmaps
+        byte src = dc_translation[dc_source[frac >> FRACBITS]];
         *dest = tinttable[((*dest) << 8)
                           +
-                          dc_colormap[0][dc_translation
-                                      [dc_source[frac >> FRACBITS]]]];
+                          dc_colormap[dc_brightmap[src]][src]];
         dest += SCREENWIDTH;
         frac += fracstep;
     }


### PR DESCRIPTION
Same idea and aproach as in https://github.com/fabiangreffrath/woof/pull/1340. No new functions, just extended current ones to draw brightmapped pixels. Few remarks:
- For Doom we _deffinitly_ needed, and it's easy to test with a [testing map](https://github.com/fabiangreffrath/woof/files/13697596/tl_bmap.zip) from Woof's PR. There is not translucent walls in original Specifics, it's a Boom-ism. Small expection was made long time ago for scrolling texture right, AFAIR, just as small possible nicification for NOVA.wad.
- For Heretic we _probably_ need it. Testing translucent columns was easy, just set `MF_SHADOW` flag to Phoenix Rod, but testing translucent+translated columns - no idea how. Neigher I am able to run HeHacked, this is what always happening with 1.3 version for DOS ([screenshot](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/806607af-a27e-41ad-9a92-7f29d133e5c9)).
- For Hexen we _most likely_ need it. Probably ACS allows to set mobj flags? Aside from that, mobj flags `MF_SHADOW` and `MF_ALTSHADOW` were used for testing translucent columns. Translucent+translated columns are the same dilemma as in Heretic.
- For Strife we don't need it, as there is no Crispy brightmaps, and Strife using own aproach with `COLORMAP` trick.
