### PR TITLE
Heretic: add missing change for R_DrawTranslatedTLColumn

### DIFF
--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -321,7 +321,7 @@ void R_DrawTranslatedTLColumn(void)
                           +
                           dc_colormap[dc_brightmap[src]][src]];
 #else
-        const pixel_t destrgb = dc_colormap[0][dc_translation[dc_source[frac >> FRACBITS]]];
+        const pixel_t destrgb = dc_colormap[dc_brightmap[src]][src];
         *dest = blendfunc(*dest, destrgb);
 #endif
         dest += SCREENWIDTH;


### PR DESCRIPTION
This adds missing change to R_DrawTranslatedTLColumn()` in true color render.