### PR TITLE
Always set SDL music volume

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -415,13 +415,15 @@ void I_ShutdownMusic(void)
 
 void I_SetMusicVolume(int volume)
 {
-    if (active_music_module != NULL)
+    if (music_module != NULL)
     {
-        active_music_module->SetMusicVolume(volume);
+        music_module->SetMusicVolume(volume);
 
-        if (music_packs_active && active_music_module != &music_pack_module)
+        // [crispy] always broadcast volume changes to SDL. This also covers
+        // the musicpack module.
+        if (music_module != &music_sdl_module)
         {
-            music_pack_module.SetMusicVolume(volume);
+            music_sdl_module.SetMusicVolume(volume);
         }
     }
 }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -419,12 +419,14 @@ void I_SetMusicVolume(int volume)
     {
         music_module->SetMusicVolume(volume);
 
+#ifndef DISABLE_SDL2MIXER
         // [crispy] always broadcast volume changes to SDL. This also covers
         // the musicpack module.
         if (music_module != &music_sdl_module)
         {
             music_sdl_module.SetMusicVolume(volume);
         }
+#endif
     }
 }
 


### PR DESCRIPTION
I noticed that the Sigil and Sigil II MP3 soundtracks would always start off at max volume when sideloading. This fixes that.