### PR TITLE
The zero gamma index in array is 9, not 10

### DIFF
--- a/src/crispy.c
+++ b/src/crispy.c
@@ -24,7 +24,7 @@
 static crispy_t crispy_s = {
 	0,
 	.extautomap = 1,
-	.gamma = 10,  // default level is "OFF" for intermediate gamma levels
+	.gamma = 9,  // default level is "OFF" for intermediate gamma levels
 	.hires = 1,
 	.smoothscaling = 1,
 	.soundfix = 1,


### PR DESCRIPTION
Quite obvious, in C array indices begin with 0, so 10th element has index 9