### PR TITLE
Heretic: apply brightmaps to D'Sparil teleporting frames

### DIFF
--- a/src/heretic/r_bmaps.c
+++ b/src/heretic/r_bmaps.c
@@ -406,6 +406,19 @@ const byte *R_BrightmapForSprite (const int state)
             case S_SOR2_ATK1:
             case S_SOR2_ATK2:
             case S_SOR2_ATK3:
+            // Walking D'Sparil (teleport states)
+            case S_SOR2_TELE1:
+            case S_SOR2_TELE2:
+            case S_SOR2_TELE3:
+            case S_SOR2_TELE4:
+            case S_SOR2_TELE5:
+            case S_SOR2_TELE6:
+            case S_SOR2TELEFADE1:
+            case S_SOR2TELEFADE2:
+            case S_SOR2TELEFADE3:
+            case S_SOR2TELEFADE4:
+            case S_SOR2TELEFADE5:
+            case S_SOR2TELEFADE6:
             // Walking D'Sparil (death states)
             case S_SOR2_DIE1:
             case S_SOR2_DIE2:


### PR DESCRIPTION
Not very noticeable in vanilla Heretic as fighting area is pretty bright, but the missing brightmap is quite noticeable in Curse of D'Sparil. Basically, this, `TELE` (left) is for destination `TELEFADE` (right) is for source D'Sparil state:

![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/0cbbbfeb-0d16-4596-86dd-07d283efbd5a)

Have to admit, it's pretty cool effect technically, as mobj is not immediately moving from one coord to another, but splitted to two mobjs.

_Original issue: https://github.com/JNechaevsky/international-doom/commit/246fd169ed36bb5a96439c0684c2ebf432a86a0b_