### PR TITLE
Heretic: fix hitscan/missile puffs disappearing in certain areas

### DIFF
--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -1101,7 +1101,7 @@ boolean PTR_ShootTraverse (intercept_t* in)
 	    }
 	}
 
-	// [crispy] check if the pullet puff's z-coordinate is below of above
+	// [crispy] check if the bullet puff's z-coordinate is below of above
 	// its spawning sector's floor or ceiling, respectively, and move its
 	// coordinates to the point where the trajectory hits the plane
 	if (aimslope)

--- a/src/heretic/m_random.c
+++ b/src/heretic/m_random.c
@@ -83,3 +83,9 @@ int P_SubRandom (void)
     int r = P_Random();
     return r - P_Random();
 }
+
+int Crispy_SubRandom (void)
+{
+    int r = Crispy_Random();
+    return r - Crispy_Random();
+}

--- a/src/heretic/m_random.h
+++ b/src/heretic/m_random.h
@@ -35,6 +35,7 @@ extern int rndindex;
 
 // Defined version of P_Random() - P_Random()
 int P_SubRandom (void);
+int Crispy_SubRandom (void);
 
 #endif // HERETIC_M_RANDOM_H
 

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -146,6 +146,7 @@ boolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax);
 void P_MobjThinker(thinker_t *thinker);
 void P_BlasterMobjThinker(thinker_t *thinker);
 void P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
+void P_SpawnPuffSafe(fixed_t x, fixed_t y, fixed_t z, boolean safe);
 void P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage);
 void P_BloodSplatter(fixed_t x, fixed_t y, fixed_t z, mobj_t * originator);
 void P_RipperBlood(mobj_t * mo);


### PR DESCRIPTION
Barely I need to make any explanations for your code. Just a few remarks, as always:
* This is a two-in-one fix, for both hitscan puffs wasn't able to hit floor/ceiling and projectiles were disappearing on some two sided lines.
* There are no `acv` action pointers in Heretic, that's the only difference in `P_LatestSafeState` function.
* You may notice a small knockback when using Phoenix Rod (local rocket launcer). This is not because of splash damage (health isn't touched), this is [by design](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/heretic/p_pspr.c#L1623-L1624) in original game mechanics.
* Testing map: We won't be visiting _that MAP15_ today. Instead, we will visit E1M8 of Doom 1, recreated in Heretic as E1M1. 😮 Why? It have all necessary for testing, that's the only thing I can remember. I used this place in Doom back in ... 2017th probably, and it still can serve well here: [htic_puffs.zip](https://github.com/fabiangreffrath/crispy-doom/files/13979748/htic_puffs.zip)
* Heretic doesn't have bullets and laser. Just a spaces instead of tabs. 🙂

**Before**
<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/a83f5b98-4e34-42b4-886f-ec20c21ddb9d

</details>

**After**
<details>

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/8f61f202-7cc1-4036-8ab1-245d3dbc3923

</details>