### PR TITLE
Heretic and Hexen: check if saving is allowed

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1260,6 +1260,12 @@ static boolean SCSaveGame(int option)
 {
     char *ptr;
 
+    // [crispy] check if saving is allowed
+    if (!usergame)
+    {
+        return false;
+    }
+
     if (!FileMenuKeySteal)
     {
         int x, y;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1251,6 +1251,12 @@ static void SCSaveGame(int option)
 {
     char *ptr;
 
+    // [crispy] check if saving is allowed
+    if (!usergame)
+    {
+        return;
+    }
+
     if (!FileMenuKeySteal)
     {
         int x, y;


### PR DESCRIPTION
As suggested in https://github.com/fabiangreffrath/crispy-doom/issues/1137#issuecomment-1899920487. Few remarks:
- Not sure if comment fits well. Technically it's described pretty clear in [original code](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/heretic/g_game.c#L100).
- There are no `false` in Hexen, as `SCSaveGame` is a `void` function type, not a `boolean`.

Fixes https://github.com/fabiangreffrath/crispy-doom/issues/1137.