### PR TITLE
Minor sideloading improvements

### DIFF
--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -454,17 +454,17 @@ static boolean CheckMasterlevelsLoaded (void)
 	return false;
 }
 
+static const lump_rename_t master_lumps [] = {
+	{"TITLEPIC", "MASTRPIC"},
+	{"INTERPIC", "MASTRINT"},
+};
+
 // [crispy] auto-load the single MASTERLEVELS.WAD if available
 static boolean CheckLoadMasterlevels (void)
 {
 	const char *master_basename;
 	char *autoload_dir;
 	int i, j;
-
-	static const lump_rename_t master_lumps [] = {
-		{"TITLEPIC", "MASTRPIC"},
-		{"INTERPIC", "MASTRINT"},
-	};
 
 	// [crispy] don't load if another PWAD already provides MAP01
 	i = W_CheckNumForName("MAP01");
@@ -630,6 +630,7 @@ static void LoadMasterlevelsWads (void)
 {
 	int i, j;
 	char lumpname[9];
+	char *autoload_dir;
 
 	const char *const sky_lumps[] = {
 		"RSKY1",
@@ -672,6 +673,17 @@ static void LoadMasterlevelsWads (void)
 
 	// [crispy] indicate this is not the single MASTERLEVELS.WAD
 	crispy->havemaster = (char *)-1;
+
+	// [crispy] autoload from MASTERLEVELS.WAD autoload directory
+	if (!M_ParmExists("-noautoload"))
+	{
+		if ((autoload_dir = M_GetAutoloadDir("MASTERLEVELS.WAD", false)))
+		{
+			W_AutoLoadWADsRename(autoload_dir, master_lumps, arrlen(master_lumps));
+			DEH_AutoLoadPatches(autoload_dir);
+			free(autoload_dir);
+		}
+	}
 
 	// [crispy] regenerate the hashtable
 	W_GenerateHashTable();

--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -46,10 +46,7 @@ static boolean LoadSigilWad (const char *iwaddir, boolean pwadtexture)
 		"SIGIL.wad"
 	};
 
-	static const struct {
-		const char *name;
-		const char new_name[8];
-	} sigil_lumps [] = {
+	static const lump_rename_t sigil_lumps [] = {
 		{"CREDIT",   "SIGCREDI"},
 		{"HELP1",    "SIGHELP1"},
 		{"TITLEPIC", "SIGTITLE"},
@@ -164,7 +161,7 @@ static boolean LoadSigilWad (const char *iwaddir, boolean pwadtexture)
 	{
 		if ((autoload_dir = M_GetAutoloadDir(sigil_basename, false)))
 		{
-			W_AutoLoadWADs(autoload_dir);
+			W_AutoLoadWADsRename(autoload_dir, sigil_lumps, arrlen(sigil_lumps));
 			DEH_AutoLoadPatches(autoload_dir);
 			free(autoload_dir);
 		}
@@ -185,10 +182,7 @@ static boolean LoadSigil2Wad (const char *iwaddir, boolean pwadtexture)
         "SIGIL_II_V1_0.WAD",
     };
 
-    static const struct {
-        const char *name;
-        const char new_name[8];
-    } sigil2_lumps [] = {
+    static const lump_rename_t sigil2_lumps [] = {
         {"CREDIT",   "SG2CREDI"},
         {"HELP1",    "SG2HELP1"},
         {"TITLEPIC", "SG2TITLE"},
@@ -268,7 +262,7 @@ static boolean LoadSigil2Wad (const char *iwaddir, boolean pwadtexture)
     {
         if ((autoload_dir = M_GetAutoloadDir(sigil2_basename, false)))
         {
-            W_AutoLoadWADs(autoload_dir);
+            W_AutoLoadWADsRename(autoload_dir, sigil2_lumps, arrlen(sigil2_lumps));
             DEH_AutoLoadPatches(autoload_dir);
             free(autoload_dir);
         }
@@ -351,10 +345,7 @@ static void CheckLoadNerve (void)
 	char *autoload_dir;
 	int i, j;
 
-	static const struct {
-		const char *name;
-		const char new_name[8];
-	} nerve_lumps [] = {
+	static const lump_rename_t nerve_lumps [] = {
 		{"TITLEPIC", "NERVEPIC"},
 		{"INTERPIC", "NERVEINT"},
 	};
@@ -423,7 +414,7 @@ static void CheckLoadNerve (void)
 	{
 		if ((autoload_dir = M_GetAutoloadDir(nerve_basename, false)))
 		{
-			W_AutoLoadWADs(autoload_dir);
+			W_AutoLoadWADsRename(autoload_dir, nerve_lumps, arrlen(nerve_lumps));
 			DEH_AutoLoadPatches(autoload_dir);
 			free(autoload_dir);
 		}

--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -461,6 +461,11 @@ static boolean CheckLoadMasterlevels (void)
 	char *autoload_dir;
 	int i, j;
 
+	static const lump_rename_t master_lumps [] = {
+		{"TITLEPIC", "MASTRPIC"},
+		{"INTERPIC", "MASTRINT"},
+	};
+
 	// [crispy] don't load if another PWAD already provides MAP01
 	i = W_CheckNumForName("MAP01");
 	if (i != -1 && !W_IsIWADLump(lumpinfo[i]))
@@ -523,7 +528,7 @@ static boolean CheckLoadMasterlevels (void)
 	{
 		if ((autoload_dir = M_GetAutoloadDir(master_basename, false)))
 		{
-			W_AutoLoadWADs(autoload_dir);
+			W_AutoLoadWADsRename(autoload_dir, master_lumps, arrlen(master_lumps));
 			DEH_AutoLoadPatches(autoload_dir);
 			free(autoload_dir);
 		}

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -1865,6 +1865,10 @@ static void WI_loadUnloadData(load_callback_t callback)
         {
             M_StringCopy(name, DEH_String("NERVEINT"), sizeof(name));
         }
+        else if (crispy->havemaster && wbs->epsd == 2 && W_CheckNumForName(DEH_String("MASTRINT")) != -1) // [crispy] gamemission == pack_master
+        {
+            M_StringCopy(name, DEH_String("MASTRINT"), sizeof(name));
+        }
         else
         {
         M_StringCopy(name, DEH_String("INTERPIC"), sizeof(name));

--- a/src/w_main.h
+++ b/src/w_main.h
@@ -20,6 +20,13 @@
 
 #include "d_mode.h"
 
+// [crispy]
+typedef struct
+{
+    const char *name;
+    const char new_name[8];
+} lump_rename_t;
+
 boolean W_ParseCommandLine(void);
 void W_CheckCorrectIWAD(GameMission_t mission);
 
@@ -28,6 +35,10 @@ int W_LumpDump (const char *lumpname);
 
 // Autoload all .wad files from the given directory:
 void W_AutoLoadWADs(const char *path);
+
+// [crispy] Autoload from directory with lump renaming
+void W_AutoLoadWADsRename(const char *path, const lump_rename_t *renames,
+                          int num_renames);
 
 #endif /* #ifndef W_MAIN_H */
 


### PR DESCRIPTION
* Lumps in autoloaded wads pulled in by sideloading are now subject to the same renaming as the original sideloaded wad. (Fixes #1094)
* Apply TITLEPIC and INTERPIC renaming to Master Levels autoloads when sideloading. Also, grant the Master Levels its own intermission picture.
* Autoload from the MASTERLEVELS.WAD directory when using the loose Master Levels files.