### PR TITLE
Hexen: add true color support 

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -167,7 +167,7 @@ fixed_t*	spritewidth;
 fixed_t*	spriteoffset;
 fixed_t*	spritetopoffset;
 
-lighttable_t	*colormaps;
+lighttable_t	*colormaps, *pal_color;
 
 // [FG] check if the lump can be a Doom patch
 // taken from PrBoom+ prboom2/src/r_patch.c:L350-L390
@@ -1199,6 +1199,8 @@ void R_InitColormaps (void)
 	{
 		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
 	}
+
+	pal_color = colormaps;
 
 	if (crispy->truecolor)
 	{

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -70,7 +70,7 @@ fixed_t *spritewidth;           // needed for pre rendering
 fixed_t *spriteoffset;
 fixed_t *spritetopoffset;
 
-lighttable_t *colormaps;
+lighttable_t *colormaps, *pal_color;
 
 
 /*
@@ -541,6 +541,8 @@ void R_InitColormaps(void)
 	{
 		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
 	}
+
+	pal_color = colormaps;
 
 	if (crispy->truecolor)
 	{

--- a/src/hexen/f_finale.c
+++ b/src/hexen/f_finale.c
@@ -267,7 +267,11 @@ static void InitializeFade(boolean fadeIn)
             PaletteDelta[i] = FixedDiv(Palette[i], -70 * FRACUNIT);
         }
     }
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(RealPalette);
+#else
+    // [cirspy] TODO - perform fading via I_BlendDark function?
+#endif
 }
 
 //===========================================================================
@@ -298,7 +302,11 @@ static void FadePic(void)
         Palette[i] += PaletteDelta[i];
         RealPalette[i] = Palette[i] >> FRACBITS;
     }
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(RealPalette);
+#else
+    // [cirspy] TODO - perform fading via I_BlendDark function?
+#endif
 }
 
 //===========================================================================

--- a/src/hexen/f_finale.c
+++ b/src/hexen/f_finale.c
@@ -294,6 +294,7 @@ static void InitializeFade(boolean fadeIn)
             PaletteDelta[i] = FixedDiv(Palette[i], -70 * FRACUNIT);
         }
     }
+    I_SetPalette(RealPalette);
 #else
     // [crispy] reset blending tic to initial value
     BlendTic = fadeIn ? 0 : 255;

--- a/src/hexen/f_finale.c
+++ b/src/hexen/f_finale.c
@@ -67,8 +67,8 @@ static fixed_t *Palette;
 static fixed_t *PaletteDelta;
 static byte *RealPalette;
 #else
-// [crispy] tics representing opacity value for blending function
-static int BlendTic;
+static int BlendTic; // [crispy] tics representing opacity value for blending function
+#define BLENDSTEP  4 // [crispy] step of increasing/decreasing opacity value
 #endif
 
 // CODE --------------------------------------------------------------------
@@ -164,7 +164,7 @@ void F_Ticker(void)
     // and fade out (from normal-to-black) on 3 stage.
     if (FinaleStage == 0 || FinaleStage == 4)
     {
-        BlendTic += 4;
+        BlendTic += BLENDSTEP;
         if (BlendTic > 255)
         {
             BlendTic = 255;
@@ -172,7 +172,7 @@ void F_Ticker(void)
     }
     if (FinaleStage == 3)
     {
-        BlendTic -= 4;
+        BlendTic -= BLENDSTEP;
         if (BlendTic < 0)
         {
             BlendTic = 0;

--- a/src/hexen/f_finale.c
+++ b/src/hexen/f_finale.c
@@ -26,6 +26,7 @@
 #include "v_video.h"
 #include "i_swap.h"
 #include "am_map.h"
+#include "v_trans.h" // [crispy] blending functions
 
 
 // MACROS ------------------------------------------------------------------
@@ -61,9 +62,14 @@ static int FinaleLumpNum;
 static int FontABaseLump;
 static char *FinaleText;
 
+#ifndef CRISPY_TRUECOLOR
 static fixed_t *Palette;
 static fixed_t *PaletteDelta;
 static byte *RealPalette;
+#else
+// [crispy] tics representing opacity value for blending function
+static int BlendTic;
+#endif
 
 // CODE --------------------------------------------------------------------
 
@@ -153,6 +159,26 @@ void F_Ticker(void)
     {
         FadePic();
     }
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] Fade in (from-black-to-normal) on 0 and 4 stages,
+    // and fade out (from normal-to-black) on 3 stage.
+    if (FinaleStage == 0 || FinaleStage == 4)
+    {
+        BlendTic += 4;
+        if (BlendTic > 255)
+        {
+            BlendTic = 255;
+        }
+    }
+    if (FinaleStage == 3)
+    {
+        BlendTic -= 4;
+        if (BlendTic < 0)
+        {
+            BlendTic = 0;
+        }
+    }
+#endif
 }
 
 //===========================================================================
@@ -240,6 +266,7 @@ static void TextWrite(void)
 
 static void InitializeFade(boolean fadeIn)
 {
+#ifndef CRISPY_TRUECOLOR
     unsigned i;
 
     Palette = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC, 0);
@@ -267,10 +294,9 @@ static void InitializeFade(boolean fadeIn)
             PaletteDelta[i] = FixedDiv(Palette[i], -70 * FRACUNIT);
         }
     }
-#ifndef CRISPY_TRUECOLOR
-    I_SetPalette(RealPalette);
 #else
-    // [cirspy] TODO - perform fading via I_BlendDark function?
+    // [crispy] reset blending tic to initial value
+    BlendTic = fadeIn ? 0 : 255;
 #endif
 }
 
@@ -282,9 +308,11 @@ static void InitializeFade(boolean fadeIn)
 
 static void DeInitializeFade(void)
 {
+#ifndef CRISPY_TRUECOLOR
     Z_Free(Palette);
     Z_Free(PaletteDelta);
     Z_Free(RealPalette);
+#endif
 }
 
 //===========================================================================
@@ -295,6 +323,7 @@ static void DeInitializeFade(void)
 
 static void FadePic(void)
 {
+#ifndef CRISPY_TRUECOLOR
     unsigned i;
 
     for (i = 0; i < 768; i++)
@@ -302,10 +331,7 @@ static void FadePic(void)
         Palette[i] += PaletteDelta[i];
         RealPalette[i] = Palette[i] >> FRACBITS;
     }
-#ifndef CRISPY_TRUECOLOR
     I_SetPalette(RealPalette);
-#else
-    // [cirspy] TODO - perform fading via I_BlendDark function?
 #endif
 }
 
@@ -331,6 +357,13 @@ static void DrawPic(void)
                                               1, PU_CACHE));
         }
     }
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] apply true color blending on top of patch drawing functions
+    for (int y = 0; y < SCREENWIDTH * SCREENHEIGHT; y++)
+    {
+        I_VideoBuffer[y] = I_BlendDark(I_VideoBuffer[y], BlendTic);
+    }
+#endif
 }
 
 //===========================================================================

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -208,6 +208,9 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_mouselook",       &crispy->mouselook);
     M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
+#ifdef CRISPY_TRUECOLOR
+    M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+#endif
     M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);
     M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);

--- a/src/hexen/in_lude.c
+++ b/src/hexen/in_lude.c
@@ -99,7 +99,11 @@ static char *HubText;
 void IN_Start(void)
 {
     int i;
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+    I_SetPalette(0);
+#endif
     InitStats();
     LoadPics();
     intermission = true;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2192,7 +2192,7 @@ boolean MN_Responder(event_t * event)
             }
             SB_PaletteFlash(true);  // force change
 #ifdef CRISPY_TRUECOLOR
-            R_InitColormaps(actual_colormap, false);
+            R_InitTrueColormaps(LevelUseFullBright ? "COLORMAP" : "FOGMAP");
             BorderNeedRefresh = true;
             SB_state = -1;
 #endif

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2192,7 +2192,7 @@ boolean MN_Responder(event_t * event)
             }
             SB_PaletteFlash(true);  // force change
 #ifdef CRISPY_TRUECOLOR
-            R_InitColormaps();
+            R_InitColormaps(actual_colormap, false);
             BorderNeedRefresh = true;
             SB_state = -1;
 #endif

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1948,7 +1948,11 @@ boolean MN_Responder(event_t * event)
                     askforquit = false;
                     typeofask = 0;
                     paused = false;
+#ifndef CRISPY_TRUECOLOR
                     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+                    I_SetPalette(0);
+#endif
                     H2_StartTitle();    // go to intro/demo mode.
                     return false;
                 case 3:
@@ -2187,6 +2191,11 @@ boolean MN_Responder(event_t * event)
                 crispy->gamma = 0;
             }
             SB_PaletteFlash(true);  // force change
+#ifdef CRISPY_TRUECOLOR
+            R_InitColormaps();
+            BorderNeedRefresh = true;
+            SB_state = -1;
+#endif
             P_SetMessage(&players[consoleplayer], GammaText[crispy->gamma],
                          false);
             return true;
@@ -2593,7 +2602,11 @@ void MN_DrawInfo(void)
 {
     lumpindex_t lumpindex; // [crispy]
 
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+    I_SetPalette(0);
+#endif
 
     // [crispy] Refactor to allow for use of V_DrawFullscreenRawOrPatch
 
@@ -2699,7 +2712,8 @@ static void DrawMouseMenu(void)
 
 static void M_DrawCrispnessBackground(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
 
     src = W_CacheLumpName("F_022", PU_CACHE);
     dest = I_VideoBuffer;

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -1943,8 +1943,7 @@ void A_CHolyAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + STARTHOLYPAL * 768);
 #else
-        // [crispy] TODO - extra panes for Cleric's Wraithverge attack.
-        // Palette indexes: 22, 23, 24
+        I_SetPalette(STARTHOLYPAL);
 #endif
     }
     S_StartSound(player->mo, SFX_CHOLY_FIRE);
@@ -1971,8 +1970,7 @@ void A_CHolyPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
 #else
-        // [crispy] TODO - extra panes for Cleric's Wraithverge attack.
-        // Palette indexes: 22, 23, 24
+        I_SetPalette(pal);
 #endif
     }
 }

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -1187,9 +1187,14 @@ void A_MStaffAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
     {
         player->damagecount = 0;
         player->bonuscount = 0;
+#ifndef CRISPY_TRUECOLOR
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) +
                      STARTSCOURGEPAL * 768);
+#else
+        // [crispy] TODO - extra panes for Mage's Bloodscourge attack.
+        // Palette indexes: 25, 26, 27
+#endif
     }
 }
 
@@ -1210,8 +1215,13 @@ void A_MStaffPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         {                       // reset back to original playpal
             pal = 0;
         }
+#ifndef CRISPY_TRUECOLOR
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
+#else
+        // [crispy] TODO - extra panes for Mage's Bloodscourge attack.
+        // Palette indexes: 25, 26, 27
+#endif
     }
 }
 
@@ -1929,8 +1939,13 @@ void A_CHolyAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
     {
         player->damagecount = 0;
         player->bonuscount = 0;
+#ifndef CRISPY_TRUECOLOR
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + STARTHOLYPAL * 768);
+#else
+        // [crispy] TODO - extra panes for Cleric's Wraithverge attack.
+        // Palette indexes: 22, 23, 24
+#endif
     }
     S_StartSound(player->mo, SFX_CHOLY_FIRE);
 }
@@ -1952,8 +1967,13 @@ void A_CHolyPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         {                       // reset back to original playpal
             pal = 0;
         }
+#ifndef CRISPY_TRUECOLOR
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
+#else
+        // [crispy] TODO - extra panes for Cleric's Wraithverge attack.
+        // Palette indexes: 22, 23, 24
+#endif
     }
 }
 

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -1192,8 +1192,7 @@ void A_MStaffAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
                                              PU_CACHE) +
                      STARTSCOURGEPAL * 768);
 #else
-        // [crispy] TODO - extra panes for Mage's Bloodscourge attack.
-        // Palette indexes: 25, 26, 27
+        I_SetPalette(STARTSCOURGEPAL);
 #endif
     }
 }
@@ -1219,8 +1218,7 @@ void A_MStaffPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
 #else
-        // [crispy] TODO - extra panes for Mage's Bloodscourge attack.
-        // Palette indexes: 25, 26, 27
+        I_SetPalette(pal);
 #endif
     }
 }

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -806,6 +806,12 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     {                           // Probably fog ... don't use fullbright sprites
         LevelUseFullBright = false;
     }
+#ifdef CRISPY_TRUECOLOR
+    // [cirspy] TODO - two problems:
+    // 1) Need to re-generate colormaps, otherwise brightest light levels will be screwed up.
+    // 2) Foggy maps, or technically, ANY map with custom colormap MUST use pregenerated colormap lump.
+    R_InitColormaps();
+#endif
 
 // preload graphics
     if (precache)

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -801,21 +801,16 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     if (i == W_GetNumForName("COLORMAP"))
     {
         LevelUseFullBright = true;
-#ifdef CRISPY_TRUECOLOR
-        actual_colormap = "COLORMAP";
-#endif
     }
     else
     {                           // Probably fog ... don't use fullbright sprites
         LevelUseFullBright = false;
-#ifdef CRISPY_TRUECOLOR
-        // [cirspy] TODO - do not use hardcoded "FOGMAP" lump name.
-        // Need to get it from MAPINFO's fadetable variable, but it's int type there.
-        actual_colormap = "FOGMAP";
-#endif
     }
+
 #ifdef CRISPY_TRUECOLOR
-    R_InitColormaps(actual_colormap, false);
+    // [crispy] If true color is compiled in but disabled as an option,
+    // we still need to re-generate colormaps for proper colormaps[] array colors.
+    R_InitTrueColormaps(LevelUseFullBright ? "COLORMAP" : "FOGMAP");
 #endif
 
 // preload graphics

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -801,16 +801,21 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     if (i == W_GetNumForName("COLORMAP"))
     {
         LevelUseFullBright = true;
+#ifdef CRISPY_TRUECOLOR
+        actual_colormap = "COLORMAP";
+#endif
     }
     else
     {                           // Probably fog ... don't use fullbright sprites
         LevelUseFullBright = false;
+#ifdef CRISPY_TRUECOLOR
+        // [cirspy] TODO - do not use hardcoded "FOGMAP" lump name.
+        // Need to get it from MAPINFO's fadetable variable, but it's int type there.
+        actual_colormap = "FOGMAP";
+#endif
     }
 #ifdef CRISPY_TRUECOLOR
-    // [cirspy] TODO - two problems:
-    // 1) Need to re-generate colormaps, otherwise brightest light levels will be screwed up.
-    // 2) Foggy maps, or technically, ANY map with custom colormap MUST use pregenerated colormap lump.
-    R_InitColormaps();
+    R_InitColormaps(actual_colormap, false);
 #endif
 
 // preload graphics

--- a/src/hexen/p_user.c
+++ b/src/hexen/p_user.c
@@ -431,7 +431,11 @@ void P_DeathThink(player_t * player)
     {
         if (player == &players[consoleplayer])
         {
+#ifndef CRISPY_TRUECOLOR
             I_SetPalette((byte *) W_CacheLumpName("PLAYPAL", PU_CACHE));
+#else
+            I_SetPalette(0);
+#endif
             inv_ptr = 0;
             curpos = 0;
             newtorch = 0;

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -67,6 +67,7 @@ fixed_t *spriteoffset;
 fixed_t *spritetopoffset;
 
 lighttable_t *colormaps;
+char *actual_colormap;
 
 
 /*
@@ -482,7 +483,7 @@ void R_InitSpriteLumps(void)
 =================
 */
 
-void R_InitColormaps(void)
+void R_InitColormaps(char *current_colormap, boolean init_translations)
 {
 #ifndef CRISPY_TRUECOLOR
     int lump, length;
@@ -496,7 +497,7 @@ void R_InitColormaps(void)
     W_ReadLump(lump, colormaps);
 #else
 	byte *playpal;
-	byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
+	byte *const colormap = W_CacheLumpName(current_colormap, PU_STATIC);
 	int c, i, j = 0;
 	byte r, g, b;
 
@@ -507,9 +508,9 @@ void R_InitColormaps(void)
 		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
 	}
 
-	if (crispy->truecolor)
+	if (crispy->truecolor && LevelUseFullBright)
 	{
-		for (c = 0; c < NUMCOLORMAPS-2; c++)
+		for (c = 0; c < NUMCOLORMAPS; c++)
 		{
 			const float scale = 1. * c / NUMCOLORMAPS;
 
@@ -538,10 +539,11 @@ void R_InitColormaps(void)
 		}
 	}
 
-	W_ReleaseLumpName("COLORMAP");
+	W_ReleaseLumpName(current_colormap);
 #endif
 
     // [crispy] initialize color translation and color string tables
+    if (init_translations)
     {
 	byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 	char c[3];
@@ -584,7 +586,12 @@ void R_InitData(void)
     R_InitSpriteLumps();
     // [crispy] Initialize and generate gamma-correction levels.
     I_SetGammaTable();
-    R_InitColormaps();
+#ifndef CRISPY_TRUECOLOR
+    R_InitColormaps("COLORMAP", true);
+#else
+    actual_colormap = "COLORMAP";
+    R_InitColormaps(actual_colormap, true);
+#endif
 }
 
 //=============================================================================

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -548,6 +548,7 @@ void R_InitTrueColormaps(char *current_colormap)
 		}
 	}
 
+	W_ReleaseLumpName("PLAYPAL");
 	W_ReleaseLumpName(current_colormap);
 }
 #endif

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -67,19 +67,6 @@ fixed_t *spriteoffset;
 fixed_t *spritetopoffset;
 
 lighttable_t *colormaps, *pal_color;
-#ifdef CRISPY_TRUECOLOR
-// [crispy] Vanilla Hexen have a bug with 255 PLAYPAL color index:
-// - it's white (255, 255, 255) in PLAYPAL lump,
-// - it's black (2, 2, 2) in COLORMAP lump.
-// This is leading to mistake in colormaps[] array generation, where
-// white color becomes black in case of true color is compiled in,
-// but disabled in configuration file. To avoid this and preserve
-// some reasonable custom COLORMAP compatibility, we performing check
-// for modified COLORMAP lump and deciding how 255th color will be
-// handled in R_InitTrueColormaps.
-static int original_colormap;
-static boolean broken_wite;
-#endif
 
 
 /*
@@ -628,10 +615,6 @@ void R_InitData(void)
 #ifndef CRISPY_TRUECOLOR
     R_InitColormaps();
 #else
-    // [crispy] Check if COLORMAP is unmodified to decide how to
-    // handle colormaps[] array generation in R_InitTrueColormaps.
-    original_colormap = W_CheckNumForName("COLORMAP");
-    broken_wite = W_IsIWADLump(lumpinfo[original_colormap]);
     // [crispy] Generate initial colormaps[] array from standard COLORMAP.
     R_InitTrueColormaps("COLORMAP");
 #endif

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -514,11 +514,11 @@ void R_InitColormaps(void)
 // [crispy] Our own function to generate colormaps for normal and foggy levels.
 void R_InitTrueColormaps(char *current_colormap)
 {
-	byte *playpal;
 	int c, i, j = 0;
 	byte r, g, b;
 
-	playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	byte *const colormap = W_CacheLumpName(current_colormap, PU_STATIC);
 
 	if (!colormaps)
 	{
@@ -537,9 +537,11 @@ void R_InitTrueColormaps(char *current_colormap)
 
 			for (i = 0; i < 256; i++)
 			{
-				r = gamma2table[crispy->gamma][playpal[3 * i + 0]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
-				g = gamma2table[crispy->gamma][playpal[3 * i + 1]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
-				b = gamma2table[crispy->gamma][playpal[3 * i + 2]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
+				const byte k = colormap[i];
+
+				r = gamma2table[crispy->gamma][playpal[3 * k + 0]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
+				g = gamma2table[crispy->gamma][playpal[3 * k + 1]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
+				b = gamma2table[crispy->gamma][playpal[3 * k + 2]] * (1. - scale) + gamma2table[crispy->gamma][fade_color] * scale;
 
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
@@ -547,32 +549,20 @@ void R_InitTrueColormaps(char *current_colormap)
 	}
 	else
 	{
-		byte *const colormap = W_CacheLumpName(current_colormap, PU_STATIC);
-
 		for (c = 0; c < NUMCOLORMAPS; c++)
 		{
 			for (i = 0; i < 256; i++)
 			{
-				if (broken_wite && i == 255)
-				{
-					// [crispy] it's original COLORMAP lump,
-					// replace black 255th color with white
-					r = g = b = colormaps[i];
-				}
-				else
-				{
-					r = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
-					g = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
-					b = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
-				}
+				r = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+				g = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+				b = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
 
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
 		}
-
-		W_ReleaseLumpName(current_colormap);
 	}
 
+	W_ReleaseLumpName(current_colormap);
 	W_ReleaseLumpName("PLAYPAL");
 }
 #endif

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -66,7 +66,7 @@ fixed_t *spritewidth;           // needed for pre rendering
 fixed_t *spriteoffset;
 fixed_t *spritetopoffset;
 
-lighttable_t *colormaps;
+lighttable_t *colormaps, *pal_color;
 #ifdef CRISPY_TRUECOLOR
 // [crispy] Vanilla Hexen have a bug with 255 PLAYPAL color index:
 // - it's white (255, 255, 255) in PLAYPAL lump,
@@ -563,6 +563,21 @@ void R_InitTrueColormaps(char *current_colormap)
 	}
 
 	W_ReleaseLumpName(current_colormap);
+
+	if (!pal_color)
+	{
+		pal_color = (pixel_t*) Z_Malloc(256 * sizeof(pixel_t), PU_STATIC, 0);
+	}
+
+	for (i = 0, j = 0; i < 256; i++)
+	{
+		r = gamma2table[crispy->gamma][playpal[3 * i + 0]];
+		g = gamma2table[crispy->gamma][playpal[3 * i + 1]];
+		b = gamma2table[crispy->gamma][playpal[3 * i + 2]];
+
+		pal_color[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+	}
+
 	W_ReleaseLumpName("PLAYPAL");
 }
 #endif

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -517,8 +517,7 @@ void R_InitData(void);
 void R_PrecacheLevel(void);
 
 #ifdef CRISPY_TRUECOLOR
-extern char *actual_colormap;
-extern void R_InitColormaps(char *current_colormap, boolean init_translations);
+extern void R_InitTrueColormaps(char *current_colormap);
 #endif
 
 //

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -293,6 +293,9 @@ typedef struct vissprite_s
     boolean psprite;            // true if psprite
     int class;                  // player class (used in translation)
     fixed_t floorclip;
+#ifdef CRISPY_TRUECOLOR
+    const pixel_t (*blendfunc)(const pixel_t fg, const pixel_t bg);
+#endif
 } vissprite_t;
 
 

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -231,7 +231,7 @@ typedef struct
 ==============================================================================
 */
 
-typedef byte lighttable_t;      // this could be wider for >8 bit display
+typedef pixel_t lighttable_t;      // this could be wider for >8 bit display
 
 #define MAXVISPLANES    160*8
 #define MAXOPENINGS             MAXWIDTH*64*4
@@ -513,6 +513,7 @@ byte *R_GetColumn(int tex, int col);
 void R_InitData(void);
 void R_PrecacheLevel(void);
 
+extern void R_InitColormaps(void);
 
 //
 // R_things.c
@@ -563,7 +564,7 @@ extern int dc_yh;
 extern fixed_t dc_iscale;
 extern fixed_t dc_texturemid;
 extern byte *dc_source;         // first pixel in a column
-extern byte *ylookup[MAXHEIGHT];
+extern pixel_t *ylookup[MAXHEIGHT];
 extern int columnofs[MAXWIDTH];
 extern int dc_texheight; // [crispy]
 extern const byte *dc_brightmap;

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -516,7 +516,10 @@ byte *R_GetColumn(int tex, int col);
 void R_InitData(void);
 void R_PrecacheLevel(void);
 
-extern void R_InitColormaps(void);
+#ifdef CRISPY_TRUECOLOR
+extern char *actual_colormap;
+extern void R_InitColormaps(char *current_colormap, boolean init_translations);
+#endif
 
 //
 // R_things.c

--- a/src/hexen/r_plane.c
+++ b/src/hexen/r_plane.c
@@ -396,7 +396,7 @@ void R_DrawPlanes(void)
     byte *tempSource;
     byte *source;
     byte *source2;
-    byte *dest;
+    pixel_t *dest;
     int count;
     int offset;
     int skyTexture;
@@ -475,11 +475,19 @@ void R_DrawPlanes(void)
                             {
                                 if (source[frac >> FRACBITS])
                                 {
+#ifndef CRISPY_TRUECOLOR
                                     *dest = source[frac >> FRACBITS];
+#else
+                                    *dest = colormaps[source[frac >> FRACBITS]];
+#endif
                                 }
                                 else
                                 {
+#ifndef CRISPY_TRUECOLOR
                                     *dest = source2[frac >> FRACBITS];
+#else
+                                    *dest = colormaps[source2[frac >> FRACBITS]];
+#endif
                                 }
                                 dest += SCREENWIDTH;
                                 if ((frac += fracstep) >= heightmask)
@@ -495,11 +503,19 @@ void R_DrawPlanes(void)
                             {
                                 if (source[(frac >> FRACBITS) & heightmask])
                                 {
+#ifndef CRISPY_TRUECOLOR
                                     *dest = source[(frac >> FRACBITS) & heightmask];
+#else
+                                    *dest = colormaps[source[(frac >> FRACBITS) & heightmask]];
+#endif
                                 }
                                 else
                                 {
+#ifndef CRISPY_TRUECOLOR
                                     *dest = source2[(frac >> FRACBITS) & heightmask];
+#else
+                                    *dest = colormaps[source2[(frac >> FRACBITS) & heightmask]];
+#endif
                                 }
 
                                 dest += SCREENWIDTH;
@@ -553,7 +569,11 @@ void R_DrawPlanes(void)
 
                             do
                             {
+#ifndef CRISPY_TRUECOLOR
                                 *dest = source[frac >> FRACBITS];
+#else
+                                *dest = colormaps[source[frac >> FRACBITS]];
+#endif
                                 dest += SCREENWIDTH;
 
                                 if ((frac += fracstep) >= heightmask)
@@ -567,7 +587,11 @@ void R_DrawPlanes(void)
                         {
                             do
                             {
+#ifndef CRISPY_TRUECOLOR
                                 *dest = source[(frac >> FRACBITS) & heightmask];
+#else
+                                *dest = colormaps[source[(frac >> FRACBITS) & heightmask]];
+#endif
                                 dest += SCREENWIDTH;
                                 frac += fracstep;
                             } while (count--);

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -830,15 +830,24 @@ void R_DrawPSprite(pspdef_t * psp)
             if (viewplayer->mo->flags2 & MF2_DONTDRAW)
             {                   // don't draw the psprite
                 vis->mobjflags |= MF_SHADOW;
+#ifdef CRISPY_TRUECOLOR
+                vis->blendfunc = I_BlendOverTinttab;
+#endif
             }
             else if (viewplayer->mo->flags & MF_SHADOW)
             {
                 vis->mobjflags |= MF_ALTSHADOW;
+#ifdef CRISPY_TRUECOLOR
+                vis->blendfunc = I_BlendOverAltTinttab;
+#endif
             }
         }
         else if (viewplayer->powers[pw_invulnerability] & 8)
         {
             vis->mobjflags |= MF_SHADOW;
+#ifdef CRISPY_TRUECOLOR
+            vis->blendfunc = I_BlendOverTinttab;
+#endif
         }
     }
     else if (fixedcolormap)

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -668,11 +668,15 @@ void R_ProjectSprite(mobj_t * thing)
 
     vis->brightmap = R_BrightmapForSprite(thing->state - states);
 #ifdef CRISPY_TRUECOLOR
-    if (thing->flags & (MF_SHADOW | MF_ALTSHADOW))
+    // [crispy] not using additive blending (I_BlendAdd) here for full
+    // bright states to preserve look & feel of original Hexen's translucency
+    if (thing->flags & MF_SHADOW)
     {
-        // [crispy] not using additive blending (I_BlendAdd) here 
-        // to preserve look & feel of original Hexen's translucency
         vis->blendfunc = I_BlendOverTinttab;
+    }
+    if (thing->flags & MF_ALTSHADOW)
+    {
+        vis->blendfunc = I_BlendOverAltTinttab;
     }
 #endif
 }

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -22,6 +22,7 @@
 #include "i_swap.h"
 #include "r_bmaps.h"
 #include "r_local.h"
+#include "v_trans.h" // [crispy] blending functions
 
 //void R_DrawTranslatedAltTLColumn(void);
 
@@ -415,6 +416,9 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
         {
             colfunc = R_DrawAltTLColumn;
         }
+#ifdef CRISPY_TRUECOLOR
+        blendfunc = vis->blendfunc;
+#endif
     }
     else if (vis->mobjflags & MF_TRANSLATION)
     {
@@ -465,6 +469,9 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
     }
 
     colfunc = basecolfunc;
+#ifdef CRISPY_TRUECOLOR
+    blendfunc = I_BlendOverTinttab;
+#endif
 }
 
 
@@ -660,6 +667,14 @@ void R_ProjectSprite(mobj_t * thing)
     }
 
     vis->brightmap = R_BrightmapForSprite(thing->state - states);
+#ifdef CRISPY_TRUECOLOR
+    if (thing->flags & (MF_SHADOW | MF_ALTSHADOW))
+    {
+        // [crispy] not using additive blending (I_BlendAdd) here 
+        // to preserve look & feel of original Hexen's translucency
+        vis->blendfunc = I_BlendOverTinttab;
+    }
+#endif
 }
 
 

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -674,6 +674,7 @@ void R_ProjectSprite(mobj_t * thing)
     {
         vis->blendfunc = I_BlendOverTinttab;
     }
+    else
     if (thing->flags & MF_ALTSHADOW)
     {
         vis->blendfunc = I_BlendOverAltTinttab;

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1001,7 +1001,9 @@ void SB_PaletteFlash(boolean forceChange)
 {
     static int sb_palette = 0;
     int palette;
+#ifndef CRISPY_TRUECOLOR
     byte *pal;
+#endif
 
     if (forceChange)
     {
@@ -1054,8 +1056,12 @@ void SB_PaletteFlash(boolean forceChange)
     if (palette != sb_palette)
     {
         sb_palette = palette;
+#ifndef CRISPY_TRUECOLOR
         pal = (byte *) W_CacheLumpNum(PlayPalette, PU_CACHE) + palette * 768;
         I_SetPalette(pal);
+#else
+        I_SetPalette(palette);
+#endif
     }
 }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -104,7 +104,8 @@ static SDL_Texture *orngpane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
-static const uint8_t blend_alpha_tinttab = 0x60;
+static const uint8_t blend_alpha_tinttab = 0x60; // 96
+static const uint8_t blend_alpha_alttinttab = 0x8E; // 142
 extern pixel_t* colormaps; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
@@ -2150,6 +2151,16 @@ const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg)
 	const uint32_t r = ((blend_alpha_tinttab * (fg & rmask) + (0xff - blend_alpha_tinttab) * (bg & rmask)) >> 8) & rmask;
 	const uint32_t g = ((blend_alpha_tinttab * (fg & gmask) + (0xff - blend_alpha_tinttab) * (bg & gmask)) >> 8) & gmask;
 	const uint32_t b = ((blend_alpha_tinttab * (fg & bmask) + (0xff - blend_alpha_tinttab) * (bg & bmask)) >> 8) & bmask;
+
+	return amask | r | g | b;
+}
+
+// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
+const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg)
+{
+	const uint32_t r = ((blend_alpha_alttinttab * (fg & rmask) + (0xff - blend_alpha_alttinttab) * (bg & rmask)) >> 8) & rmask;
+	const uint32_t g = ((blend_alpha_alttinttab * (fg & gmask) + (0xff - blend_alpha_alttinttab) * (bg & gmask)) >> 8) & gmask;
+	const uint32_t b = ((blend_alpha_alttinttab * (fg & bmask) + (0xff - blend_alpha_alttinttab) * (bg & bmask)) >> 8) & bmask;
 
 	return amask | r | g | b;
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -99,6 +99,7 @@ static SDL_Texture *grnpane = NULL;
 // Hexen exclusive color panes
 static SDL_Texture *bluepane = NULL;
 static SDL_Texture *graypane = NULL;
+static SDL_Texture *orngpane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
@@ -1071,19 +1072,27 @@ void I_SetPalette (int palette)
 	    break;
 	case 22:  // STARTHOLYPAL
 	    curpane = graypane;
-	    pane_alpha = 0x8c; // 140
+	    pane_alpha = 0x78; // 120
 	    break;
 	case 23:
 	    curpane = graypane;
-	    pane_alpha = 0x74; // 116
+	    pane_alpha = 0x5c; // 92
 	    break;
 	case 24:
 	    curpane = graypane;
-	    pane_alpha = 0x54; // 84
+	    pane_alpha = 0x2c; // 44
 	    break;
-	case 25:
-	    curpane = graypane;
-	    pane_alpha = 0x34; // 52
+	case 25:  // STARTSCOURGEPAL
+	    curpane = orngpane;
+	    pane_alpha = 0x6c; // 108
+	    break;
+	case 26:
+	    curpane = orngpane;
+	    pane_alpha = 0x50; // 80
+	    break;
+	case 27:
+	    curpane = orngpane;
+	    pane_alpha = 0x38; // 56
 	    break;
 	default:
 	    I_Error("Unknown palette: %d!\n", palette);
@@ -1615,6 +1624,10 @@ static void SetVideoMode(void)
         SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x80, 0x80, 0x80)); // 128, 128, 128
         graypane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(graypane, SDL_BLENDMODE_BLEND);
+
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x98, 0x70, 0x0)); // 152, 112, 0
+        orngpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
+        SDL_SetTextureBlendMode(orngpane, SDL_BLENDMODE_BLEND);
 #endif
         SDL_FillRect(argbbuffer, NULL, 0);
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -97,6 +97,7 @@ static SDL_Texture *redpane = NULL;
 static SDL_Texture *yelpane = NULL;
 static SDL_Texture *grnpane = NULL;
 // Hexen exclusive color panes
+static SDL_Texture *grnspane = NULL;
 static SDL_Texture *bluepane = NULL;
 static SDL_Texture *graypane = NULL;
 static SDL_Texture *orngpane = NULL;
@@ -1064,8 +1065,37 @@ void I_SetPalette (int palette)
 	    curpane = grnpane;
 	    pane_alpha = 0xff * 125 / 1000;
 	    break;
-	// [crispy] Hexen TODO - add 14-27 palette indexes and extra panes.
 	// Hexen exclusive color panes and palette indexes
+	// [JN] Hexen TODO - double check with disabled true color variable
+	// to make sure that colors are precise and identical enough to vanilla.
+	case 14:  // STARTPOISONPALS + 1 (13 is shared with other games)
+	    curpane = grnspane;
+	    pane_alpha = 0x2b; // 43
+	    break;
+	case 15:
+	    curpane = grnspane;
+	    pane_alpha = 0x3c; // 60
+	    break;
+	case 16:
+	    curpane = grnspane;
+	    pane_alpha = 0x58; // 88
+	    break;
+	case 17:
+	    curpane = grnspane;
+	    pane_alpha = 0x74; // 116
+	    break;
+	case 18:
+	    curpane = grnspane;
+	    pane_alpha = 0x91; // 145
+	    break;
+	case 19:
+	    curpane = grnspane;
+	    pane_alpha = 0xad; // 173
+	    break;
+	case 20:
+	    curpane = grnspane;
+	    pane_alpha = 0xc9; // 201
+	    break;
 	case 21:  // STARTICEPAL
 	    curpane = bluepane;
 	    pane_alpha = 0x7e; // 126
@@ -1616,6 +1646,10 @@ static void SetVideoMode(void)
         SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0xff, 0x0));
         grnpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnpane, SDL_BLENDMODE_BLEND);
+
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x35, 0x68, 0x2d)); // 53, 104, 45
+        grnspane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
+        SDL_SetTextureBlendMode(grnspane, SDL_BLENDMODE_BLEND);
 
         SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0x0, 0xef)); // 0, 0, 239
         bluepane = SDL_CreateTextureFromSurface(renderer, argbbuffer);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1066,63 +1066,61 @@ void I_SetPalette (int palette)
 	    pane_alpha = 0xff * 125 / 1000;
 	    break;
 	// Hexen exclusive color panes and palette indexes
-	// [JN] Hexen TODO - double check with disabled true color variable
-	// to make sure that colors are precise and identical enough to vanilla.
 	case 14:  // STARTPOISONPALS + 1 (13 is shared with other games)
 	    curpane = grnspane;
-	    pane_alpha = 0x2b; // 43
+	    pane_alpha = 0x42; // 66
 	    break;
 	case 15:
 	    curpane = grnspane;
-	    pane_alpha = 0x3c; // 60
+	    pane_alpha = 0x52; // 82
 	    break;
 	case 16:
 	    curpane = grnspane;
-	    pane_alpha = 0x58; // 88
+	    pane_alpha = 0x62; // 98
 	    break;
 	case 17:
 	    curpane = grnspane;
-	    pane_alpha = 0x74; // 116
+	    pane_alpha = 0x72; // 114
 	    break;
 	case 18:
 	    curpane = grnspane;
-	    pane_alpha = 0x91; // 145
+	    pane_alpha = 0x82; // 130
 	    break;
 	case 19:
 	    curpane = grnspane;
-	    pane_alpha = 0xad; // 173
+	    pane_alpha = 0x92; // 146
 	    break;
 	case 20:
 	    curpane = grnspane;
-	    pane_alpha = 0xc9; // 201
+	    pane_alpha = 0xa2; // 162
 	    break;
 	case 21:  // STARTICEPAL
 	    curpane = bluepane;
-	    pane_alpha = 0x7e; // 126
+	    pane_alpha = 0x74; // 116
 	    break;
 	case 22:  // STARTHOLYPAL
 	    curpane = graypane;
-	    pane_alpha = 0x78; // 120
+	    pane_alpha = 0x83; // 131
 	    break;
 	case 23:
 	    curpane = graypane;
-	    pane_alpha = 0x5c; // 92
+	    pane_alpha = 0x6a; // 106
 	    break;
 	case 24:
 	    curpane = graypane;
-	    pane_alpha = 0x2c; // 44
+	    pane_alpha = 0x34; // 52
 	    break;
 	case 25:  // STARTSCOURGEPAL
 	    curpane = orngpane;
-	    pane_alpha = 0x6c; // 108
+	    pane_alpha = 0x7c; // 124
 	    break;
 	case 26:
 	    curpane = orngpane;
-	    pane_alpha = 0x50; // 80
+	    pane_alpha = 0x60; // 96
 	    break;
 	case 27:
 	    curpane = orngpane;
-	    pane_alpha = 0x38; // 56
+	    pane_alpha = 0x48; // 72
 	    break;
 	default:
 	    I_Error("Unknown palette: %d!\n", palette);
@@ -1647,7 +1645,7 @@ static void SetVideoMode(void)
         grnpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnpane, SDL_BLENDMODE_BLEND);
 
-        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x35, 0x68, 0x2d)); // 53, 104, 45
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x30, 0x6d, 0x28)); // 48, 109, 40
         grnspane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnspane, SDL_BLENDMODE_BLEND);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1066,41 +1066,42 @@ void I_SetPalette (int palette)
 	    pane_alpha = 0xff * 125 / 1000;
 	    break;
 	// Hexen exclusive color panes and palette indexes
+	// https://doomwiki.org/wiki/PLAYPAL#Hexen
 	case 14:  // STARTPOISONPALS + 1 (13 is shared with other games)
 	    curpane = grnspane;
-	    pane_alpha = 0x42; // 66
+	    pane_alpha = 0x33; // 51 (20%)
 	    break;
 	case 15:
 	    curpane = grnspane;
-	    pane_alpha = 0x52; // 82
+	    pane_alpha = 0x4c; // 76 (30%)
 	    break;
 	case 16:
 	    curpane = grnspane;
-	    pane_alpha = 0x62; // 98
+	    pane_alpha = 0x66; // 102 (40%)
 	    break;
 	case 17:
 	    curpane = grnspane;
-	    pane_alpha = 0x72; // 114
+	    pane_alpha = 0x7f; // 127 (50%)
 	    break;
 	case 18:
 	    curpane = grnspane;
-	    pane_alpha = 0x82; // 130
+	    pane_alpha = 0x99; // 153 (60%)
 	    break;
 	case 19:
 	    curpane = grnspane;
-	    pane_alpha = 0x92; // 146
+	    pane_alpha = 0xb2; // 178 (70%)
 	    break;
 	case 20:
 	    curpane = grnspane;
-	    pane_alpha = 0xa2; // 162
+	    pane_alpha = 0xcc; // 204 (80%)
 	    break;
 	case 21:  // STARTICEPAL
 	    curpane = bluepane;
-	    pane_alpha = 0x74; // 116
+	    pane_alpha = 0x80; // 128 (50%)
 	    break;
 	case 22:  // STARTHOLYPAL
 	    curpane = graypane;
-	    pane_alpha = 0x83; // 131
+	    pane_alpha = 0x7f; // 127 (50%)
 	    break;
 	case 23:
 	    curpane = graypane;
@@ -1112,7 +1113,7 @@ void I_SetPalette (int palette)
 	    break;
 	case 25:  // STARTSCOURGEPAL
 	    curpane = orngpane;
-	    pane_alpha = 0x7c; // 124
+	    pane_alpha = 0x7f; // 127 (50%)
 	    break;
 	case 26:
 	    curpane = orngpane;
@@ -1645,19 +1646,19 @@ static void SetVideoMode(void)
         grnpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnpane, SDL_BLENDMODE_BLEND);
 
-        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x30, 0x6d, 0x28)); // 48, 109, 40
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x2c, 0x5c, 0x24)); // 44, 92, 36
         grnspane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnspane, SDL_BLENDMODE_BLEND);
 
-        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0x0, 0xef)); // 0, 0, 239
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0x0, 0xe0)); // 0, 0, 224
         bluepane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(bluepane, SDL_BLENDMODE_BLEND);
 
-        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x80, 0x80, 0x80)); // 128, 128, 128
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x82, 0x82, 0x82)); // 130, 130, 130
         graypane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(graypane, SDL_BLENDMODE_BLEND);
 
-        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x98, 0x70, 0x0)); // 152, 112, 0
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x96, 0x6e, 0x0)); // 150, 110, 0
         orngpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(orngpane, SDL_BLENDMODE_BLEND);
 #endif

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -96,6 +96,9 @@ static SDL_Texture *curpane = NULL;
 static SDL_Texture *redpane = NULL;
 static SDL_Texture *yelpane = NULL;
 static SDL_Texture *grnpane = NULL;
+// Hexen exclusive color panes
+static SDL_Texture *bluepane = NULL;
+static SDL_Texture *graypane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
@@ -1061,7 +1064,27 @@ void I_SetPalette (int palette)
 	    pane_alpha = 0xff * 125 / 1000;
 	    break;
 	// [crispy] Hexen TODO - add 14-27 palette indexes and extra panes.
-	// But what about coloring formulas?
+	// Hexen exclusive color panes and palette indexes
+	case 21:  // STARTICEPAL
+	    curpane = bluepane;
+	    pane_alpha = 0x7e; // 126
+	    break;
+	case 22:  // STARTHOLYPAL
+	    curpane = graypane;
+	    pane_alpha = 0x8c; // 140
+	    break;
+	case 23:
+	    curpane = graypane;
+	    pane_alpha = 0x74; // 116
+	    break;
+	case 24:
+	    curpane = graypane;
+	    pane_alpha = 0x54; // 84
+	    break;
+	case 25:
+	    curpane = graypane;
+	    pane_alpha = 0x34; // 52
+	    break;
 	default:
 	    I_Error("Unknown palette: %d!\n", palette);
 	    break;
@@ -1584,6 +1607,14 @@ static void SetVideoMode(void)
         SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0xff, 0x0));
         grnpane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
         SDL_SetTextureBlendMode(grnpane, SDL_BLENDMODE_BLEND);
+
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x0, 0x0, 0xef)); // 0, 0, 239
+        bluepane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
+        SDL_SetTextureBlendMode(bluepane, SDL_BLENDMODE_BLEND);
+
+        SDL_FillRect(argbbuffer, NULL, I_MapRGB(0x80, 0x80, 0x80)); // 128, 128, 128
+        graypane = SDL_CreateTextureFromSurface(renderer, argbbuffer);
+        SDL_SetTextureBlendMode(graypane, SDL_BLENDMODE_BLEND);
 #endif
         SDL_FillRect(argbbuffer, NULL, 0);
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1060,6 +1060,8 @@ void I_SetPalette (int palette)
 	    curpane = grnpane;
 	    pane_alpha = 0xff * 125 / 1000;
 	    break;
+	// [crispy] Hexen TODO - add 14-27 palette indexes and extra panes.
+	// But what about coloring formulas?
 	default:
 	    I_Error("Unknown palette: %d!\n", palette);
 	    break;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -106,7 +106,7 @@ static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
 static const uint8_t blend_alpha_tinttab = 0x60; // 96
 static const uint8_t blend_alpha_alttinttab = 0x8E; // 142
-extern pixel_t* colormaps; // [crispy] evil hack to get FPS dots working as in Vanilla
+extern pixel_t* pal_color; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
 #endif
@@ -808,13 +808,13 @@ void I_FinishUpdate (void)
 #ifndef CRISPY_TRUECOLOR
 	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = 0xff;
 #else
-	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = colormaps[0xff];
+	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = pal_color[0xff];
 #endif
 	for ( ; i<20*4 ; i+=4)
 #ifndef CRISPY_TRUECOLOR
 	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = 0x0;
 #else
-	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = colormaps[0x0];
+	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = pal_color[0x0];
 #endif
     }
 

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -157,7 +157,7 @@ fixed_t*	spritewidth;
 fixed_t*	spriteoffset;
 fixed_t*	spritetopoffset;
 
-lighttable_t	*colormaps;
+lighttable_t	*colormaps, *pal_color;
 
 
 //
@@ -695,6 +695,7 @@ void R_InitColormaps (void)
     // Load in the light tables, 256 byte align tables.
     lump = W_GetNumForName(DEH_String("COLORMAP"));
     colormaps = W_CacheLumpNum(lump, PU_STATIC);
+    pal_color = colormaps;
 
     // [crispy] initialize color translation and color strings tables
     {

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -64,6 +64,7 @@ extern const pixel_t I_BlendAdd (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendDark (const pixel_t bg, const int d);
 extern const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg);
 #endif
 
 int V_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -506,6 +506,9 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
     byte *source;
     int w;
 
+    // [crispy] translucent patch, no coloring or color-translation are used
+    drawpatchpx_t *const drawpatchpx = drawtinttab_a[dp_translucent];
+
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);
     x += WIDESCREENDELTA; // [crispy] horizontal widescreen offset
@@ -537,7 +540,7 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
 
             while (count--)
             {
-                *dest = tinttable[*dest + ((source[srccol >> FRACBITS]) << 8)];
+                *dest = drawpatchpx(*dest, source[srccol >> FRACBITS]);
                 srccol += dyi;
                 dest += SCREENWIDTH;
             }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -61,7 +61,7 @@ byte *tranmap = NULL;
 byte *dp_translation = NULL;
 boolean dp_translucent = false;
 #ifdef CRISPY_TRUECOLOR
-extern pixel_t *colormaps;
+extern pixel_t *pal_color;
 #endif
 
 // villsa [STRIFE] Blending table used for Strife
@@ -170,28 +170,28 @@ static const inline pixel_t drawpatchpx00 (const pixel_t dest, const pixel_t sou
 #ifndef CRISPY_TRUECOLOR
 {return source;}
 #else
-{return colormaps[source];}
+{return pal_color[source];}
 #endif
 // (2) color-translated, opaque patch
 static const inline pixel_t drawpatchpx01 (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return dp_translation[source];}
 #else
-{return colormaps[dp_translation[source]];}
+{return pal_color[dp_translation[source]];}
 #endif
 // (3) normal, translucent patch
 static const inline pixel_t drawpatchpx10 (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tranmap[(dest<<8)+source];}
 #else
-{return I_BlendOver(dest, colormaps[source]);}
+{return I_BlendOver(dest, pal_color[source]);}
 #endif
 // (4) color-translated, translucent patch
 static const inline pixel_t drawpatchpx11 (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tranmap[(dest<<8)+dp_translation[source]];}
 #else
-{return I_BlendOver(dest, colormaps[dp_translation[source]]);}
+{return I_BlendOver(dest, pal_color[dp_translation[source]]);}
 #endif
 
 // [crispy] TINTTAB rendering functions:
@@ -207,14 +207,14 @@ static const inline pixel_t drawtinttab (const pixel_t dest, const pixel_t sourc
 #ifndef CRISPY_TRUECOLOR
 {return tinttable[dest+(source<<8)];}
 #else
-{return I_BlendOverTinttab(dest, colormaps[source]);}
+{return I_BlendOverTinttab(dest, pal_color[source]);}
 #endif
 // V_DrawAltTLPatch (translucent patch, no coloring or color-translation are used)
 static const inline pixel_t drawalttinttab (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tinttable[(dest<<8)+source];}
 #else
-{return I_BlendOverAltTinttab(dest, colormaps[source]);}
+{return I_BlendOverAltTinttab(dest, pal_color[source]);}
 #endif
 
 // [crispy] array of function pointers holding the different rendering functions
@@ -476,7 +476,7 @@ void V_DrawPatchFlipped(int x, int y, patch_t *patch)
 #ifndef CRISPY_TRUECOLOR
                     *dest = source[srccol >> FRACBITS];
 #else
-                    *dest = colormaps[source[srccol >> FRACBITS]];
+                    *dest = pal_color[source[srccol >> FRACBITS]];
 #endif
                 }
                 srccol += dyi;
@@ -919,7 +919,7 @@ void V_CopyScaledBuffer(pixel_t *dest, byte *src, size_t size)
 #ifndef CRISPY_TRUECOLOR
                 *(dest + index - (j * SCREENWIDTH) - i) = *(src + size);
 #else
-                *(dest + index - (j * SCREENWIDTH) - i) = colormaps[src[size]];
+                *(dest + index - (j * SCREENWIDTH) - i) = pal_color[src[size]];
 #endif
             }
         }
@@ -974,7 +974,7 @@ void V_FillFlat(int y_start, int y_stop, int x_start, int x_stop,
 #ifndef CRISPY_TRUECOLOR
             *dest++ = src[((y & 63) * 64) + (x & 63)];
 #else
-            *dest++ = colormaps[src[((y & 63) * 64) + (x & 63)]];
+            *dest++ = pal_color[src[((y & 63) * 64) + (x & 63)]];
 #endif
         }
     }


### PR DESCRIPTION
Almost a carbon copy of Doom and Heretic code with few exceptions. At the moment of writing this PR, all rendering initials and nominals should be formed, and despite of massive changes this is an easy part. Hard part is:

* Extra color panes to support 13-27 palette indexes. And what about formulas?
* Foggy maps should use pregenerated colormap table + there is something unclear with brightest levels, see my comment at p_setup.c.
* Fade in / fade out effects for finale screen. We can't operate with `PLAYPAL` values, but we can fade screen with `I_BlendDark` in f_finale.c.
* I'm sure there can potentially be couple of underwater mines in ACS scripts.