### PR TITLE
Heretic & Hexen: demo playback fixes

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1142,6 +1142,14 @@ boolean G_Responder(event_t * ev)
         usearti = true;
     }
 
+    // [crispy] demo fast-forward
+    if (ev->type == ev_keydown && ev->data1 == key_demospeed && 
+        (demoplayback || gamestate == GS_DEMOSCREEN))
+    {
+        singletics = !singletics;
+        return true;
+    }
+
     // Check for spy mode player cycle
     if (gamestate == GS_LEVEL && ev->type == ev_keydown
         && ev->data1 == KEY_F12 && !deathmatch)

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2220,7 +2220,8 @@ boolean MN_Responder(event_t * event)
 
     if (!MenuActive)
     {
-        if (key == key_menu_activate || gamestate == GS_DEMOSCREEN || demoplayback)
+        //[crispy] don't pop up the menu on other keys during a demo
+        if (key == key_menu_activate)
         {
             MN_ActivateMenu();
             return (true);

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2221,7 +2221,7 @@ boolean MN_Responder(event_t * event)
     if (!MenuActive)
     {
         //[crispy] don't pop up the menu on other keys during a demo
-        if (key == key_menu_activate)
+        if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
         {
             MN_ActivateMenu();
             return (true);

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2220,7 +2220,7 @@ boolean MN_Responder(event_t * event)
 
     if (!MenuActive)
     {
-        //[crispy] don't pop up the menu on other keys during a demo
+        // [crispy] don't pop up the menu on other keys during a demo
         if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
         {
             MN_ActivateMenu();

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1072,6 +1072,14 @@ boolean G_Responder(event_t * ev)
         usearti = true;
     }
 
+    // [crispy] demo fast-forward
+    if (ev->type == ev_keydown && ev->data1 == key_demospeed && 
+        (demoplayback || gamestate == GS_DEMOSCREEN))
+    {
+        singletics = !singletics;
+        return true;
+    }
+
     // Check for spy mode player cycle
     if (gamestate == GS_LEVEL && ev->type == ev_keydown
         && ev->data1 == key_spy && !deathmatch)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2057,7 +2057,7 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
 
     // Set up a bunch of globals
-    if (!demoextend)
+    if ((!demoextend) || (!demorecording && !demoplayback))
     {
         // This prevents map-loading from interrupting a demo.
         // demoextend is set back to false only if starting a new game or

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2057,7 +2057,9 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
 
     // Set up a bunch of globals
-    if ((!demoextend) || (!demorecording && !demoplayback))
+    // [crispy] since demoextend is the default, we also want to check to
+    // make sure we're not playing a demo
+    if (!demoextend || (!demorecording && !demoplayback))
     {
         // This prevents map-loading from interrupting a demo.
         // demoextend is set back to false only if starting a new game or

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2215,7 +2215,8 @@ boolean MN_Responder(event_t * event)
 
     if (!MenuActive)
     {
-        if (key == key_menu_activate || gamestate == GS_DEMOSCREEN || demoplayback)
+        //[crispy] don't pop up the menu on other keys during a demo
+        if (key == key_menu_activate)
         {
             MN_ActivateMenu();
             return (true);

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2216,7 +2216,7 @@ boolean MN_Responder(event_t * event)
     if (!MenuActive)
     {
         //[crispy] don't pop up the menu on other keys during a demo
-        if (key == key_menu_activate)
+        if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
         {
             MN_ActivateMenu();
             return (true);

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2215,7 +2215,7 @@ boolean MN_Responder(event_t * event)
 
     if (!MenuActive)
     {
-        //[crispy] don't pop up the menu on other keys during a demo
+        // [crispy] don't pop up the menu on other keys during a demo
         if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
         {
             MN_ActivateMenu();


### PR DESCRIPTION
- Enable `demospeed` key, and disable opening the menu when a non-menu key is pressed

- Check `usergame` when not in a demo properly
    This could also be applied to Chocolate Doom but I don't think it's necessary since `-demoextend` is not the default.