### PR TITLE
raven: Fix medusa effect

### DIFF
--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -16,6 +16,8 @@
 
 // R_data.c
 
+#include <stdlib.h> // [crispy] calloc()
+
 #include "doomdef.h"
 #include "deh_str.h"
 
@@ -59,7 +61,7 @@ int *texturewidthmask;
 fixed_t *textureheight;         // needed for texture pegging
 int *texturecompositesize;
 short **texturecolumnlump;
-unsigned short **texturecolumnofs;
+unsigned **texturecolumnofs; // [crispy] was short
 byte **texturecomposite;
 const byte **texturebrightmap;  // [crispy] brightmaps
 
@@ -87,53 +89,73 @@ will have new column_ts generated.
 ==============================================================================
 */
 
-/*
-===================
-=
-= R_DrawColumnInCache
-=
-= Clip and draw a column from a patch into a cached post
-=
-===================
-*/
+// [crispy] replace R_DrawColumnInCache(), R_GenerateComposite() and
+// R_GenerateLookup() with Lee Killough's implementations found in MBF to fix
+// Medusa bug taken from mbfsrc/R_DATA.C:136-425
+//
+// R_DrawColumnInCache
+// Clip and draw a column from a patch into a cached post.
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
+//
 
 void R_DrawColumnInCache(column_t * patch, byte * cache, int originy,
-                         int cacheheight)
+                         int cacheheight, byte * marks)
 {
     int count, position;
     byte *source;
+    int top = -1;
 
     while (patch->topdelta != 0xff)
     {
-        source = (byte *) patch + 3;
+        // [crispy] support for DeePsea tall patches
+        if (patch->topdelta <= top)
+        {
+            top += patch->topdelta;
+        }
+        else
+        {
+            top = patch->topdelta;
+        }
+        source = (byte *)patch + 3;
         count = patch->length;
-        position = originy + patch->topdelta;
+        position = originy + top;
+
         if (position < 0)
         {
             count += position;
             position = 0;
         }
+
         if (position + count > cacheheight)
             count = cacheheight - position;
+
         if (count > 0)
+        {
             memcpy(cache + position, source, count);
 
-        patch = (column_t *) ((byte *) patch + patch->length + 4);
+            // killough 4/9/98: remember which cells in column have been drawn,
+            // so that column can later be converted into a series of posts, to
+            // fix the Medusa bug.
+
+            memset(marks + position, 0xff, count);
+        }
+
+        patch = (column_t *)((byte *)patch + patch->length + 4);
     }
 }
 
 
-/*
-===================
-=
-= R_GenerateComposite
-=
-===================
-*/
+//
+// R_GenerateComposite
+// Using the texture definition, the composite texture is created from the
+// patches, and each column is cached.
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
 
 void R_GenerateComposite(int texnum)
 {
-    byte *block;
+    byte* block;
     texture_t *texture;
     texpatch_t *patch;
     patch_t *realpatch;
@@ -141,13 +163,23 @@ void R_GenerateComposite(int texnum)
     int i;
     column_t *patchcol;
     short *collump;
-    unsigned short *colofs;
+    unsigned* colofs; // killough 4/9/98: make 32-bit
+    byte *marks; // killough 4/9/98: transparency marks
+    byte *source; // killough 4/9/98: temporary column
 
     texture = textures[texnum];
+
     block = Z_Malloc(texturecompositesize[texnum], PU_STATIC,
                      &texturecomposite[texnum]);
+
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
+
+    // killough 4/9/98: marks to identify transparent regions in merged textures
+    marks = calloc(texture->width, texture->height);
+
+    // [crispy] initialize composite background to palette index 0 (usually black)
+    memset(block, 0, texturecompositesize[texnum]);
 
 //
 // composite the columns together
@@ -170,41 +202,111 @@ void R_GenerateComposite(int texnum)
         {
             if (collump[x] >= 0)
                 continue;       // column does not have multiple patches
+
             patchcol = (column_t *) ((byte *) realpatch +
                                      LONG(realpatch->columnofs[x - x1]));
-            R_DrawColumnInCache(patchcol, block + colofs[x], patch->originy,
-                                texture->height);
+            R_DrawColumnInCache(patchcol, block + colofs[x],
+                                patch->originy,
+                                texture->height,
+                                marks + x * texture->height);
         }
 
     }
 
-// now that the texture has been built, it is purgable
+    // killough 4/9/98: Next, convert multipatched columns into true columns,
+    // to fix Medusa bug while still allowing for transparent regions.
+
+    source = I_Realloc(NULL, texture->height); // temporary column
+    for (i = 0; i < texture->width; i++)
+    {
+        if (collump[i] == -1) // process only multipatched columns
+        {
+            column_t *col =
+                (column_t *) (block + colofs[i] - 3); // cached column
+            const byte *mark = marks + i * texture->height;
+            int j = 0;
+            // [crispy] absolute topdelta for first 254 pixels, then relative
+            int abstop, reltop = 0;
+            boolean relative = false;
+
+            // save column in temporary so we can shuffle it around
+            memcpy(source, (byte *) col + 3, texture->height);
+
+            for (;;) // reconstruct the column by scanning transparency marks
+            {
+                unsigned len; // killough 12/98
+
+                while (j < texture->height && reltop < 254 &&
+                       !mark[j]) // skip transparent cells
+                    j++, reltop++;
+
+                if (j >= texture->height) // if at end of column
+                {
+                    col->topdelta = -1; // end-of-column marker
+                    break;
+                }
+
+                // [crispy] absolute topdelta for first 254 pixels, then relative
+                col->topdelta =
+                    relative ? reltop : j; // starting offset of post
+
+                // [crispy] once we pass the 254 boundary, topdelta becomes relative
+                if ((abstop = j) >= 254)
+                {
+                    relative = true;
+                    reltop = 0;
+                }
+
+                // killough 12/98: Use 32-bit len counter, to support tall 1s
+                // multipatched textures
+
+                for (len = 0; j < texture->height && reltop < 254 && mark[j];
+                     j++, reltop++)
+                    len++; // count opaque cells
+
+                col->length = len; // killough 12/98: intentionally truncate length
+
+                // copy opaque cells from the temporary back into the column
+                memcpy((byte *) col + 3, source + abstop, len);
+                col = (column_t *) ((byte *) col + len + 4); // next post
+            }
+        }
+    }
+
+    free(source); // free temporary column
+    free(marks); // free transparency marks
+
+    // Now that the texture has been built in column cache, it is purgable
+    // from zone memory.
     Z_ChangeTag(block, PU_CACHE);
 }
 
 
-/*
-===================
-=
-= R_GenerateLookup
-=
-===================
-*/
+//
+// R_GenerateLookup
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
+//
 
 void R_GenerateLookup(int texnum)
 {
     texture_t *texture;
     byte *patchcount;           // [texture->width]
+    byte *postcount; // killough 4/9/98: keep count of posts in addition to patches.
     texpatch_t *patch;
     patch_t *realpatch;
     int x, x1, x2;
     int i;
     short *collump;
-    unsigned short *colofs;
+    unsigned *colofs; // killough 4/9/98: make 32-bit
+    int csize = 0; // killough 10/98
+    int err = 0; // killough 10/98
 
     texture = textures[texnum];
 
-    texturecomposite[texnum] = 0;       // composited not created yet
+    // Composited texture not created yet.
+    texturecomposite[texnum] = 0;
+
     texturecompositesize[texnum] = 0;
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
@@ -215,7 +317,9 @@ void R_GenerateLookup(int texnum)
 // all done
 //
     patchcount = (byte *) Z_Malloc(texture->width, PU_STATIC, &patchcount);
+    postcount = (byte *) Z_Malloc(texture->width, PU_STATIC, &postcount);
     memset(patchcount, 0, texture->width);
+    memset(postcount, 0, texture->width);
 
     for (i = 0, patch = texture->patches; i < texture->patchcount;
          i++, patch++)
@@ -237,26 +341,101 @@ void R_GenerateLookup(int texnum)
         }
     }
 
-    for (x = 0; x < texture->width; x++)
+    // killough 4/9/98: keep a count of the number of posts in column,
+    // to fix Medusa bug while allowing for transparent multipatches.
+    //
+    // killough 12/98:
+    // Post counts are only necessary if column is multipatched,
+    // so skip counting posts if column comes from a single patch.
+    // This allows arbitrarily tall textures for 1s walls.
+    //
+    // If texture is >= 256 tall, assume it's 1s, and hence it has
+    // only one post per column. This avoids crashes while allowing
+    // for arbitrarily tall multipatched 1s textures.
+
+    if (texture->patchcount > 1 && texture->height < 256)
     {
-        if (!patchcount[x])
+        // killough 12/98: Warn about a common column construction bug
+        unsigned limit = texture->height * 3 + 3; // absolute column size limit
+
+        for (i = texture->patchcount, patch = texture->patches; --i >= 0;)
         {
-            printf("R_GenerateLookup: column without a patch (%s)\n",
-                   texture->name);
-            return;
-        }
-//                      I_Error ("R_GenerateLookup: column without a patch");
-        if (patchcount[x] > 1)
-        {
-            collump[x] = -1;    // use the cached block
-            colofs[x] = texturecompositesize[texnum];
-            if (texturecompositesize[texnum] > 0x10000 - texture->height)
-                I_Error("R_GenerateLookup: texture %i is >64k", texnum);
-            texturecompositesize[texnum] += texture->height;
+            int pat = patch->patch;
+            const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
+            int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
+            const int *cofs = realpatch->columnofs - x1;
+
+            if (x2 > texture->width)
+                x2 = texture->width;
+            if (x1 < 0)
+                x1 = 0;
+
+            for (x = x1; x < x2; x++)
+            {
+                if (patchcount[x] > 1) // Only multipatched columns
+                {
+                    const column_t *col =
+                        (const column_t *) ((const byte *) realpatch +
+                                            LONG(cofs[x]));
+                    const byte *base = (const byte *) col;
+
+                    // count posts
+                    for (; col->topdelta != 0xff; postcount[x]++)
+                    {
+                        if ((unsigned) ((const byte *) col - base) <= limit)
+                            col = (const column_t *) ((const byte *) col +
+                                                      col->length + 4);
+                        else
+                            break;
+                    }
+                }
+            }
         }
     }
 
+    for (x = 0; x < texture->width; x++)
+    {
+        if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
+        {
+            // [crispy] fix absurd texture name in error message
+            printf("R_GenerateLookup: column without a patch (%.8s)\n",
+                texture->name);
+            // [crispy] do not return yet
+            /*
+            return;
+            */
+        }
+        // I_Error ("R_GenerateLookup: column without a patch");
+
+        // [crispy] treat patch-less columns the same as multi-patched
+        if (patchcount[x] > 1 || !patchcount[x])
+        {
+            // killough 1/25/98, 4/9/98:
+            //
+            // Fix Medusa bug, by adding room for column header
+            // and trailer bytes for each post in merged column.
+            // For now, just allocate conservatively 4 bytes
+            // per post per patch per column, since we don't
+            // yet know how many posts the merged column will
+            // require, and it's bounded above by this limit.
+            collump[x] = -1; // use the cached block
+            colofs[x] = csize + 3; // three header bytes in a column
+            // killough 12/98: add room for one extra post
+            csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
+        }
+
+            // [crispy] remove limit
+            /*
+            if (texturecompositesize[texnum] > 0x10000 - texture->height)
+                I_Error("R_GenerateLookup: texture %i is >64k", texnum);
+            */
+        csize += texture->height; // height bytes of texture data
+    }
+
+    texturecompositesize[texnum] += csize;
+
     Z_Free(patchcount);
+    Z_Free(postcount);
 }
 
 
@@ -281,7 +460,6 @@ byte *R_GetColumn(int tex, int col)
         R_GenerateComposite(tex);
     return texturecomposite[tex] + ofs;
 }
-
 
 /*
 ==================
@@ -363,7 +541,7 @@ void R_InitTextures(void)
 
     textures = Z_Malloc(numtextures * sizeof(texture_t *), PU_STATIC, 0);
     texturecolumnlump = Z_Malloc(numtextures * sizeof(short *), PU_STATIC, 0);
-    texturecolumnofs = Z_Malloc(numtextures * sizeof(unsigned short *), PU_STATIC, 0);
+    texturecolumnofs = Z_Malloc(numtextures * sizeof(*texturecolumnofs), PU_STATIC, 0);
     texturecomposite = Z_Malloc(numtextures * sizeof(byte *), PU_STATIC, 0);
     texturecompositesize = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
     texturewidthmask = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
@@ -411,9 +589,9 @@ void R_InitTextures(void)
                 I_Error("R_InitTextures: Missing patch in texture %s",
                         texture->name);
         }
-        texturecolumnlump[i] = Z_Malloc(texture->width * sizeof(short),
+        texturecolumnlump[i] = Z_Malloc(texture->width * sizeof(**texturecolumnlump),
                                         PU_STATIC, 0);
-        texturecolumnofs[i] = Z_Malloc(texture->width * sizeof(short), 
+        texturecolumnofs[i] = Z_Malloc(texture->width * sizeof(**texturecolumnofs),
                                        PU_STATIC, 0);
         j = 1;
         while (j * 2 <= texture->width)

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -14,6 +14,7 @@
 // GNU General Public License for more details.
 //
 
+#include <stdlib.h> // [crispy] calloc()
 
 #include "h2def.h"
 #include "i_system.h"
@@ -55,7 +56,7 @@ int *texturewidthmask;
 fixed_t *textureheight;         // needed for texture pegging
 int *texturecompositesize;
 short **texturecolumnlump;
-unsigned short **texturecolumnofs;
+unsigned **texturecolumnofs; // [crispy] was short
 byte **texturecomposite;
 const byte **texturebrightmap;  // [crispy] brightmaps
 
@@ -83,53 +84,73 @@ will have new column_ts generated.
 ==============================================================================
 */
 
-/*
-===================
-=
-= R_DrawColumnInCache
-=
-= Clip and draw a column from a patch into a cached post
-=
-===================
-*/
+// [crispy] replace R_DrawColumnInCache(), R_GenerateComposite() and
+// R_GenerateLookup() with Lee Killough's implementations found in MBF to fix
+// Medusa bug taken from mbfsrc/R_DATA.C:136-425
+//
+// R_DrawColumnInCache
+// Clip and draw a column from a patch into a cached post.
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
+//
 
 void R_DrawColumnInCache(column_t * patch, byte * cache, int originy,
-                         int cacheheight)
+                         int cacheheight, byte * marks)
 {
     int count, position;
     byte *source;
+    int top = -1;
 
     while (patch->topdelta != 0xff)
     {
-        source = (byte *) patch + 3;
+        // [crispy] support for DeePsea tall patches
+        if (patch->topdelta <= top)
+        {
+            top += patch->topdelta;
+        }
+        else
+        {
+            top = patch->topdelta;
+        }
+        source = (byte *)patch + 3;
         count = patch->length;
-        position = originy + patch->topdelta;
+        position = originy + top;
+
         if (position < 0)
         {
             count += position;
             position = 0;
         }
+
         if (position + count > cacheheight)
             count = cacheheight - position;
+
         if (count > 0)
+        {
             memcpy(cache + position, source, count);
 
-        patch = (column_t *) ((byte *) patch + patch->length + 4);
+            // killough 4/9/98: remember which cells in column have been drawn,
+            // so that column can later be converted into a series of posts, to
+            // fix the Medusa bug.
+
+            memset(marks + position, 0xff, count);
+        }
+
+        patch = (column_t *)((byte *)patch + patch->length + 4);
     }
 }
 
 
-/*
-===================
-=
-= R_GenerateComposite
-=
-===================
-*/
+//
+// R_GenerateComposite
+// Using the texture definition, the composite texture is created from the
+// patches, and each column is cached.
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
 
 void R_GenerateComposite(int texnum)
 {
-    byte *block;
+    byte* block;
     texture_t *texture;
     texpatch_t *patch;
     patch_t *realpatch;
@@ -137,13 +158,23 @@ void R_GenerateComposite(int texnum)
     int i;
     column_t *patchcol;
     short *collump;
-    unsigned short *colofs;
+    unsigned* colofs; // killough 4/9/98: make 32-bit
+    byte *marks; // killough 4/9/98: transparency marks
+    byte *source; // killough 4/9/98: temporary column
 
     texture = textures[texnum];
+
     block = Z_Malloc(texturecompositesize[texnum], PU_STATIC,
                      &texturecomposite[texnum]);
+
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
+
+    // killough 4/9/98: marks to identify transparent regions in merged textures
+    marks = calloc(texture->width, texture->height);
+
+    // [crispy] initialize composite background to palette index 0 (usually black)
+    memset(block, 0, texturecompositesize[texnum]);
 
 //
 // composite the columns together
@@ -166,41 +197,111 @@ void R_GenerateComposite(int texnum)
         {
             if (collump[x] >= 0)
                 continue;       // column does not have multiple patches
+
             patchcol = (column_t *) ((byte *) realpatch +
                                      LONG(realpatch->columnofs[x - x1]));
-            R_DrawColumnInCache(patchcol, block + colofs[x], patch->originy,
-                                texture->height);
+            R_DrawColumnInCache(patchcol, block + colofs[x],
+                                patch->originy,
+                                texture->height,
+                                marks + x * texture->height);
         }
 
     }
 
-// now that the texture has been built, it is purgable
+    // killough 4/9/98: Next, convert multipatched columns into true columns,
+    // to fix Medusa bug while still allowing for transparent regions.
+
+    source = I_Realloc(NULL, texture->height); // temporary column
+    for (i = 0; i < texture->width; i++)
+    {
+        if (collump[i] == -1) // process only multipatched columns
+        {
+            column_t *col =
+                (column_t *) (block + colofs[i] - 3); // cached column
+            const byte *mark = marks + i * texture->height;
+            int j = 0;
+            // [crispy] absolute topdelta for first 254 pixels, then relative
+            int abstop, reltop = 0;
+            boolean relative = false;
+
+            // save column in temporary so we can shuffle it around
+            memcpy(source, (byte *) col + 3, texture->height);
+
+            for (;;) // reconstruct the column by scanning transparency marks
+            {
+                unsigned len; // killough 12/98
+
+                while (j < texture->height && reltop < 254 &&
+                       !mark[j]) // skip transparent cells
+                    j++, reltop++;
+
+                if (j >= texture->height) // if at end of column
+                {
+                    col->topdelta = -1; // end-of-column marker
+                    break;
+                }
+
+                // [crispy] absolute topdelta for first 254 pixels, then relative
+                col->topdelta =
+                    relative ? reltop : j; // starting offset of post
+
+                // [crispy] once we pass the 254 boundary, topdelta becomes relative
+                if ((abstop = j) >= 254)
+                {
+                    relative = true;
+                    reltop = 0;
+                }
+
+                // killough 12/98: Use 32-bit len counter, to support tall 1s
+                // multipatched textures
+
+                for (len = 0; j < texture->height && reltop < 254 && mark[j];
+                     j++, reltop++)
+                    len++; // count opaque cells
+
+                col->length = len; // killough 12/98: intentionally truncate length
+
+                // copy opaque cells from the temporary back into the column
+                memcpy((byte *) col + 3, source + abstop, len);
+                col = (column_t *) ((byte *) col + len + 4); // next post
+            }
+        }
+    }
+
+    free(source); // free temporary column
+    free(marks); // free transparency marks
+
+    // Now that the texture has been built in column cache, it is purgable
+    // from zone memory.
     Z_ChangeTag(block, PU_CACHE);
 }
 
 
-/*
-===================
-=
-= R_GenerateLookup
-=
-===================
-*/
+//
+// R_GenerateLookup
+//
+// Rewritten by Lee Killough for performance and to fix Medusa bug
+//
 
 void R_GenerateLookup(int texnum)
 {
     texture_t *texture;
     byte *patchcount;           // [texture->width]
+    byte *postcount; // killough 4/9/98: keep count of posts in addition to patches.
     texpatch_t *patch;
     patch_t *realpatch;
     int x, x1, x2;
     int i;
     short *collump;
-    unsigned short *colofs;
+    unsigned *colofs; // killough 4/9/98: make 32-bit
+    int csize = 0; // killough 10/98
+    int err = 0; // killough 10/98
 
     texture = textures[texnum];
 
-    texturecomposite[texnum] = 0;       // composited not created yet
+    // Composited texture not created yet.
+    texturecomposite[texnum] = 0;
+
     texturecompositesize[texnum] = 0;
     collump = texturecolumnlump[texnum];
     colofs = texturecolumnofs[texnum];
@@ -211,7 +312,10 @@ void R_GenerateLookup(int texnum)
 // all done
 //
     patchcount = (byte *) Z_Malloc(texture->width, PU_STATIC, &patchcount);
+    postcount = (byte *) Z_Malloc(texture->width, PU_STATIC, &postcount);
     memset(patchcount, 0, texture->width);
+    memset(postcount, 0, texture->width);
+
     for (i = 0, patch = texture->patches; i < texture->patchcount;
          i++, patch++)
     {
@@ -232,26 +336,101 @@ void R_GenerateLookup(int texnum)
         }
     }
 
-    for (x = 0; x < texture->width; x++)
+    // killough 4/9/98: keep a count of the number of posts in column,
+    // to fix Medusa bug while allowing for transparent multipatches.
+    //
+    // killough 12/98:
+    // Post counts are only necessary if column is multipatched,
+    // so skip counting posts if column comes from a single patch.
+    // This allows arbitrarily tall textures for 1s walls.
+    //
+    // If texture is >= 256 tall, assume it's 1s, and hence it has
+    // only one post per column. This avoids crashes while allowing
+    // for arbitrarily tall multipatched 1s textures.
+
+    if (texture->patchcount > 1 && texture->height < 256)
     {
-        if (!patchcount[x])
+        // killough 12/98: Warn about a common column construction bug
+        unsigned limit = texture->height * 3 + 3; // absolute column size limit
+
+        for (i = texture->patchcount, patch = texture->patches; --i >= 0;)
         {
-            ST_Message("R_GenerateLookup: column without a patch (%s)\n",
-                       texture->name);
-            return;
-        }
-//                      I_Error ("R_GenerateLookup: column without a patch");
-        if (patchcount[x] > 1)
-        {
-            collump[x] = -1;    // use the cached block
-            colofs[x] = texturecompositesize[texnum];
-            if (texturecompositesize[texnum] > 0x10000 - texture->height)
-                I_Error("R_GenerateLookup: texture %i is >64k", texnum);
-            texturecompositesize[texnum] += texture->height;
+            int pat = patch->patch;
+            const patch_t *realpatch = W_CacheLumpNum(pat, PU_CACHE);
+            int x, x1 = patch++->originx, x2 = x1 + SHORT(realpatch->width);
+            const int *cofs = realpatch->columnofs - x1;
+
+            if (x2 > texture->width)
+                x2 = texture->width;
+            if (x1 < 0)
+                x1 = 0;
+
+            for (x = x1; x < x2; x++)
+            {
+                if (patchcount[x] > 1) // Only multipatched columns
+                {
+                    const column_t *col =
+                        (const column_t *) ((const byte *) realpatch +
+                                            LONG(cofs[x]));
+                    const byte *base = (const byte *) col;
+
+                    // count posts
+                    for (; col->topdelta != 0xff; postcount[x]++)
+                    {
+                        if ((unsigned) ((const byte *) col - base) <= limit)
+                            col = (const column_t *) ((const byte *) col +
+                                                      col->length + 4);
+                        else
+                            break;
+                    }
+                }
+            }
         }
     }
 
+    for (x = 0; x < texture->width; x++)
+    {
+        if (!patchcount[x] && !err++) // killough 10/98: non-verbose output
+        {
+            // [crispy] fix absurd texture name in error message
+            printf("R_GenerateLookup: column without a patch (%.8s)\n",
+                texture->name);
+            // [crispy] do not return yet
+            /*
+            return;
+            */
+        }
+        // I_Error ("R_GenerateLookup: column without a patch");
+
+        // [crispy] treat patch-less columns the same as multi-patched
+        if (patchcount[x] > 1 || !patchcount[x])
+        {
+            // killough 1/25/98, 4/9/98:
+            //
+            // Fix Medusa bug, by adding room for column header
+            // and trailer bytes for each post in merged column.
+            // For now, just allocate conservatively 4 bytes
+            // per post per patch per column, since we don't
+            // yet know how many posts the merged column will
+            // require, and it's bounded above by this limit.
+            collump[x] = -1; // use the cached block
+            colofs[x] = csize + 3; // three header bytes in a column
+            // killough 12/98: add room for one extra post
+            csize += 4 * postcount[x] + 5; // 1 stop byte plus 4 bytes per post
+        }
+
+            // [crispy] remove limit
+            /*
+            if (texturecompositesize[texnum] > 0x10000 - texture->height)
+                I_Error("R_GenerateLookup: texture %i is >64k", texnum);
+            */
+        csize += texture->height; // height bytes of texture data
+    }
+
+    texturecompositesize[texnum] += csize;
+
     Z_Free(patchcount);
+    Z_Free(postcount);
 }
 
 
@@ -341,7 +520,7 @@ void R_InitTextures(void)
 
     textures = Z_Malloc(numtextures * sizeof(texture_t *), PU_STATIC, 0);
     texturecolumnlump = Z_Malloc(numtextures * sizeof(short *), PU_STATIC, 0);
-    texturecolumnofs = Z_Malloc(numtextures * sizeof(short *), PU_STATIC, 0);
+    texturecolumnofs = Z_Malloc(numtextures * sizeof(*texturecolumnofs), PU_STATIC, 0);
     texturecomposite = Z_Malloc(numtextures * sizeof(byte *), PU_STATIC, 0);
     texturecompositesize = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
     texturewidthmask = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
@@ -384,7 +563,8 @@ void R_InitTextures(void)
                         texture->name);
         }
         texturecolumnlump[i] = Z_Malloc(texture->width * sizeof(short), PU_STATIC, 0);
-        texturecolumnofs[i] = Z_Malloc(texture->width * sizeof(short), PU_STATIC, 0);
+        texturecolumnofs[i] = Z_Malloc(texture->width * sizeof(**texturecolumnofs),
+                                       PU_STATIC, 0);
         j = 1;
         while (j * 2 <= texture->width)
             j <<= 1;


### PR DESCRIPTION
This is largely Lee Killough's original fix taken from MBF. There are some extra improvements that Fabian added to Doom that are not present here. In particular this implementation does not composite single patch textures, because doing so breaks the Heretic and Hexen skies.

Fixes #1146.