### PR TITLE
Hexen: fix possible overflows on walls rendering

### DIFF
--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -237,6 +237,17 @@ void P_LoadSegs(int lump)
 
 // [crispy] fix long wall wobble
 
+static angle_t anglediff(angle_t a, angle_t b)
+{
+    if (b > a)
+        return anglediff(b, a);
+
+    if (a - b < ANG180)
+        return a - b;
+    else // [crispy] wrap around
+        return b - a;
+}
+
 static void P_SegLengths (void)
 {
     int i;
@@ -250,6 +261,17 @@ static void P_SegLengths (void)
         dy = li->v2->y - li->v1->y;
 
         li->length = (uint32_t)(sqrt((double)dx*dx + (double)dy*dy)/2);
+
+        // [crispy] re-calculate angle used for rendering
+        viewx = li->v1->r_x;
+        viewy = li->v1->r_y;
+        li->r_angle = R_PointToAngleCrispy(li->v2->r_x, li->v2->r_y);
+        // [crispy] more than just a little adjustment?
+        // back to the original angle then
+        if (anglediff(li->r_angle, li->angle) > ANG60/2)
+        {
+            li->r_angle = li->angle;
+        }
     }
 }
 

--- a/src/hexen/r_bsp.c
+++ b/src/hexen/r_bsp.c
@@ -246,8 +246,9 @@ void R_AddLine(seg_t * line)
 
 // OPTIMIZE: quickly reject orthogonal back sides
 
-    angle1 = R_PointToAngle(line->v1->r_x, line->v1->r_y);
-    angle2 = R_PointToAngle(line->v2->r_x, line->v2->r_y);
+    // [crispy] remove slime trails
+    angle1 = R_PointToAngleCrispy(line->v1->r_x, line->v1->r_y);
+    angle2 = R_PointToAngleCrispy(line->v2->r_x, line->v2->r_y);
 
 //
 // clip to view edges
@@ -385,8 +386,8 @@ boolean R_CheckBBox(fixed_t * bspcoord)
 //
 // check clip list for an open space
 //
-    angle1 = R_PointToAngle(x1, y1) - viewangle;
-    angle2 = R_PointToAngle(x2, y2) - viewangle;
+    angle1 = R_PointToAngleCrispy(x1, y1) - viewangle;
+    angle2 = R_PointToAngleCrispy(x2, y2) - viewangle;
 
     span = angle1 - angle2;
     if (span >= ANG180)

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -402,6 +402,7 @@ extern void R_InterpolateTextureOffsets (void);
 int R_PointOnSide(fixed_t x, fixed_t y, node_t * node);
 int R_PointOnSegSide(fixed_t x, fixed_t y, seg_t * line);
 angle_t R_PointToAngle(fixed_t x, fixed_t y);
+angle_t R_PointToAngleCrispy(fixed_t x, fixed_t y);
 angle_t R_PointToAngle2(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2);
 fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_ScaleFromGlobalAngle(angle_t visangle);

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -188,17 +188,21 @@ int R_PointOnSegSide(fixed_t x, fixed_t y, seg_t * line)
 }
 
 
+// [crispy] turned into a general R_PointToAngle() flavor
+// called with either slope_div = SlopeDivCrispy() from R_PointToAngleCrispy()
+// or slope_div = SlopeDiv() else
 /*
 ===============================================================================
 =
-= R_PointToAngle
+= R_PointToAngleSlope
 =
 ===============================================================================
 */
 
 #define	DBITS		(FRACBITS-SLOPEBITS)
 
-angle_t R_PointToAngle(fixed_t x, fixed_t y)
+angle_t R_PointToAngleSlope(fixed_t x, fixed_t y,
+            int (*slope_div) (unsigned int num, unsigned int den))
 {
     x -= viewx;
     y -= viewy;
@@ -246,11 +250,38 @@ angle_t R_PointToAngle(fixed_t x, fixed_t y)
 }
 
 
+angle_t R_PointToAngle(fixed_t x, fixed_t y)
+{
+    return R_PointToAngleSlope(x, y, SlopeDiv);
+}
+
+// [crispy] overflow-safe R_PointToAngle() flavor
+// called only from R_CheckBBox(), R_AddLine() and P_SegLengths()
+angle_t R_PointToAngleCrispy(fixed_t x, fixed_t y)
+{
+    // [crispy] fix overflows for very long distances
+    int64_t y_viewy = (int64_t)y - viewy;
+    int64_t x_viewx = (int64_t)x - viewx;
+
+    // [crispy] the worst that could happen is e.g. INT_MIN-INT_MAX = 2*INT_MIN
+    if (x_viewx < INT_MIN || x_viewx > INT_MAX ||
+        y_viewy < INT_MIN || y_viewy > INT_MAX)
+    {
+        // [crispy] preserving the angle by halfing the distance in both directions
+        x = x_viewx / 2 + viewx;
+        y = y_viewy / 2 + viewy;
+    }
+
+    return R_PointToAngleSlope(x, y, SlopeDivCrispy);
+}
+
+
 angle_t R_PointToAngle2(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2)
 {
     viewx = x1;
     viewy = y1;
-    return R_PointToAngle(x2, y2);
+    // [crispy] R_PointToAngle2() is never called during rendering
+    return R_PointToAngleSlope(x2, y2, SlopeDiv);
 }
 
 


### PR DESCRIPTION
This will fix possible overflows on walls rendering. Probably it was brought by fixing long wall wobbling, but recently introduced "pseudo-vertexes" (or "render-vertexes" as they called now) by @mikeday0 make this fix very easy.

This glitch is happening in released version 6.0, but appears rarely in general. Faster way to see it is to `VISIT09` (first part of video), and it looks likes this: https://youtu.be/aFf-EdLE9MM