### PR TITLE
Hexen: remove redundant sizeof multipler for fixed colormaps handling

### DIFF
--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -878,7 +878,9 @@ void R_SetupFrame(player_t * player)
     if (player->fixedcolormap)
     {
         fixedcolormap = colormaps + player->fixedcolormap
-            * 256 * sizeof(lighttable_t);
+            // [crispy] sizeof(lighttable_t) not needed in paletted render
+            // and breaks Torch's fixed colormap indexes in true color render
+            * 256 /* * sizeof(lighttable_t)*/;
         walllights = scalelightfixed;
         for (i = 0; i < MAXLIGHTSCALE; i++)
         {


### PR DESCRIPTION
Unlike Heretic, there is no invulnerability colormap in Hexen. However, this redundant `sizeof()` multiplier slightly breaks fixed colormap indexes while using Torch arrtifact: index may go too low, making game map notably darker than it should. This was fixed in Heretic [already](https://github.com/fabiangreffrath/crispy-doom/pull/1111/commits/dad0d47ed01e38218d86196b70f613ec97825ab4), but missed while true color implementation.

Kind thanks to @kitchen-ace for [pointing out](https://github.com/JNechaevsky/international-doom/issues/73).