### PR TITLE
Hexen: don't interpolate mobjs that pass through teleporters

### DIFF
--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -189,6 +189,10 @@ boolean P_TeleportMove(mobj_t * thing, fixed_t x, fixed_t y)
     thing->x = x;
     thing->y = y;
 
+    // [AM] Don't interpolate mobjs that pass
+    //      through teleporters
+    thing->interp = false;
+
     P_SetThingPosition(thing);
 
     return true;


### PR DESCRIPTION
Lexi's comment explains itself, this fixes rendering glitch while silent teleportation effect. Unfortunately, Raven Software's implementation is not even close to be as smooth as it was done in Boom engine, matters no is it capped or uncapped frame rate. 

On first looks it seems that `deltaviewheight` or bob factor is not carried properly to teleport destination, and it was accounted in [Boom implementation](https://github.com/fabiangreffrath/woof/blob/master/src/p_telept.c#L166-L181), but it doesn't seems to be safe to copy-over, extra touching of `P_CalcHeight` _may_ or _will_ cause demo desync. Probably worth to leave leave "as is" for good...

This should fix https://github.com/fabiangreffrath/crispy-doom/issues/1157, kind thanks to @kitchen-ace for pointing out.