### PR TITLE
Get full output from libsamplerate by default

### DIFF
--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -53,7 +53,10 @@ int use_libsamplerate = 1;
 // of the time: with all the Doom IWAD sound effects, at least. If a PWAD
 // is used, clipping might occur.
 
-float libsamplerate_scale = 0.65f;
+// [crispy] Get full output from libsamplerate. Our default is to use linear
+// interpolation, which means the resampling process will not introduce any new
+// clipping. This will also better match vanilla's volume.
+float libsamplerate_scale = 1.0f;
 
 
 #ifndef DISABLE_SDL2MIXER

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -75,7 +75,7 @@ static int show_talk = 1; // [crispy] show subtitles by default
 // but 1 is closer to "use_libsamplerate = 0" which is the default in Choco
 // and causes only a short delay at startup
 int use_libsamplerate = 1;
-float libsamplerate_scale = 0.65;
+float libsamplerate_scale = 1.0f; // [crispy]
 
 char *music_pack_path = NULL;
 char *timidity_cfg_path = NULL;


### PR DESCRIPTION
The default for `use_libsamplerate` is 1 which in turn selects linear interpolation for the resampling process. Unlike windowed sinc, linear interpolation cannot introduce any new clipping into the waveform. Therefore we should use a default of 1.0 for `libsamplerate_scale`. This will give the sound effects a bit of a volume boost compared to the previous default of 0.65, and Crispy should now have better volume matching with other ports.

Closes #1162.