### PR TITLE
Hexen: remove redundant r_angle initialization

### DIFF
--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -218,7 +218,6 @@ void P_LoadSegs(int lump)
         li->v2 = &vertexes[SHORT(ml->v2)];
 
         li->angle = (SHORT(ml->angle)) << 16;
-        li->r_angle = li->angle; // [crispy] initialize rendering angle
         li->offset = (SHORT(ml->offset)) << 16;
         linedef = SHORT(ml->linedef);
         ldef = &lines[linedef];


### PR DESCRIPTION
[This line](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/hexen/p_setup.c#L221) is now redundant, as such rendering-only lines now calculated enterely in `P_SegLengths`, i.e. [here](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/hexen/p_setup.c#L268). 