### PR TITLE
Heretic & Hexen: any key opens the menu when not in a demo

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2221,7 +2221,7 @@ boolean MN_Responder(event_t * event)
     if (!MenuActive)
     {
         // [crispy] don't pop up the menu on other keys during a demo
-        if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
+        if (key == key_menu_activate || gamestate == GS_DEMOSCREEN || (demoplayback && !singledemo))
         {
             MN_ActivateMenu();
             return (true);

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2225,7 +2225,7 @@ boolean MN_Responder(event_t * event)
     if (!MenuActive)
     {
         // [crispy] don't pop up the menu on other keys during a demo
-        if (key == key_menu_activate) //|| gamestate == GS_DEMOSCREEN || demoplayback)
+        if (key == key_menu_activate || gamestate == GS_DEMOSCREEN || (demoplayback && !singledemo))
         {
             MN_ActivateMenu();
             return (true);


### PR DESCRIPTION
Fixes minor regression in #1151
Thanks @mikeday0

I kept it simple and just changed to check against `!singledemo`. Map and fast-forward still bring up the menu in internal demos as a result, but I doubt anyone will care. 