### PR TITLE
Heretic: Use HHEVER lump to set HHE version for HEHACKED lumps

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1188,6 +1188,13 @@ void D_DoomMain(void)
         }
     }
 
+    // [crispy] load version number from HHEVER lump if it exists.
+    // -hhever parm takes priority, even if it's invalid
+    if (W_CheckNumForName("HHEVER") != -1 && !M_ParmExists("-hhever"))
+    {
+        SetHHEVersionFromLump(W_CheckNumForName("HHEVER"));
+    }
+
     if (W_CheckNumForName("HEHACKED") != -1)
     {
         DEH_LoadLumpByName("HEHACKED", true, true);

--- a/src/heretic/deh_htic.c
+++ b/src/heretic/deh_htic.c
@@ -24,6 +24,8 @@
 #include "deh_htic.h"
 #include "info.h"
 #include "m_argv.h"
+#include "w_wad.h" // [crispy]
+#include "z_zone.h" // [crispy]
 
 const char *deh_signatures[] =
 {
@@ -78,6 +80,18 @@ static void SetHHEVersionByName(const char *name)
     {
         fprintf(stderr, "\t%s\n", hhe_versions[i]);
     }
+}
+
+// [crispy] read an HHEVER lump if one exists
+// let SetHHEVersionByName figure out if it's vaild or not
+void SetHHEVersionFromLump(int lumpnum)
+{
+    char *data = NULL;
+
+    data = W_CacheLumpNum(lumpnum, PU_CACHE);
+    SetHHEVersionByName(data);
+
+    return;
 }
 
 // Initialize Heretic(HHE)-specific dehacked bits.

--- a/src/heretic/deh_htic.h
+++ b/src/heretic/deh_htic.h
@@ -45,6 +45,7 @@ void DEH_HereticInit(void);
 int DEH_MapHereticThingType(int type);
 int DEH_MapHereticFrameNumber(int frame);
 void DEH_SuggestHereticVersion(deh_hhe_version_t version);
+void SetHHEVersionFromLump(int lumpnum);
 
 extern deh_hhe_version_t deh_hhe_version;
 


### PR DESCRIPTION
Will resolve #1167 

I chose to implement checking a HHEVER lump; relying on heuristics alone is too ambiguous (though might be beneficial as an addition), and adding the info in the HEHACKED lump itself is too annoying for people who might want to work with HHE and would constantly have to manually edit their patch. 

Outstanding issues:

* I get this warning that I don't know how to fix properly:

  `crispy-doom/src/heretic/d_main.c:1195:9: warning: implicit declaration of function ‘SetHHEVersionFromLump’ [-Wimplicit-function-declaration]`

  including `"deh_htic.h"`, where the function is declared, gives an error instead:

  `crispy-doom/src/heretic/deh_htic.h:53:8: error: unknown type name ‘deh_section_t’`

  I'm probably missing something obvious but I'm not sure what.

* Do I need to sanity-check the HHEVER lump? We only need to ever read 3 bytes from it.

* Right now I've set it to ignore the HHEVER lump if `-hhever` is specified, but there's no technical reason this needs to be the case; it seems fine if you add a patch with `-deh mypatch.hhe -hhever 1.0` and then read more patches from HEHACKED lumps from the wad, with HHEVER set to 1.3. Thoughs/opinions?

  Even with this implementation, it's still possible to load 1.0 patches (the default) outside of a wad without a `-hhever` parameter. I think this is important since that's necessary for autoload without specifying a HHE version.

