### PR TITLE
Hexen: improve line drawing in automap overlay mode

### DIFF
--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -100,9 +100,9 @@ static byte antialias_normal[NUMALIAS][8] = {
 
 // [crispy] gradient table for map overlay mode
 static byte antialias_overlay[NUMALIAS][8] = {
-    {86, 85, 84, 83, 82, 81, 100, 99},
-    {96, 93, 90, 87, 85, 83, 81, 99},
-    {107, 105, 104, 103, 102, 101, 100, 99}
+    {86, 85, 85, 84, 83, 83, 82, 81},
+    {93, 93, 92, 91, 90, 89, 88, 87},
+    {107, 107, 106, 105, 104, 103, 102, 101}
 };
 
 static byte (*antialias)[NUMALIAS][8]; // [crispy]


### PR DESCRIPTION
This was the case when palette indexes were doing right thing, but actual colors are not. Such approach with `1...8` is working fine in normal automap mode because colors are "fading" to parch background color, but situation is a bit different in overlay mode.

This approach slightly reduces amount of smoothing colors, yet preserves reasonable smoothing, making lines slightly less... _broken_ (not sure what's word is more correct here). And the result is: [before](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/6c7ae7ce-ea8a-4ee5-a855-4e812dcb4eb5) and [after](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/d3b1e68f-0b7c-40dd-8f2f-3df9480bdc52). Please note that fading to dark near the screen borders is now reduced, but I believe it's a small price, at least this gives some better visibility.