### PR TITLE
Heretic & Hexen: keep cursor position after deleting a save game

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1200,6 +1200,7 @@ static boolean SCDeleteGame(int option)
     remove(filename);
     free(filename);
 
+    CurrentMenu->oldItPos = CurrentItPos;
     MN_LoadSlotText();
     BorderNeedRefresh = true;
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1198,6 +1198,7 @@ static void SCDeleteGame(int option)
     }
 
     SV_ClearSaveSlot(option);
+    CurrentMenu->oldItPos = CurrentItPos;
     MN_LoadSlotText();
     BorderNeedRefresh = true;
 }


### PR DESCRIPTION
This fixes small issue in Raven menu code when deleting a save game resets cursor position to last actual save (or first slot if no save was made). Small demonstration:

https://github.com/fabiangreffrath/crispy-doom/assets/21193394/bc6cb9f9-6fa3-4bd8-a78c-b6b99c91088a

I'm deleting `5`, `2` and `3` slots (let's count from one, not from zero 🙂), and cursor is jumping to slot `1` after deleting. It behaves same way in Heretic, as menu system is almost identical.