### PR TITLE
Raven: allow multiple jumps over menu items with same first letters

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2428,7 +2428,7 @@ boolean MN_Responder(event_t * event)
                     }
                 }
             }
-            for (i = 0; i < CurrentMenu->itemCount; i++)
+            for (i = 0; i <= CurrentItPos; i++)
             {
                 if (CurrentMenu->items[i].text)
                 {

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2415,6 +2415,19 @@ boolean MN_Responder(event_t * event)
         {
             // Jump to menu item based on first letter:
 
+            // [crispy] allow multiple jumps over menu items with same first letters.
+            for (i = CurrentItPos + 1; i < CurrentMenu->itemCount; i++)
+            {
+                if (CurrentMenu->items[i].text)
+                {
+                    if (toupper(charTyped)
+                        == toupper(DEH_String(CurrentMenu->items[i].text)[0]))
+                    {
+                        CurrentItPos = i;
+                        return (true);
+                    }
+                }
+            }
             for (i = 0; i < CurrentMenu->itemCount; i++)
             {
                 if (CurrentMenu->items[i].text)

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2429,7 +2429,7 @@ boolean MN_Responder(event_t * event)
                     }
                 }
             }
-            for (i = 0; i < CurrentMenu->itemCount; i++)
+            for (i = 0; i <= CurrentItPos; i++)
             {
                 if (CurrentMenu->items[i].text)
                 {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2416,6 +2416,19 @@ boolean MN_Responder(event_t * event)
         }
         else if (charTyped != 0)
         {
+            // [crispy] allow multiple jumps over menu items with same first letters.
+            for (i = CurrentItPos + 1; i < CurrentMenu->itemCount; i++)
+            {
+                if (CurrentMenu->items[i].text)
+                {
+                    if (toupper(charTyped)
+                        == toupper(CurrentMenu->items[i].text[0]))
+                    {
+                        CurrentItPos = i;
+                        return (true);
+                    }
+                }
+            }
             for (i = 0; i < CurrentMenu->itemCount; i++)
             {
                 if (CurrentMenu->items[i].text)


### PR DESCRIPTION
This is a tiny correction to fix tiny oversight in Raven menu system. How to see this oversight in action:

- Go to the standard Options menu, where three menu items with "M" names are placed (Messages, Mouse sensitivity and More).
- Press `M` on a keyboard. Cursor will move to Messages item.
- Press `M` again. Nothing happens, cursor will stay on same menu item.
- Same problem applies to Crispness menu, and this fix will handle it.

In Doom, however, in Options menu cursor will move to the next menu item with same first letter (Messages/Mouse sensitivity or Screen size/Sound volume). My first though such oversight was a leftover from Doom 1.2, but nope, even Doom 0.99 shareware supports multiple jumps.

The approach itself is basically a carbon copy of implementation [from Doom](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/doom/m_menu.c#L3033-L3054), except vanilla Raven menu doesn't play any sounds on keypress jumping and I decided to follow the suite. Note that despite of Heretic doesn't have menu items in HeHacked strings, there is still `DEH_String` parser, just in case and just like in original `for` vector few lines below.

It is also possible to implement support for choosing save/load slot via pressing number key (yes, it is possible in Doom!), but not sure it is really needed, especially without too much code changes. I [did it](https://github.com/JNechaevsky/international-doom/commit/4b9746405dc76e830a880b957b1d6d8c82a213e7) in Inter, but menu system itself is a little bit extended there.

P.S. I wonder if it can be simplified. The only difference in the first part of `for` vectors: `i = CurrentItPos + 1` vs `i = 0`, the rest of conditions are identical. Using a macro is not a real simplification here, and moving `{...}` vector condition doesn't seems to be a good idea. But are there any other possible tricks existing? 🤔