### PR TITLE
Strife: add true color support

### DIFF
--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -544,7 +544,7 @@ R_DrawVisSprite
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOver;
+    blendfunc = I_BlendOverTranmap;
 #endif
 }
 
@@ -817,7 +817,7 @@ void R_ProjectSprite (mobj_t* thing)
     // [crispy] translucent sprites
     if (thing->flags & MF_TRANSLUCENT)
     {
-	vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAdd : I_BlendOver;
+	vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAdd : I_BlendOverTranmap;
     }
 #endif
 }
@@ -1079,7 +1079,7 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
     {
         vis->mobjflags |= MF_TRANSLUCENT;
 #ifdef CRISPY_TRUECOLOR
-        vis->blendfunc = I_BlendOver; // I_BlendAdd;
+        vis->blendfunc = I_BlendOverTranmap; // I_BlendAdd;
 #endif
     }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -2187,6 +2187,16 @@ const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg)
 	return amask | r | g | b;
 }
 
+// [crispy] Perform screen crossfading effect by given amount of opacity, used for Strife
+const pixel_t I_BlendOverCrossfade (const pixel_t bg, const pixel_t fg, const int amount)
+{
+	const uint32_t r = ((amount * (fg & rmask) + (0xff - amount) * (bg & rmask)) >> 8) & rmask;
+	const uint32_t g = ((amount * (fg & gmask) + (0xff - amount) * (bg & gmask)) >> 8) & gmask;
+	const uint32_t b = ((amount * (fg & bmask) + (0xff - amount) * (bg & bmask)) >> 8) & bmask;
+
+	return amask | r | g | b;
+}
+
 const pixel_t (*blendfunc) (const pixel_t fg, const pixel_t bg) = I_BlendOver;
 
 const pixel_t I_MapRGB (const uint8_t r, const uint8_t g, const uint8_t b)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -106,6 +106,8 @@ static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
 static const uint8_t blend_alpha_tinttab = 0x60; // 96
 static const uint8_t blend_alpha_alttinttab = 0x8E; // 142
+static const uint8_t blend_alpha_xlatab = 0xB2;// 178 (70% opacity)
+static const uint8_t blend_alpha_altxlatab = 0x40; // 64 (25% opacity)
 extern pixel_t* pal_color; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
@@ -2161,6 +2163,26 @@ const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg)
 	const uint32_t r = ((blend_alpha_alttinttab * (fg & rmask) + (0xff - blend_alpha_alttinttab) * (bg & rmask)) >> 8) & rmask;
 	const uint32_t g = ((blend_alpha_alttinttab * (fg & gmask) + (0xff - blend_alpha_alttinttab) * (bg & gmask)) >> 8) & gmask;
 	const uint32_t b = ((blend_alpha_alttinttab * (fg & bmask) + (0xff - blend_alpha_alttinttab) * (bg & bmask)) >> 8) & bmask;
+
+	return amask | r | g | b;
+}
+
+// [crispy] More opaque (70%) XLATAB blending emulation, used for Strife
+const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg)
+{
+	const uint32_t r = ((blend_alpha_xlatab * (fg & rmask) + (0xff - blend_alpha_xlatab) * (bg & rmask)) >> 8) & rmask;
+	const uint32_t g = ((blend_alpha_xlatab * (fg & gmask) + (0xff - blend_alpha_xlatab) * (bg & gmask)) >> 8) & gmask;
+	const uint32_t b = ((blend_alpha_xlatab * (fg & bmask) + (0xff - blend_alpha_xlatab) * (bg & bmask)) >> 8) & bmask;
+
+	return amask | r | g | b;
+}
+
+// [crispy] Less opaque (25%) XLATAB blending emulation, used for Strife
+const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg)
+{
+	const uint32_t r = ((blend_alpha_altxlatab * (fg & rmask) + (0xff - blend_alpha_altxlatab) * (bg & rmask)) >> 8) & rmask;
+	const uint32_t g = ((blend_alpha_altxlatab * (fg & gmask) + (0xff - blend_alpha_altxlatab) * (bg & gmask)) >> 8) & gmask;
+	const uint32_t b = ((blend_alpha_altxlatab * (fg & bmask) + (0xff - blend_alpha_altxlatab) * (bg & bmask)) >> 8) & bmask;
 
 	return amask | r | g | b;
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -106,7 +106,7 @@ static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 static const uint8_t blend_alpha = 0xa8;
 static const uint8_t blend_alpha_tinttab = 0x60; // 96
 static const uint8_t blend_alpha_alttinttab = 0x8E; // 142
-static const uint8_t blend_alpha_xlatab = 0xB2;// 178 (70% opacity)
+static const uint8_t blend_alpha_xlatab = 0xC0;// 192 (75% opacity)
 static const uint8_t blend_alpha_altxlatab = 0x40; // 64 (25% opacity)
 extern pixel_t* pal_color; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
@@ -2167,7 +2167,7 @@ const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg)
 	return amask | r | g | b;
 }
 
-// [crispy] More opaque (70%) XLATAB blending emulation, used for Strife
+// [crispy] More opaque (75%) XLATAB blending emulation, used for Strife
 const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg)
 {
 	const uint32_t r = ((blend_alpha_xlatab * (fg & rmask) + (0xff - blend_alpha_xlatab) * (bg & rmask)) >> 8) & rmask;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -103,11 +103,6 @@ static SDL_Texture *graypane = NULL;
 static SDL_Texture *orngpane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
-static const uint8_t blend_alpha = 0xa8;
-static const uint8_t blend_alpha_tinttab = 0x60; // 96
-static const uint8_t blend_alpha_alttinttab = 0x8E; // 142
-static const uint8_t blend_alpha_xlatab = 0xC0;// 192 (75% opacity)
-static const uint8_t blend_alpha_altxlatab = 0x40; // 64 (25% opacity)
 extern pixel_t* pal_color; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
@@ -2138,57 +2133,8 @@ const pixel_t I_BlendDark (const pixel_t bg, const int d)
 	return amask | sag | srb;
 }
 
-const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg)
-{
-	const uint32_t r = ((blend_alpha * (fg & rmask) + (0xff - blend_alpha) * (bg & rmask)) >> 8) & rmask;
-	const uint32_t g = ((blend_alpha * (fg & gmask) + (0xff - blend_alpha) * (bg & gmask)) >> 8) & gmask;
-	const uint32_t b = ((blend_alpha * (fg & bmask) + (0xff - blend_alpha) * (bg & bmask)) >> 8) & bmask;
-
-	return amask | r | g | b;
-}
-
-// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
-const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg)
-{
-	const uint32_t r = ((blend_alpha_tinttab * (fg & rmask) + (0xff - blend_alpha_tinttab) * (bg & rmask)) >> 8) & rmask;
-	const uint32_t g = ((blend_alpha_tinttab * (fg & gmask) + (0xff - blend_alpha_tinttab) * (bg & gmask)) >> 8) & gmask;
-	const uint32_t b = ((blend_alpha_tinttab * (fg & bmask) + (0xff - blend_alpha_tinttab) * (bg & bmask)) >> 8) & bmask;
-
-	return amask | r | g | b;
-}
-
-// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
-const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg)
-{
-	const uint32_t r = ((blend_alpha_alttinttab * (fg & rmask) + (0xff - blend_alpha_alttinttab) * (bg & rmask)) >> 8) & rmask;
-	const uint32_t g = ((blend_alpha_alttinttab * (fg & gmask) + (0xff - blend_alpha_alttinttab) * (bg & gmask)) >> 8) & gmask;
-	const uint32_t b = ((blend_alpha_alttinttab * (fg & bmask) + (0xff - blend_alpha_alttinttab) * (bg & bmask)) >> 8) & bmask;
-
-	return amask | r | g | b;
-}
-
-// [crispy] More opaque (75%) XLATAB blending emulation, used for Strife
-const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg)
-{
-	const uint32_t r = ((blend_alpha_xlatab * (fg & rmask) + (0xff - blend_alpha_xlatab) * (bg & rmask)) >> 8) & rmask;
-	const uint32_t g = ((blend_alpha_xlatab * (fg & gmask) + (0xff - blend_alpha_xlatab) * (bg & gmask)) >> 8) & gmask;
-	const uint32_t b = ((blend_alpha_xlatab * (fg & bmask) + (0xff - blend_alpha_xlatab) * (bg & bmask)) >> 8) & bmask;
-
-	return amask | r | g | b;
-}
-
-// [crispy] Less opaque (25%) XLATAB blending emulation, used for Strife
-const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg)
-{
-	const uint32_t r = ((blend_alpha_altxlatab * (fg & rmask) + (0xff - blend_alpha_altxlatab) * (bg & rmask)) >> 8) & rmask;
-	const uint32_t g = ((blend_alpha_altxlatab * (fg & gmask) + (0xff - blend_alpha_altxlatab) * (bg & gmask)) >> 8) & gmask;
-	const uint32_t b = ((blend_alpha_altxlatab * (fg & bmask) + (0xff - blend_alpha_altxlatab) * (bg & bmask)) >> 8) & bmask;
-
-	return amask | r | g | b;
-}
-
-// [crispy] Perform screen crossfading effect by given amount of opacity, used for Strife
-const pixel_t I_BlendOverCrossfade (const pixel_t bg, const pixel_t fg, const int amount)
+// [crispy] Main overlay blending function
+const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg, const int amount)
 {
 	const uint32_t r = ((amount * (fg & rmask) + (0xff - amount) * (bg & rmask)) >> 8) & rmask;
 	const uint32_t g = ((amount * (fg & gmask) + (0xff - amount) * (bg & gmask)) >> 8) & gmask;
@@ -2197,7 +2143,37 @@ const pixel_t I_BlendOverCrossfade (const pixel_t bg, const pixel_t fg, const in
 	return amask | r | g | b;
 }
 
-const pixel_t (*blendfunc) (const pixel_t fg, const pixel_t bg) = I_BlendOver;
+// [crispy] TRANMAP blending emulation, used for Doom
+const pixel_t I_BlendOverTranmap (const pixel_t bg, const pixel_t fg)
+{
+	return I_BlendOver(bg, fg, 224); // 168 (66% opacity)
+}
+
+// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
+const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg)
+{
+	return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
+}
+
+// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
+const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg)
+{
+	return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
+}
+
+// [crispy] More opaque XLATAB blending emulation, used for Strife
+const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg)
+{
+	return I_BlendOver(bg, fg, 0xC0); // 192 (75% opacity)
+}
+
+// [crispy] Less opaque ("Alt") XLATAB blending emulation, used for Strife
+const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg)
+{
+	return I_BlendOver(bg, fg, 0x40); // 64 (25% opacity)
+}
+
+const pixel_t (*blendfunc) (const pixel_t fg, const pixel_t bg) = I_BlendOverTranmap;
 
 const pixel_t I_MapRGB (const uint8_t r, const uint8_t g, const uint8_t b)
 {

--- a/src/strife/am_map.c
+++ b/src/strife/am_map.c
@@ -49,7 +49,12 @@ extern boolean inhelpscreens; // [crispy]
 
 
 // Automap colors
+#ifndef CRISPY_TRUECOLOR
 #define BACKGROUND      240         // haleyjd [STRIFE]
+#else
+// [JN] For some reason, 240 in true color showing WHITE color.
+#define BACKGROUND      0
+#endif
 #define WALLCOLORS      5           // villsa [STRIFE]
 #define WALLRANGE       16
 #define TSWALLCOLORS    16
@@ -1235,7 +1240,12 @@ AM_drawFline_Vanilla
 	return;
     }
 
-#define PUTDOT(xx,yy,cc) fb[(yy)*f_w+(xx)]=(cc)
+#define PUTDOT_RAW(xx,yy,cc) fb[(yy)*f_w+(xx)]=(cc)
+#ifndef CRISPY_TRUECOLOR
+#define PUTDOT(xx,yy,cc) PUTDOT_RAW(xx,yy,cc)
+#else
+#define PUTDOT(xx,yy,cc) PUTDOT_RAW(xx,yy,(pal_color[(cc)]))
+#endif
 
     dx = fl->b.x - fl->a.x;
     ax = 2 * (dx<0 ? -dx : dx);
@@ -1307,7 +1317,7 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
        the line and so needs no weighting */
     /* Always write the raw color value because we've already performed the necessary lookup
      * into colormap */
-    PUTDOT(X0, Y0, BaseColor[0]);
+    PUTDOT_RAW(X0, Y0, BaseColor[0]);
 
     if ((DeltaX = X1 - X0) >= 0)
     {
@@ -1327,7 +1337,7 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
         while (DeltaX-- != 0)
         {
             X0 += XDir;
-            PUTDOT(X0, Y0, BaseColor[0]);
+            PUTDOT_RAW(X0, Y0, BaseColor[0]);
         }
         return;
     }
@@ -1337,7 +1347,7 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
         do
         {
             Y0++;
-            PUTDOT(X0, Y0, BaseColor[0]);
+            PUTDOT_RAW(X0, Y0, BaseColor[0]);
         }
         while (--DeltaY != 0);
         return;
@@ -1349,7 +1359,7 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
         {
             X0 += XDir;
             Y0++;
-            PUTDOT(X0, Y0, BaseColor[0]);
+            PUTDOT_RAW(X0, Y0, BaseColor[0]);
         }
         while (--DeltaY != 0);
         return;
@@ -1383,12 +1393,12 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
                intensity weighting for this pixel, and the complement of the
                weighting for the paired pixel */
             Weighting = ErrorAcc >> IntensityShift;
-            PUTDOT(X0, Y0, BaseColor[Weighting]);
-            PUTDOT(X0 + XDir, Y0, BaseColor[(Weighting ^ WeightingComplementMask)]);
+            PUTDOT_RAW(X0, Y0, BaseColor[Weighting]);
+            PUTDOT_RAW(X0 + XDir, Y0, BaseColor[(Weighting ^ WeightingComplementMask)]);
         }
         /* Draw the final pixel, which is always exactly intersected by the line
            and so needs no weighting */
-        PUTDOT(X1, Y1, BaseColor[0]);
+        PUTDOT_RAW(X1, Y1, BaseColor[0]);
         return;
     }
     /* It's an X-major line; calculate 16-bit fixed-point fractional part of a
@@ -1410,13 +1420,13 @@ static void AM_drawFline_Smooth(fline_t* fl, int color)
            intensity weighting for this pixel, and the complement of the
            weighting for the paired pixel */
         Weighting = ErrorAcc >> IntensityShift;
-        PUTDOT(X0, Y0, BaseColor[Weighting]);
-        PUTDOT(X0, Y0 + 1, BaseColor[(Weighting ^ WeightingComplementMask)]);
+        PUTDOT_RAW(X0, Y0, BaseColor[Weighting]);
+        PUTDOT_RAW(X0, Y0 + 1, BaseColor[(Weighting ^ WeightingComplementMask)]);
 
     }
     /* Draw the final pixel, which is always exactly intersected by the line
        and so needs no weighting */
-    PUTDOT(X1, Y1, BaseColor[0]);
+    PUTDOT_RAW(X1, Y1, BaseColor[0]);
 }
 
 //

--- a/src/strife/am_map.c
+++ b/src/strife/am_map.c
@@ -49,12 +49,7 @@ extern boolean inhelpscreens; // [crispy]
 
 
 // Automap colors
-#ifndef CRISPY_TRUECOLOR
 #define BACKGROUND      240         // haleyjd [STRIFE]
-#else
-// [JN] For some reason, 240 in true color showing WHITE color.
-#define BACKGROUND      0
-#endif
 #define WALLCOLORS      5           // villsa [STRIFE]
 #define WALLRANGE       16
 #define TSWALLCOLORS    16
@@ -1895,7 +1890,11 @@ void AM_Drawer (void)
 
     if (!crispy->automapoverlay)
     {
+#ifndef CRISPY_TRUECOLOR
         AM_clearFB(BACKGROUND);
+#else
+        AM_clearFB(pal_color[BACKGROUND]);
+#endif
         pspr_interp = false; // [crispy] interpolate weapon bobbing
     }
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -2034,7 +2034,7 @@ void D_DoomMain (void)
     // [crispy] Initialize and generate gamma-correction levels and
     // colormaps/pal_color arrays before introduction sequence.
     I_SetGammaTable();
-    R_InitColormaps ();
+    R_InitColormaps();
 
     // haleyjd 20110206 [STRIFE] Startup the introduction sequence
     D_InitIntroSequence();

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -2038,6 +2038,14 @@ void D_DoomMain (void)
 
     I_GraphicsCheckCommandLine();
 
+    // [crispy] we have to predefine pal_colors[] array for proper
+    // drawing of intro sequence
+    // [JN] TODO - probably unoptimal, R_InitPalColors is called
+    // second time in R_InitColormaps, otherwise patches will be
+    // drawn with solid black color.
+#ifdef CRISPY_TRUECOLOR
+    R_InitPalColors();
+#endif
     // haleyjd 20110206 [STRIFE] Startup the introduction sequence
     D_InitIntroSequence();
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -547,6 +547,9 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_soundfix",        &crispy->soundfix);
     M_BindIntVariable("crispy_soundfull",       &crispy->soundfull);
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
+#ifdef CRISPY_TRUECOLOR
+    M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+#endif
     M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);
     M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -2032,14 +2032,11 @@ void D_DoomMain (void)
 
     I_GraphicsCheckCommandLine();
 
-    // [crispy] we have to predefine pal_colors[] array for proper
-    // drawing of intro sequence
-    // [JN] TODO - probably unoptimal, R_InitPalColors is called
-    // second time in R_InitColormaps, otherwise patches will be
-    // drawn with solid black color.
-#ifdef CRISPY_TRUECOLOR
+    // [crispy] Initialize and generate gamma-correction levels and
+    // pal_color[] array (TrueColor only) before introduction sequence.
+    I_SetGammaTable();
     R_InitPalColors();
-#endif
+
     // haleyjd 20110206 [STRIFE] Startup the introduction sequence
     D_InitIntroSequence();
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1363,7 +1363,6 @@ static void D_IntroBackground(void)
     // Draw a 95-pixel rect from STARTUP0 starting at y=57 to (0,41) on the
     // screen (this was a memcpy directly to 0xA3340 in low DOS memory)
     // [crispy] use scaled function
-    // [JN] TODO - update for true color.
     V_DrawScaledBlock(0, 41, 320, 95, rawgfx_startup0 + (320*57));
 }
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -231,7 +231,13 @@ void D_Display (void)
     }
 
     // save the current screen if about to wipe
+#ifndef CRISPY_TRUECOLOR
     if (gamestate != wipegamestate)
+#else
+    // [JN] TODO - implement support for true color,
+    // wiping/fading via XLATAB is not possible!
+    if (gamestate != wipegamestate && false)
+#endif
     {
         screenwipe = true; // [crispy]
         wipe = true;
@@ -292,7 +298,11 @@ void D_Display (void)
 
     // clean up border stuff
     if (gamestate != oldgamestate && gamestate != GS_LEVEL)
+#ifndef CRISPY_TRUECOLOR
         I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
+#else
+        I_SetPalette (0);
+#endif
 
     // see if the border needs to be initially drawn
     if (gamestate == GS_LEVEL && oldgamestate != GS_LEVEL)
@@ -1350,6 +1360,7 @@ static void D_IntroBackground(void)
     // Draw a 95-pixel rect from STARTUP0 starting at y=57 to (0,41) on the
     // screen (this was a memcpy directly to 0xA3340 in low DOS memory)
     // [crispy] use scaled function
+    // [JN] TODO - update for true color.
     V_DrawScaledBlock(0, 41, 320, 95, rawgfx_startup0 + (320*57));
 }
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -2033,9 +2033,9 @@ void D_DoomMain (void)
     I_GraphicsCheckCommandLine();
 
     // [crispy] Initialize and generate gamma-correction levels and
-    // pal_color[] array (TrueColor only) before introduction sequence.
+    // colormaps/pal_color arrays before introduction sequence.
     I_SetGammaTable();
-    R_InitPalColors();
+    R_InitColormaps ();
 
     // haleyjd 20110206 [STRIFE] Startup the introduction sequence
     D_InitIntroSequence();

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -231,15 +231,10 @@ void D_Display (void)
     }
 
     // save the current screen if about to wipe
-#ifndef CRISPY_TRUECOLOR
     if (gamestate != wipegamestate)
-#else
-    // [JN] TODO - implement support for true color,
-    // wiping/fading via XLATAB is not possible!
-    if (gamestate != wipegamestate && false)
-#endif
     {
         screenwipe = true; // [crispy]
+        fade_safe_tics = CROSSFADETICS; // [crispy] arm fail-safe crossfade counter
         wipe = true;
         wipe_StartScreen(0, 0, SCREENWIDTH, SCREENHEIGHT);
     }

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -234,7 +234,6 @@ void D_Display (void)
     if (gamestate != wipegamestate)
     {
         screenwipe = true; // [crispy]
-        fade_safe_tics = CROSSFADETICS; // [crispy] arm fail-safe crossfade counter
         wipe = true;
         wipe_StartScreen(0, 0, SCREENWIDTH, SCREENHEIGHT);
     }

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -19,8 +19,8 @@
 #include <string.h>
 
 #include "z_zone.h"
-#include "v_trans.h" // [crispy] blending functions
 #include "i_video.h"
+#include "v_trans.h" // [crispy] blending functions
 #include "v_video.h"
 #include "m_random.h"
 

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -109,7 +109,9 @@ wipe_doColorXForm
 #ifndef CRISPY_TRUECOLOR
             *cur_screen = xlatab[(*cur_screen << 8) + *end_screen];
 #else
-            *cur_screen = I_BlendOverXlatab(*cur_screen, *end_screen);
+            // [crispy] perform crossfading effect with 13 given opacity steps, multipled by 19:
+            // 247, 228, 209, 190, 171, 152, 133, 114, 95, 76, 57, 38, 19
+            *cur_screen = I_BlendOverCrossfade(*end_screen, *cur_screen, fade_safe_tics * 19);
 #endif
         }
         ++cur_screen;

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -111,7 +111,7 @@ wipe_doColorXForm
 #else
             // [crispy] perform crossfading effect with 13 given opacity steps, multipled by 19:
             // 247, 228, 209, 190, 171, 152, 133, 114, 95, 76, 57, 38, 19
-            *cur_screen = I_BlendOverCrossfade(*end_screen, *cur_screen, fade_safe_tics * 19);
+            *cur_screen = I_BlendOver(*end_screen, *cur_screen, fade_safe_tics * 19);
 #endif
         }
         ++cur_screen;

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -43,8 +43,7 @@ static pixel_t*	wipe_scr_end;
 static pixel_t*	wipe_scr;
 
 // [crispy] Additional fail-safe counter for performing crossfade effect.
-// Full crossfading takes 13 game tics and counter is armed in D_Display.
-int fade_safe_tics;
+static int fade_counter;
 
 void
 wipe_shittyColMajorXform
@@ -76,6 +75,9 @@ wipe_initColorXForm
   int	ticks )
 {
     memcpy(wipe_scr, wipe_scr_start, width*height*sizeof(*wipe_scr));
+    // [crispy] arm fail-safe crossfade counter with
+    // 13 screen transitions, "zero" count won't be used.
+    fade_counter = 14;
     return 0;
 }
 
@@ -99,11 +101,11 @@ wipe_doColorXForm
     boolean changed = false;
 
     // [crispy] reduce fail-safe crossfade counter tics
-    fade_safe_tics--;
+    fade_counter--;
 
     for(i = pix; i > 0; i--)
     {
-        if(*cur_screen != *end_screen && fade_safe_tics)
+        if(*cur_screen != *end_screen && fade_counter)
         {
             changed = true;
 #ifndef CRISPY_TRUECOLOR
@@ -111,7 +113,7 @@ wipe_doColorXForm
 #else
             // [crispy] perform crossfading effect with 13 given opacity steps, multipled by 19:
             // 247, 228, 209, 190, 171, 152, 133, 114, 95, 76, 57, 38, 19
-            *cur_screen = I_BlendOver(*end_screen, *cur_screen, fade_safe_tics * 19);
+            *cur_screen = I_BlendOver(*end_screen, *cur_screen, fade_counter * 19);
 #endif
         }
         ++cur_screen;

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -283,14 +283,8 @@ wipe_ScreenWipe
     {
 	go = 1;
         // haleyjd 20110629 [STRIFE]: We *must* use a temp buffer here.
-#ifndef CRISPY_TRUECOLOR
-	wipe_scr = (pixel_t *) Z_Malloc(width*height, PU_STATIC, 0); // DEBUG
+	wipe_scr = (pixel_t *) Z_Malloc(width*height*sizeof(*wipe_scr), PU_STATIC, 0); // DEBUG
 	//wipe_scr = I_VideoBuffer;
-#else
-	// [crispy] In TrueColor render perform everything in common buffer.
-	// Otherwise serious malloc errors will happen.
-	wipe_scr = I_VideoBuffer;
-#endif
 	(*wipes[wipeno*3])(width, height, ticks);
     }
 
@@ -298,10 +292,8 @@ wipe_ScreenWipe
     V_MarkRect(0, 0, width, height);
     rc = (*wipes[wipeno*3+1])(width, height, ticks);
 
-#ifndef CRISPY_TRUECOLOR
     // haleyjd 20110629 [STRIFE]: Copy temp buffer to the real screen.
     V_DrawBlock(x, y, width, height, wipe_scr);
-#endif
 
     // final stuff
     if (rc)

--- a/src/strife/f_wipe.h
+++ b/src/strife/f_wipe.h
@@ -60,8 +60,4 @@ wipe_ScreenWipe
   int		height,
   int		ticks );
 
-// [crispy] Additional fail-safe counter for performing crossfade effect.
-#define CROSSFADETICS  13;
-extern int fade_safe_tics;
-
 #endif

--- a/src/strife/f_wipe.h
+++ b/src/strife/f_wipe.h
@@ -60,4 +60,8 @@ wipe_ScreenWipe
   int		height,
   int		ticks );
 
+// [crispy] Additional fail-safe counter for performing crossfade effect.
+#define CROSSFADETICS  13;
+extern int fade_safe_tics;
+
 #endif

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2719,7 +2719,7 @@ boolean M_Responder (event_t* ev)
 #ifndef CRISPY_TRUECOLOR
             I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
 #else
-            I_SetPalette (0);
+            I_SetPalette(0);
             R_InitColormaps();
             inhelpscreens = true;
             R_FillBackScreen();

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2719,13 +2719,11 @@ boolean M_Responder (event_t* ev)
 #ifndef CRISPY_TRUECOLOR
             I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
 #else
-            {
             I_SetPalette (0);
             R_InitColormaps();
             inhelpscreens = true;
             R_FillBackScreen();
             viewactive = false;
-            }
 #endif
             return true;
         }

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -1395,7 +1395,8 @@ void M_DrawMouse(void)
 // [crispy] Crispness menu
 static void M_DrawCrispnessBackground(void)
 {
-    byte *src, *dest;
+    byte *src;
+    pixel_t *dest;
 
     src = W_CacheLumpName(back_flat, PU_CACHE);
     dest = I_VideoBuffer;
@@ -2715,7 +2716,18 @@ boolean M_Responder (event_t* ev)
             if (crispy->gamma > 4+13) // [crispy] intermediate gamma levels
                 crispy->gamma = 0;
             players[consoleplayer].message = DEH_String(gammamsg[crispy->gamma]);
+#ifndef CRISPY_TRUECOLOR
             I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
+#else
+            {
+            // [JN] TODO - externalize R_InitColormaps() to header file.
+            extern void R_InitColormaps (void);
+            I_SetPalette (0);
+            R_InitColormaps();
+            inhelpscreens = true;
+            R_FillBackScreen();
+            }
+#endif
             return true;
         }
         else if(gameversion == exe_strife_1_31 && key == key_spy)

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2724,6 +2724,7 @@ boolean M_Responder (event_t* ev)
             R_InitColormaps();
             inhelpscreens = true;
             R_FillBackScreen();
+            viewactive = false;
             }
 #endif
             return true;

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2720,8 +2720,6 @@ boolean M_Responder (event_t* ev)
             I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
 #else
             {
-            // [JN] TODO - externalize R_InitColormaps() to header file.
-            extern void R_InitColormaps (void);
             I_SetPalette (0);
             R_InitColormaps();
             inhelpscreens = true;

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -766,16 +766,6 @@ void R_InitColormaps (void)
 	}
 
 	W_ReleaseLumpName("COLORMAP");
-	W_ReleaseLumpName("PLAYPAL");
-#endif
-}
-
-void R_InitPalColors (void)
-{
-#ifdef CRISPY_TRUECOLOR
-	int i, j = 0;
-	byte r, g, b;
-	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
 	if (!pal_color)
 	{
@@ -847,7 +837,9 @@ void R_InitData (void)
     else
         D_IntroTick();
 
-    R_InitColormaps ();
+    // [crispy] Moved to D_DoomMain for color arrays
+    // initialization before introduction sequence.
+    // R_InitColormaps ();
     // [crispy] Initialize color translation and color string tables.
     R_InitHSVColors ();
 }

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -767,12 +767,12 @@ void R_InitColormaps (void)
 
 	W_ReleaseLumpName("COLORMAP");
 	W_ReleaseLumpName("PLAYPAL");
-	R_InitPalColors();
 #endif
 }
 
 void R_InitPalColors (void)
 {
+#ifdef CRISPY_TRUECOLOR
 	int i, j = 0;
 	byte r, g, b;
 	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
@@ -792,6 +792,7 @@ void R_InitPalColors (void)
 	}
 
 	W_ReleaseLumpName("PLAYPAL");
+#endif
 }
 
 // [crispy] initialize color translation and color string tables
@@ -829,8 +830,6 @@ static void R_InitHSVColors (void)
 void R_InitData (void)
 {
     R_InitTextures ();
-    // [crispy] Initialize and generate gamma-correction levels.
-    I_SetGammaTable();
     if(devparm)
         printf (".");
     else

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -726,6 +726,18 @@ void R_InitColormaps (void)
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}
 		}
+
+		// [crispy] Sigil weapon effect (c == COLORMAPS)
+		for (i = 0; i < 256; i++)
+		{
+			const byte gray = 0xff -
+			     (byte) (0.299 * playpal[3 * i + 0] +
+			             0.587 * playpal[3 * i + 1] +
+			             0.114 * playpal[3 * i + 2]);
+			r = g = b = gamma2table[crispy->gamma][gray];
+
+			colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+		}
 	}
 	else
 	{

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -727,11 +727,11 @@ void R_InitColormaps (void)
 				}
 				else
 				{
-					// [JN] Vanilla Strife is using COLORMAP indexes 224-255 without fading to black
+					// [crispy] Vanilla Strife is using COLORMAP columns 224-255 without fading to black
 					// so they work as brightmaps. To replicate it, lock such indexes on first light level.
-					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] + gamma2table[crispy->gamma][0] * scale;
-					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] + gamma2table[crispy->gamma][0] * scale;
-					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] + gamma2table[crispy->gamma][0] * scale;
+					r = gamma2table[crispy->gamma][playpal[3 * k + 0]];
+					g = gamma2table[crispy->gamma][playpal[3 * k + 1]];
+					b = gamma2table[crispy->gamma][playpal[3 * k + 2]];
 				}
 
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -719,9 +719,20 @@ void R_InitColormaps (void)
 			{
 				const byte k = colormap[i];
 
-				r = gamma2table[crispy->gamma][playpal[3 * k + 0]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
-				g = gamma2table[crispy->gamma][playpal[3 * k + 1]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
-				b = gamma2table[crispy->gamma][playpal[3 * k + 2]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+				// [JN] Vanilla Strife is using COLORMAP indexes 224-255 without fading to black
+				// so they work as brightmaps. To replicate it, lock such indexes on first light level.
+				if (i > 223)
+				{
+					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] + gamma2table[crispy->gamma][0] * scale;
+					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] + gamma2table[crispy->gamma][0] * scale;
+					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] + gamma2table[crispy->gamma][0] * scale;
+				}
+				else
+				{
+					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+				}
 
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
 			}

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -719,19 +719,19 @@ void R_InitColormaps (void)
 			{
 				const byte k = colormap[i];
 
-				// [JN] Vanilla Strife is using COLORMAP indexes 224-255 without fading to black
-				// so they work as brightmaps. To replicate it, lock such indexes on first light level.
-				if (i > 223)
-				{
-					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] + gamma2table[crispy->gamma][0] * scale;
-					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] + gamma2table[crispy->gamma][0] * scale;
-					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] + gamma2table[crispy->gamma][0] * scale;
-				}
-				else
+				if (i < 224)
 				{
 					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
 					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
 					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+				}
+				else
+				{
+					// [JN] Vanilla Strife is using COLORMAP indexes 224-255 without fading to black
+					// so they work as brightmaps. To replicate it, lock such indexes on first light level.
+					r = gamma2table[crispy->gamma][playpal[3 * k + 0]] + gamma2table[crispy->gamma][0] * scale;
+					g = gamma2table[crispy->gamma][playpal[3 * k + 1]] + gamma2table[crispy->gamma][0] * scale;
+					b = gamma2table[crispy->gamma][playpal[3 * k + 2]] + gamma2table[crispy->gamma][0] * scale;
 				}
 
 				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -157,7 +157,8 @@ fixed_t*	spritewidth;
 fixed_t*	spriteoffset;
 fixed_t*	spritetopoffset;
 
-lighttable_t	*colormaps, *pal_color;
+lighttable_t	*colormaps;
+lighttable_t	*pal_color; // [crispy] array holding palette colors for true color mode
 
 
 //
@@ -690,38 +691,101 @@ void R_InitSpriteLumps (void)
 //
 void R_InitColormaps (void)
 {
+#ifndef CRISPY_TRUECOLOR
     int	lump;
 
     // Load in the light tables, 256 byte align tables.
     lump = W_GetNumForName(DEH_String("COLORMAP"));
     colormaps = W_CacheLumpNum(lump, PU_STATIC);
-    pal_color = colormaps;
+#else
+	int c, i, j = 0;
+	byte r, g, b;
 
-    // [crispy] initialize color translation and color strings tables
-    {
-        byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-        char c[3];
-        int i, j;
+	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 
-        if (!crstr)
-            crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
+	if (!colormaps)
+	{
+		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);
+	}
 
-        // [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
-        for (i = 0; i < CRMAX - 2; i++)
-        {
-            for (j = 0; j < 256; j++)
-            {
-                cr[i][j] = V_Colorize(playpal, i, j, false);
-            }
+	if (crispy->truecolor)
+	{
+		for (c = 0; c < NUMCOLORMAPS; c++)
+		{
+			const float scale = 1. * c / NUMCOLORMAPS;
 
-            M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
-            crstr[i] = M_StringDuplicate(c);
-        }
+			for (i = 0; i < 256; i++)
+			{
+				const byte k = colormap[i];
 
-        W_ReleaseLumpName("PLAYPAL");
-    }
+				r = gamma2table[crispy->gamma][playpal[3 * k + 0]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+				g = gamma2table[crispy->gamma][playpal[3 * k + 1]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+				b = gamma2table[crispy->gamma][playpal[3 * k + 2]] * (1. - scale) + gamma2table[crispy->gamma][0] * scale;
+
+				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+			}
+		}
+	}
+	else
+	{
+		for (c = 0; c <= NUMCOLORMAPS; c++)
+		{
+			for (i = 0; i < 256; i++)
+			{
+				r = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 0]] & ~3;
+				g = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 1]] & ~3;
+				b = gamma2table[crispy->gamma][playpal[3 * colormap[c * 256 + i] + 2]] & ~3;
+
+				colormaps[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+			}
+		}
+	}
+
+	W_ReleaseLumpName("COLORMAP");
+
+	if (!pal_color)
+	{
+		pal_color = (pixel_t*) Z_Malloc(256 * sizeof(pixel_t), PU_STATIC, 0);
+	}
+
+	for (i = 0, j = 0; i < 256; i++)
+	{
+		r = gamma2table[crispy->gamma][playpal[3 * i + 0]];
+		g = gamma2table[crispy->gamma][playpal[3 * i + 1]];
+		b = gamma2table[crispy->gamma][playpal[3 * i + 2]];
+
+		pal_color[j++] = 0xff000000 | (r << 16) | (g << 8) | b;
+	}
+
+	W_ReleaseLumpName("PLAYPAL");
+#endif
 }
 
+// [crispy] initialize color translation and color string tables
+static void R_InitHSVColors (void)
+{
+	byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+	char c[3];
+	int i, j;
+
+	if (!crstr)
+	    crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
+
+	// [crispy] CRMAX - 2: don't override the original GREN and BLUE2 Boom tables
+	for (i = 0; i < CRMAX - 2; i++)
+	{
+	    for (j = 0; j < 256; j++)
+	    {
+		cr[i][j] = V_Colorize(playpal, i, j, false);
+	    }
+
+	    M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
+	    crstr[i] = M_StringDuplicate(c);
+	}
+
+	W_ReleaseLumpName("PLAYPAL");
+}
 
 
 //
@@ -753,6 +817,8 @@ void R_InitData (void)
         D_IntroTick();
 
     R_InitColormaps ();
+    // [crispy] Initialize color translation and color string tables.
+    R_InitHSVColors ();
 }
 
 

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -766,6 +766,16 @@ void R_InitColormaps (void)
 	}
 
 	W_ReleaseLumpName("COLORMAP");
+	W_ReleaseLumpName("PLAYPAL");
+	R_InitPalColors();
+#endif
+}
+
+void R_InitPalColors (void)
+{
+	int i, j = 0;
+	byte r, g, b;
+	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 
 	if (!pal_color)
 	{
@@ -782,7 +792,6 @@ void R_InitColormaps (void)
 	}
 
 	W_ReleaseLumpName("PLAYPAL");
-#endif
 }
 
 // [crispy] initialize color translation and color string tables

--- a/src/strife/r_defs.h
+++ b/src/strife/r_defs.h
@@ -333,7 +333,7 @@ typedef struct
 //  precalculating 24bpp lightmap/colormap LUT.
 //  from darkening PLAYPAL to all black.
 // Could even us emore than 32 levels.
-typedef byte	lighttable_t;	
+typedef pixel_t	lighttable_t;	
 
 
 
@@ -407,6 +407,9 @@ typedef struct vissprite_s
    
     int			mobjflags;
     
+#ifdef CRISPY_TRUECOLOR
+    const pixel_t	(*blendfunc)(const pixel_t fg, const pixel_t bg);
+#endif
 } vissprite_t;
 
 

--- a/src/strife/r_draw.c
+++ b/src/strife/r_draw.c
@@ -300,8 +300,9 @@ void R_DrawMVisTLColumn(void)
         pixel_t col = xlatab[*dest + (src << 8)];
         *dest = col;
 #else
+        // [crispy] 75% opacity
         const pixel_t destrgb = src;
-        *dest = blendfunc(*dest, destrgb);
+        *dest = I_BlendOverXlatab(*dest, destrgb);
 #endif
         dest += SCREENWIDTH;
         frac += fracstep;
@@ -361,8 +362,9 @@ void R_DrawTLColumn(void)
         pixel_t col = xlatab[(*dest << 8) + src];
         *dest = col;
 #else
+        // [crispy] 25% opacity
         const pixel_t destrgb = src;
-        *dest = blendfunc(*dest, destrgb);
+        *dest = I_BlendOverAltXlatab(*dest, destrgb);
 #endif
         dest += SCREENWIDTH;
         frac += fracstep;

--- a/src/strife/r_draw.c
+++ b/src/strife/r_draw.c
@@ -902,7 +902,7 @@ void R_FillBackScreen (void)
 	
     if (background_buffer == NULL)
     {
-        background_buffer = Z_Malloc(MAXWIDTH * (MAXHEIGHT - SBARHEIGHT),
+        background_buffer = Z_Malloc(MAXWIDTH * (MAXHEIGHT - SBARHEIGHT) * sizeof(*background_buffer),
                                      PU_STATIC, NULL);
     }
 
@@ -973,7 +973,7 @@ R_VideoErase
 
     if (background_buffer != NULL)
     {
-        memcpy(I_VideoBuffer + ofs, background_buffer + ofs, count); 
+        memcpy(I_VideoBuffer + ofs, background_buffer + ofs, count * sizeof(*I_VideoBuffer)); 
     }
 } 
 

--- a/src/strife/r_draw.c
+++ b/src/strife/r_draw.c
@@ -29,6 +29,7 @@
 #include "w_wad.h"
 
 #include "r_local.h"
+#include "v_trans.h" // [crispy] blending functions
 
 // Needs access to LFB (guess what).
 #include "v_video.h"
@@ -61,7 +62,7 @@ int		scaledviewwidth;
 int		viewheight;
 int		viewwindowx;
 int		viewwindowy; 
-byte*		ylookup[MAXHEIGHT]; 
+pixel_t*		ylookup[MAXHEIGHT]; 
 int		columnofs[MAXWIDTH]; 
 
 // Color tables for different players,
@@ -74,7 +75,7 @@ int		columnofs[MAXWIDTH];
 // Backing buffer containing the bezel drawn around the screen and 
 // surrounding background.
 
-static byte *background_buffer = NULL;
+static pixel_t *background_buffer = NULL;
 
 // haleyjd 08/29/10: [STRIFE] Rogue added the ability to customize the view
 // border flat by storing it in the configuration file.
@@ -111,7 +112,7 @@ int			dccount;
 void R_DrawColumn (void) 
 { 
     int			count; 
-    byte*		dest; 
+    pixel_t*		dest; 
     fixed_t		frac;
     fixed_t		fracstep;	 
     int			heightmask = dc_texheight - 1;
@@ -256,7 +257,7 @@ void R_DrawColumn (void)
 void R_DrawMVisTLColumn(void)
 {
     int                 count; 
-    byte*               dest; 
+    pixel_t*               dest; 
     fixed_t             frac;
     fixed_t             fracstep;
 
@@ -294,9 +295,14 @@ void R_DrawMVisTLColumn(void)
 
     do
     {
-        byte src = dc_colormap[dc_source[(frac>>FRACBITS)&127]];
-        byte col = xlatab[*dest + (src << 8)];
+        pixel_t src = dc_colormap[dc_source[(frac>>FRACBITS)&127]];
+#ifndef CRISPY_TRUECOLOR
+        pixel_t col = xlatab[*dest + (src << 8)];
         *dest = col;
+#else
+        const pixel_t destrgb = src;
+        *dest = blendfunc(*dest, destrgb);
+#endif
         dest += SCREENWIDTH;
         frac += fracstep;
     } while(count--);
@@ -312,7 +318,7 @@ void R_DrawMVisTLColumn(void)
 void R_DrawTLColumn(void)
 {
     int                 count; 
-    byte*               dest; 
+    pixel_t*               dest; 
     fixed_t             frac;
     fixed_t             fracstep;	 
 
@@ -350,9 +356,14 @@ void R_DrawTLColumn(void)
 
     do
     {
-        byte src = dc_colormap[dc_source[(frac>>FRACBITS)&127]];
-        byte col = xlatab[(*dest << 8) + src];
+        pixel_t src = dc_colormap[dc_source[(frac>>FRACBITS)&127]];
+#ifndef CRISPY_TRUECOLOR
+        pixel_t col = xlatab[(*dest << 8) + src];
         *dest = col;
+#else
+        const pixel_t destrgb = src;
+        *dest = blendfunc(*dest, destrgb);
+#endif
         dest += SCREENWIDTH;
         frac += fracstep;
     } while(count--);
@@ -375,7 +386,7 @@ byte*	translationtables;
 void R_DrawTranslatedColumn (void) 
 { 
     int                 count; 
-    byte*               dest; 
+    pixel_t*               dest; 
     fixed_t             frac;
     fixed_t             fracstep;
 
@@ -425,7 +436,7 @@ void R_DrawTranslatedColumn (void)
 void R_DrawTRTLColumn(void)
 {
     int                 count; 
-    byte*               dest; 
+    pixel_t*               dest; 
     fixed_t             frac;
     fixed_t             fracstep;
 
@@ -453,8 +464,13 @@ void R_DrawTRTLColumn(void)
     do 
     {
         byte src = dc_colormap[dc_translation[dc_source[frac>>FRACBITS&127]]];
-        byte col = xlatab[(*dest << 8) + src];
+#ifndef CRISPY_TRUECOLOR
+        pixel_t col = xlatab[(*dest << 8) + src];
         *dest = col;
+#else
+        const pixel_t destrgb = src;
+        *dest = blendfunc(*dest, destrgb);
+#endif
         dest += SCREENWIDTH;
         frac += fracstep; 
     } while (count--); 
@@ -487,7 +503,9 @@ void R_InitTranslationTables (void)
     // strictly portable, all we need to do is this:
 
     // villsa [STRIFE] 09/26/10: load table through this function instead
+#ifndef CRISPY_TRUECOLOR
     V_LoadXlaTable();
+#endif
 
     // villsa [STRIFE] allocate a larger size for translation tables
     translationtables = Z_Malloc (256*8, PU_STATIC, 0);
@@ -625,7 +643,7 @@ int			dscount;
 void R_DrawSpan (void) 
 { 
 //  unsigned int position, step;
-    byte *dest;
+    pixel_t *dest;
     int count;
     int spot;
     unsigned int xtemp, ytemp;
@@ -760,7 +778,7 @@ void R_DrawSpanLow (void)
 {
 //  unsigned int position, step;
     unsigned int xtemp, ytemp;
-    byte *dest;
+    pixel_t *dest;
     int count;
     int spot;
 
@@ -859,7 +877,7 @@ R_InitBuffer
 void R_FillBackScreen (void) 
 { 
     byte*	src;
-    byte*	dest; 
+    pixel_t*	dest; 
     int		x;
     int		y; 
     patch_t*	patch;

--- a/src/strife/r_draw.c
+++ b/src/strife/r_draw.c
@@ -465,7 +465,7 @@ void R_DrawTRTLColumn(void)
     // Here we do an additional index re-mapping.
     do 
     {
-        byte src = dc_colormap[dc_translation[dc_source[frac>>FRACBITS&127]]];
+        pixel_t src = dc_colormap[dc_translation[dc_source[frac>>FRACBITS&127]]];
 #ifndef CRISPY_TRUECOLOR
         pixel_t col = xlatab[(*dest << 8) + src];
         *dest = col;

--- a/src/strife/r_main.c
+++ b/src/strife/r_main.c
@@ -1062,7 +1062,9 @@ void R_SetupFrame (player_t* player)
     {
 	fixedcolormap =
 	    colormaps
-	    + player->fixedcolormap*256*sizeof(lighttable_t);
+	    // [crispy] sizeof(lighttable_t) not needed in paletted render
+	    // and breaks Sigil weapon effects in true color render
+	    + player->fixedcolormap*256/**sizeof(lighttable_t)*/;
 	
 	walllights = scalelightfixed;
 

--- a/src/strife/r_main.h
+++ b/src/strife/r_main.h
@@ -167,7 +167,6 @@ void R_RenderPlayerView (player_t *player);
 void R_Init (void);
 
 void R_InitColormaps (void);
-void R_InitPalColors (void);
 
 // Called by M_Responder.
 void R_SetViewSize (int blocks, int detail);

--- a/src/strife/r_main.h
+++ b/src/strife/r_main.h
@@ -166,6 +166,9 @@ void R_RenderPlayerView (player_t *player);
 // Called by startup code.
 void R_Init (void);
 
+void R_InitColormaps (void);
+void R_InitPalColors (void);
+
 // Called by M_Responder.
 void R_SetViewSize (int blocks, int detail);
 

--- a/src/strife/r_state.h
+++ b/src/strife/r_state.h
@@ -44,6 +44,7 @@ extern fixed_t*		spriteoffset;
 extern fixed_t*		spritetopoffset;
 
 extern lighttable_t*	colormaps;
+extern lighttable_t*	pal_color;
 
 extern int		viewwidth;
 extern int		scaledviewwidth;

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -495,7 +495,7 @@ R_DrawVisSprite
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOverTinttab;
+    blendfunc = I_BlendOverXlatab;
 #endif
 }
 

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -32,6 +32,7 @@
 #include "w_wad.h"
 
 #include "r_local.h"
+#include "v_trans.h" // [crispy] blending functions
 
 #include "doomstat.h"
 
@@ -445,6 +446,9 @@ R_DrawVisSprite
             colfunc = R_DrawTRTLColumn;
             dc_translation = translationtables - 256 + (translation >> (MF_TRANSSHIFT - 8));
         }
+#ifdef CRISPY_TRUECOLOR
+	blendfunc = vis->blendfunc;
+#endif
     }
     else if(vis->mobjflags & MF_MVIS)
     {
@@ -490,6 +494,9 @@ R_DrawVisSprite
     }
 
     colfunc = basecolfunc;
+#ifdef CRISPY_TRUECOLOR
+    blendfunc = I_BlendOverTinttab;
+#endif
 }
 
 
@@ -680,6 +687,15 @@ void R_ProjectSprite (mobj_t* thing)
 
 	vis->colormap = spritelights[index];
     }	
+
+#ifdef CRISPY_TRUECOLOR
+    if (thing->flags & MF_SHADOW)
+    {
+        // [crispy] not using additive blending (I_BlendAdd) here 
+        // to preserve look & feel of original Strife translucency
+        vis->blendfunc = I_BlendOverAltXlatab;
+    }
+#endif
 }
 
 

--- a/src/strife/st_stuff.c
+++ b/src/strife/st_stuff.c
@@ -892,7 +892,9 @@ static void ST_doPaletteStuff(void)
 {
 
     int		palette;
+#ifndef CRISPY_TRUECOLOR
     byte*	pal;
+#endif
     int		cnt;
     int		bzc;
 
@@ -940,8 +942,12 @@ static void ST_doPaletteStuff(void)
     if (palette != st_palette)
     {
         st_palette = palette;
+#ifndef CRISPY_TRUECOLOR
         pal = (byte *) W_CacheLumpNum (lu_palette, PU_CACHE)+palette*768;
         I_SetPalette (pal);
+#else
+        I_SetPalette (palette);
+#endif
     }
 
 }
@@ -1003,14 +1009,19 @@ void ST_drawNumFontY2(int x, int y, int num)
 void ST_drawLine(int x, int y, int len, int color)
 {
     byte putcolor = (byte)(color);
-    byte *drawpos = I_VideoBuffer + (y << crispy->hires) * SCREENWIDTH + ((x + WIDESCREENDELTA) << crispy->hires);
+    pixel_t *drawpos = I_VideoBuffer + (y << crispy->hires) * SCREENWIDTH + ((x + WIDESCREENDELTA) << crispy->hires);
     int i = 0;
 
     while(i < (len << crispy->hires))
     {
         if (crispy->hires)
+#ifndef CRISPY_TRUECOLOR
             *(drawpos + SCREENWIDTH) = putcolor;
         *drawpos++ = putcolor;
+#else
+            *(drawpos + SCREENWIDTH) = pal_color[putcolor];
+        *drawpos++ = pal_color[putcolor];
+#endif
         ++i;
     }
 }
@@ -1805,7 +1816,11 @@ void ST_Stop (void)
     if (st_stopped)
         return;
 
+#ifndef CRISPY_TRUECOLOR
     I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE));
+#else
+    I_SetPalette (0);
+#endif
 
     st_stopped = true;
 }

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -65,6 +65,8 @@ extern const pixel_t I_BlendDark (const pixel_t bg, const int d);
 extern const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg);
 #endif
 
 int V_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -62,12 +62,12 @@ extern byte *tranmap;
 extern const pixel_t (*blendfunc) (const pixel_t fg, const pixel_t bg);
 extern const pixel_t I_BlendAdd (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendDark (const pixel_t bg, const int d);
-extern const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOver (const pixel_t bg, const pixel_t fg, const int amount);
+extern const pixel_t I_BlendOverTranmap (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg);
-extern const pixel_t I_BlendOverCrossfade (const pixel_t bg, const pixel_t fg, const int amount);
 #endif
 
 int V_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -67,6 +67,7 @@ extern const pixel_t I_BlendOverTinttab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverAltTinttab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverXlatab (const pixel_t bg, const pixel_t fg);
 extern const pixel_t I_BlendOverAltXlatab (const pixel_t bg, const pixel_t fg);
+extern const pixel_t I_BlendOverCrossfade (const pixel_t bg, const pixel_t fg, const int amount);
 #endif
 
 int V_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -221,10 +221,7 @@ static const inline pixel_t drawxlatab (const pixel_t dest, const pixel_t source
 #ifndef CRISPY_TRUECOLOR
 {return xlatab[dest+(source<<8)];}
 #else
-// [JN] TODO - double check if it's representing vanilla Strife translucensy
-// well enough. Paletted approach is same to V_DrawTLPatch, but true color, 
-// in fact, doesnt seem to be opaque enough.
-{return I_BlendOverAltTinttab(dest, pal_color[source]);}
+{return I_BlendOverXlatab(dest, pal_color[source]);}
 #endif
 
 // [crispy] array of function pointers holding the different rendering functions

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -184,14 +184,14 @@ static const inline pixel_t drawpatchpx10 (const pixel_t dest, const pixel_t sou
 #ifndef CRISPY_TRUECOLOR
 {return tranmap[(dest<<8)+source];}
 #else
-{return I_BlendOver(dest, pal_color[source]);}
+{return I_BlendOverTranmap(dest, pal_color[source]);}
 #endif
 // (4) color-translated, translucent patch
 static const inline pixel_t drawpatchpx11 (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tranmap[(dest<<8)+dp_translation[source]];}
 #else
-{return I_BlendOver(dest, pal_color[dp_translation[source]]);}
+{return I_BlendOverTranmap(dest, pal_color[dp_translation[source]]);}
 #endif
 
 // [crispy] TINTTAB rendering functions:

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -822,9 +822,7 @@ void V_DrawScaledBlock(int x, int y, int width, int height, byte *src)
 #ifndef CRISPY_TRUECOLOR
             *(dest + i * SCREENWIDTH + j) = *(src + (i >> crispy->hires) * width + (j >> crispy->hires));
 #else
-            // [JN] TODO - add support for true color. This should use
-            // pal_color[] array, which is initialized far *after* intro sequence.
-            *(dest + i * SCREENWIDTH + j) = *(src + (i >> crispy->hires) * width + (j >> crispy->hires));
+            *(dest + i * SCREENWIDTH + j) = pal_color[*(src + (i >> crispy->hires) * width + (j >> crispy->hires))];
 #endif
         }
     }

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -70,7 +70,7 @@ void V_DrawPatchFullScreen(patch_t *patch, boolean flipped);
 // Draw a linear block of pixels into the view buffer.
 
 void V_DrawBlock(int x, int y, int width, int height, pixel_t *src);
-void V_DrawScaledBlock(int x, int y, int width, int height, pixel_t *src);
+void V_DrawScaledBlock(int x, int y, int width, int height, byte *src);
 
 void V_MarkRect(int x, int y, int width, int height);
 


### PR DESCRIPTION
This is the final chapter of Crispy true color story, what else can be said? 🙂 Just a few remarks and TODOs:

- ~~TODO: Screen wiping disabled. It is not possible to use `XLATAB` neither for crossfading, nor for any kind of translucency. Wiping effect will require entirely different approach, probably via some SDL functions, like making a copy of existing texture and blending it with variable opacity level, depending on game tic or something. No idea how to proceed at the moment.~~
- ~~TODOs : Graphical startup with RAW patches working, but not sure it's an optimal way, since `pal_color[]` must be filled before graphical startup, and then filled again after generating colormaps.~~
- ~~Brightmaps working. Strife is using `COLORMAP` for such trick, it was easy it replicate it by locking necessary colors on the first light level.~~
- ~~Strife using two levels of translucency: 25% and 75% for column/segs drawing and only 75% for patch drawing. Kaiser's comment in [r_segs.c](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/strife/r_segs.c#L154-L160) helped a lot in the question of opacity values.~~

And of course, small and not very colorful example of before and after:
<details>

![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/d4abcac0-5ba1-44a3-9bb0-db7bad36c624)

![image](https://github.com/fabiangreffrath/crispy-doom/assets/21193394/056bbaff-4f8b-42db-9a34-b3b5cafcfa70)


</details>