### PR TITLE
Better fix for weapon sprite drawn 1 pixel too high

### DIFF
--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -1029,7 +1029,7 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
     vis->translation = NULL; // [crispy] no color translation
     vis->mobjflags = 0;
     // [crispy] weapons drawn 1 pixel too high when player is idle
-    vis->texturemid = (BASEYCENTER<<FRACBITS)+FRACUNIT/4-(psp->sy2-spritetopoffset[lump]);
+    vis->texturemid = (BASEYCENTER<<FRACBITS)/*+FRACUNIT/4*/-(psp->sy2-spritetopoffset[lump]);
     vis->x1 = x1 < 0 ? 0 : x1;
     vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;	
     vis->scale = pspritescale<<detailshift;


### PR DESCRIPTION
The addition of FRACUNIT/4 doesn't matter for original and double resolution, but leaves 1 pixel gap under the weapon sprite in quad resolution (e.g. So Doom). Sorry @JNechaevsky, I proved here that in Crispy this addition doesn't matter https://github.com/fabiangreffrath/crispy-doom/commit/a788f63a69382629545aec7d70717f7487a8d88e