### PR TITLE
Resolution-tuned weapon sprite 1 pixel height adjustment for compatibility with bit-shifting hires forks

### DIFF
--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -1029,7 +1029,7 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
     vis->translation = NULL; // [crispy] no color translation
     vis->mobjflags = 0;
     // [crispy] weapons drawn 1 pixel too high when player is idle
-    vis->texturemid = (BASEYCENTER<<FRACBITS)+FRACUNIT/4-(psp->sy2-spritetopoffset[lump]);
+    vis->texturemid = (BASEYCENTER<<FRACBITS)+FRACUNIT/(2<<crispy->hires)-(psp->sy2-spritetopoffset[lump]);
     vis->x1 = x1 < 0 ? 0 : x1;
     vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;	
     vis->scale = pspritescale<<detailshift;


### PR DESCRIPTION
Use `FRACUNIT/(2<<crispy->hires)` instead of `FRACUNIT/constant`.

Sorry @JNechaevsky, flexible solutions are usually better.