### PR TITLE
Heretic: do not crash if the wrong side of the door is pushed

### DIFF
--- a/src/heretic/p_doors.c
+++ b/src/heretic/p_doors.c
@@ -259,6 +259,13 @@ void EV_VerticalDoor(line_t * line, mobj_t * thing)
     }
 
     // if the sector has an active thinker, use it
+    if (line->sidenum[side^1] == NO_INDEX)
+    {
+        // [crispy] do not crash if the wrong side of the door is pushed
+        printf("EV_VerticalDoor: DR special type on 1-sided linedef\n");
+        return;
+    }
+
     sec = sides[line->sidenum[side ^ 1]].sector;
     if (sec->specialdata)
     {

--- a/src/heretic/p_doors.c
+++ b/src/heretic/p_doors.c
@@ -262,7 +262,7 @@ void EV_VerticalDoor(line_t * line, mobj_t * thing)
     if (line->sidenum[side^1] == NO_INDEX)
     {
         // [crispy] do not crash if the wrong side of the door is pushed
-        printf("EV_VerticalDoor: DR special type on 1-sided linedef\n");
+        fprintf(stderr, "EV_VerticalDoor: DR special type on 1-sided linedef\n");
         return;
     }
 


### PR DESCRIPTION
Very rare case and pretty straight-forward fix, but as always, few remarks:
* The fix itself is a carbon copy from [Crispy Doom](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/doom/p_doors.c#L426-L431), except using `printf`, not `fprintf` (I belive printing into a file no longer needed since SDL2 version).
* Testing map, DR door on one sided line is in front of the player view: [dr-1side.zip](https://github.com/fabiangreffrath/crispy-doom/files/14812674/dr-1side.zip)

Fixes https://github.com/fabiangreffrath/crispy-doom/issues/1188, thanks @Catoptromancy for pointing out.