### PR TITLE
Introduce fast mouse polling for lower lag interpolation

### DIFF
--- a/src/d_event.c
+++ b/src/d_event.c
@@ -24,6 +24,10 @@
 
 #define MAXEVENTS 64
 
+// [crispy]
+event_t fastmouse;
+boolean newfastmouse;
+
 static event_t events[MAXEVENTS];
 static int eventhead;
 static int eventtail;

--- a/src/d_event.h
+++ b/src/d_event.h
@@ -135,7 +135,10 @@ typedef enum
 } buttoncode2_t;
 
 
+// [crispy] For fast polling
+extern event_t fastmouse;
 
+extern boolean newfastmouse;
 
 // Called by IO functions when input is detected.
 void D_PostEvent (event_t *ev);

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1910,8 +1910,8 @@ void AM_drawPlayers(void)
 	// [crispy] interpolate other player arrows
 	if (crispy->uncapped && leveltime > oldleveltime)
 	{
-	    pt.x = (p->mo->oldx + FixedMul(p->mo->x - p->mo->oldx, fractionaltic)) >> FRACTOMAPBITS;
-	    pt.y = (p->mo->oldy + FixedMul(p->mo->y - p->mo->oldy, fractionaltic)) >> FRACTOMAPBITS;
+	    pt.x = LerpFixed(p->mo->oldx, p->mo->x) >> FRACTOMAPBITS;
+	    pt.y = LerpFixed(p->mo->oldy, p->mo->y) >> FRACTOMAPBITS;
 	}
 	else
 	{
@@ -1926,7 +1926,7 @@ void AM_drawPlayers(void)
 	}
 	else
 	{
-        theirangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
+        theirangle = LerpAngle(p->mo->oldangle, p->mo->angle);
 	}
 
 	AM_drawLineCharacter
@@ -1961,8 +1961,8 @@ AM_drawThings
 	    // [crispy] interpolate thing triangles movement
 	    if (leveltime > oldleveltime)
 	    {
-	    pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-	    pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
+	    pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+	    pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
 	    }
 	    else
 	    {

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -178,6 +178,13 @@ boolean D_Display (void)
 		
     redrawsbar = false;
     
+    if (crispy->uncapped)
+    {
+        I_StartDisplay();
+        G_FastResponder();
+        G_PrepTiccmd();
+    }
+
     // change the view size if needed
     if (setsizeneeded)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -215,7 +215,6 @@ static boolean *mousebuttons = &mousearray[1];  // allow [-1]
 
 // mouse values are used once 
 int             mousex;
-int             mousex2;
 int             mousey;         
 
 // [crispy] for rounding error
@@ -867,7 +866,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             (old_angleturn - cmd->angleturn) : (cmd->angleturn - old_angleturn);
     }
 
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
 	 
     if (forward > MAXPLMOVE) 
 	forward = MAXPLMOVE; 
@@ -1054,7 +1053,7 @@ void G_DoLoadLevel (void)
 
     memset (gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
     memset(&localview, 0, sizeof(localview)); // [crispy]
     memset(&carry, 0, sizeof(carry)); // [crispy]
     memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -218,6 +218,7 @@ int             mousex;
 int             mousex2;
 int             mousey;         
 
+// [crispy] for rounding error
 typedef struct carry_s
 {
     double angle;
@@ -359,6 +360,7 @@ boolean speedkeydown (void)
            (mousebspeed < MAX_MOUSE_BUTTONS && mousebuttons[mousebspeed]);
 }
 
+// [crispy] for carrying rounding error
 static int CarryError(double value, const double *prevcarry, double *carry)
 {
     const double desired = value + *prevcarry;
@@ -1053,9 +1055,9 @@ void G_DoLoadLevel (void)
     memset (gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
     mousex = mousex2 = mousey = 0;
-    memset(&localview, 0, sizeof(localview));
-    memset(&carry, 0, sizeof(carry));
-    memset(&prevcarry, 0, sizeof(prevcarry));
+    memset(&localview, 0, sizeof(localview)); // [crispy]
+    memset(&carry, 0, sizeof(carry)); // [crispy]
+    memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]
     memset(&basecmd, 0, sizeof(basecmd)); // [crispy]
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -371,7 +371,15 @@ static int CarryError(double value, const double *prevcarry, double *carry)
 
 static short CarryAngle(double angle)
 {
-    return CarryError(angle, &prevcarry.angle, &carry.angle);
+    if (lowres_turn && abs(angle + prevcarry.angle) < 128)
+    {
+        carry.angle = angle + prevcarry.angle;
+        return 0;
+    }
+    else
+    {
+        return CarryError(angle, &prevcarry.angle, &carry.angle);
+    }
 }
 
 static short CarryPitch(double pitch)
@@ -431,6 +439,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     int		tspeed; 
     int		lspeed;
     int		angle = 0; // [crispy]
+    short	mousex_angleturn; // [crispy]
     int		forward;
     int		side;
     int		look;
@@ -858,12 +867,14 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         testcontrols_mousespeed = 0;
     }
     
+    mousex_angleturn = cmd->angleturn;
+
     if (angle)
     {
-        const short old_angleturn = cmd->angleturn;
-        cmd->angleturn = CarryAngle(localview.rawangle + angle);
+        cmd->angleturn = CarryAngle(cmd->angleturn + angle);
         localview.ticangleturn = crispy->fliplevels ?
-            (old_angleturn - cmd->angleturn) : (cmd->angleturn - old_angleturn);
+            (mousex_angleturn - cmd->angleturn) :
+            (cmd->angleturn - mousex_angleturn);
     }
 
     mousex = mousey = 0;
@@ -914,6 +925,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 
     if (crispy->fliplevels)
     {
+	mousex_angleturn = -mousex_angleturn;
 	cmd->angleturn = -cmd->angleturn;
 	cmd->sidemove = -cmd->sidemove;
     }
@@ -922,20 +934,26 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 
     if (lowres_turn)
     {
-        static signed short carry = 0;
         signed short desired_angleturn;
 
-        desired_angleturn = cmd->angleturn + carry;
+        desired_angleturn = cmd->angleturn;
 
         // round angleturn to the nearest 256 unit boundary
         // for recording demos with single byte values for turn
 
         cmd->angleturn = (desired_angleturn + 128) & 0xff00;
 
+        if (angle)
+        {
+            localview.ticangleturn = cmd->angleturn - mousex_angleturn;
+        }
+
         // Carry forward the error from the reduced resolution to the
         // next tic, so that successive small movements can accumulate.
 
-        carry = desired_angleturn - cmd->angleturn;
+        prevcarry.angle += crispy->fliplevels ?
+                            cmd->angleturn - desired_angleturn :
+                            desired_angleturn - cmd->angleturn;
     }
 } 
  

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -860,15 +860,15 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     if (strafe && !cmd->angleturn)
 	side += CarryMouseSide(CalcMouseSide(mousex));
 
-    if (mousex == 0)
+    mousex_angleturn = cmd->angleturn;
+
+    if (mousex_angleturn == 0)
     {
         // No movement in the previous frame
 
         testcontrols_mousespeed = 0;
     }
     
-    mousex_angleturn = cmd->angleturn;
-
     if (angle)
     {
         cmd->angleturn = CarryAngle(cmd->angleturn + angle);

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -75,6 +75,8 @@ void G_BuildTiccmd (ticcmd_t *cmd, int maketic);
 
 void G_Ticker (void);
 boolean G_Responder (event_t*	ev);
+void G_FastResponder (void); // [crispy]
+void G_PrepTiccmd (void); // [crispy]
 
 void G_ScreenShot (void);
 

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -163,6 +163,7 @@ void P_MovePlayer (player_t* player)
     // [crispy] give full control in no-clipping mode
     onground |= (player->mo->flags & MF_NOCLIP);
 	
+    // [crispy] fast polling
     if (player == &players[consoleplayer])
     {
         localview.ticangle += localview.ticangleturn << 16;
@@ -295,6 +296,7 @@ void P_PlayerThink (player_t* player)
     player->oldlookdir = player->lookdir;
     player->oldrecoilpitch = player->recoilpitch;
 
+    // [crispy] fast polling
     if (player == &players[consoleplayer])
     {
         localview.oldticangle = localview.ticangle;

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -163,6 +163,12 @@ void P_MovePlayer (player_t* player)
     // [crispy] give full control in no-clipping mode
     onground |= (player->mo->flags & MF_NOCLIP);
 	
+    if (player == &players[consoleplayer])
+    {
+        localview.ticangle += localview.ticangleturn << 16;
+        localview.ticangleturn = 0;
+    }
+
     if (cmd->forwardmove && onground)
 	P_Thrust (player, player->mo->angle, cmd->forwardmove*2048);
     else
@@ -288,6 +294,11 @@ void P_PlayerThink (player_t* player)
     player->oldviewz = player->viewz;
     player->oldlookdir = player->lookdir;
     player->oldrecoilpitch = player->recoilpitch;
+
+    if (player == &players[consoleplayer])
+    {
+        localview.oldticangle = localview.ticangle;
+    }
 
     // [crispy] update weapon sound source coordinates
     if (player->so != player->mo)

--- a/src/doom/r_bsp.c
+++ b/src/doom/r_bsp.c
@@ -262,11 +262,13 @@ void R_MaybeInterpolateSector(sector_t* sector)
     {
         // Interpolate between current and last floor/ceiling position.
         if (sector->floorheight != sector->oldfloorheight)
-            sector->interpfloorheight = sector->oldfloorheight + FixedMul(sector->floorheight - sector->oldfloorheight, fractionaltic);
+            sector->interpfloorheight =
+                LerpFixed(sector->oldfloorheight, sector->floorheight);
         else
             sector->interpfloorheight = sector->floorheight;
         if (sector->ceilingheight != sector->oldceilingheight)
-            sector->interpceilingheight = sector->oldceilingheight + FixedMul(sector->ceilingheight - sector->oldceilingheight, fractionaltic);
+            sector->interpceilingheight =
+                LerpFixed(sector->oldceilingheight, sector->ceilingheight);
         else
             sector->interpceilingheight = sector->ceilingheight;
     }

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -987,6 +987,7 @@ R_PointInSubsector
 }
 
 
+// [crispy]
 static inline boolean CheckLocalView(const player_t *player)
 {
   return (

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -551,27 +551,6 @@ fixed_t R_ScaleFromGlobalAngle (angle_t visangle)
 #endif
 
 
-// [AM] Interpolate between two angles.
-angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale)
-{
-    if (nangle == oangle)
-        return nangle;
-    else if (nangle > oangle)
-    {
-        if (nangle - oangle < ANG270)
-            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(scale));
-        else // Wrapped around
-            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(scale));
-    }
-    else // nangle < oangle
-    {
-        if (oangle - nangle < ANG270)
-            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(scale));
-        else // Wrapped around
-            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(scale));
-    }
-}
-
 //
 // R_InitTables
 //
@@ -1031,13 +1010,13 @@ void R_SetupFrame (player_t* player)
         leveltime > oldleveltime)
     {
         // Interpolate player camera from their old position to their current one.
-        viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-        viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-        viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-        viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+        viewx = LerpFixed(player->mo->oldx, player->mo->x);
+        viewy = LerpFixed(player->mo->oldy, player->mo->y);
+        viewz = LerpFixed(player->oldviewz, player->viewz);
+        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
 
-        pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT
-                + (player->oldrecoilpitch + FixedMul(player->recoilpitch - player->oldrecoilpitch, fractionaltic));
+        pitch = LerpInt(player->oldlookdir, player->lookdir) / MLOOKUNIT
+                + LerpFixed(player->oldrecoilpitch, player->recoilpitch);
     }
     else
     {

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -76,6 +76,7 @@ fixed_t			viewy;
 fixed_t			viewz;
 
 angle_t			viewangle;
+localview_t		localview; // [crispy]
 
 fixed_t			viewcos;
 fixed_t			viewsin;
@@ -986,6 +987,22 @@ R_PointInSubsector
 }
 
 
+static inline boolean CheckLocalView(const player_t *player)
+{
+  return (
+    // Don't use localview if the player is spying.
+    player == &players[consoleplayer] &&
+    // Don't use localview if the player is dead.
+    player->playerstate != PST_DEAD &&
+    // Don't use localview if the player just teleported.
+    !player->mo->reactiontime &&
+    // Don't use localview if a demo is playing.
+    !demoplayback &&
+    // Don't use localview during a netgame (single-player only).
+    !netgame
+  );
+}
+
 
 //
 // R_SetupFrame
@@ -1009,11 +1026,22 @@ void R_SetupFrame (player_t* player)
         // Don't interpolate during a paused state
         leveltime > oldleveltime)
     {
+        const boolean use_localview = CheckLocalView(player);
+
         // Interpolate player camera from their old position to their current one.
         viewx = LerpFixed(player->mo->oldx, player->mo->x);
         viewy = LerpFixed(player->mo->oldy, player->mo->y);
         viewz = LerpFixed(player->oldviewz, player->viewz);
-        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        if (use_localview)
+        {
+            viewangle = (player->mo->angle + localview.angle -
+                        localview.ticangle + LerpAngle(localview.oldticangle,
+                                                       localview.ticangle)) + viewangleoffset;
+        }
+        else
+        {
+            viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        }
 
         pitch = LerpInt(player->oldlookdir, player->lookdir) / MLOOKUNIT
                 + LerpFixed(player->oldrecoilpitch, player->recoilpitch);

--- a/src/doom/r_main.h
+++ b/src/doom/r_main.h
@@ -21,6 +21,7 @@
 #define __R_MAIN__
 
 #include "d_player.h"
+#include "i_video.h" // [crispy] fractionaltic
 #include "r_data.h"
 
 
@@ -155,8 +156,36 @@ R_AddPointToBox
   fixed_t*	box );
 
 
+inline static fixed_t LerpFixed(fixed_t oldvalue, fixed_t newvalue)
+{
+    return (oldvalue + FixedMul(newvalue - oldvalue, fractionaltic));
+}
+
+inline static int LerpInt(int oldvalue, int newvalue)
+{
+    return (oldvalue + (int)((newvalue - oldvalue) * FIXED2DOUBLE(fractionaltic)));
+}
+
 // [AM] Interpolate between two angles.
-angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);
+inline static angle_t LerpAngle(angle_t oangle, angle_t nangle)
+{
+    if (nangle == oangle)
+        return nangle;
+    else if (nangle > oangle)
+    {
+        if (nangle - oangle < ANG270)
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+    }
+    else // nangle < oangle
+    {
+        if (oangle - nangle < ANG270)
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+    }
+}
 
 //
 // REFRESH - the actual rendering functions.

--- a/src/doom/r_state.h
+++ b/src/doom/r_state.h
@@ -95,6 +95,15 @@ extern line_t*		lines;
 extern int		numsides;
 extern side_t*		sides;
 
+// [crispy]
+typedef struct localview_s
+{
+    angle_t oldticangle;
+    angle_t ticangle;
+    short ticangleturn;
+    double rawangle;
+    angle_t angle;
+} localview_t;
 
 //
 // POV data.
@@ -104,6 +113,7 @@ extern fixed_t		viewy;
 extern fixed_t		viewz;
 
 extern angle_t		viewangle;
+extern localview_t      localview; // [crispy]
 extern player_t*	viewplayer;
 
 

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -600,10 +600,10 @@ void R_ProjectSprite (mobj_t* thing)
         // Don't interpolate during a paused state.
         leveltime > oldleveltime)
     {
-        interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
-        interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
-        interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
-        interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
+        interpx = LerpFixed(thing->oldx, thing->x);
+        interpy = LerpFixed(thing->oldy, thing->y);
+        interpz = LerpFixed(thing->oldz, thing->z);
+        interpangle = LerpAngle(thing->oldangle, thing->angle);
     }
     else
     {
@@ -1104,10 +1104,10 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] differentiate 
         if (lump == oldlump && pspr_interp)
         {
             int deltax = vis->x2 - vis->x1;
-            vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+            vis->x1 = LerpFixed(oldx1, vis->x1);
             vis->x2 = vis->x1 + deltax;
             vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
-            vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+            vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
         }
         else
         {

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -1846,8 +1846,8 @@ void AM_drawThings(int colors, int colorrange)
             // [crispy] interpolate thing triangles movement
             if (leveltime > oldleveltime)
             {
-            pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-            pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
+            pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+            pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
             }
             else
             {

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -250,6 +250,13 @@ static void CrispyDrawStats (void)
 
 void D_Display(void)
 {
+    if (crispy->uncapped)
+    {
+        I_StartDisplay();
+        G_FastResponder();
+        G_PrepTiccmd();
+    }
+
     // Change the view size if needed
     if (setsizeneeded)
     {

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -749,6 +749,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic);
 
 void G_Ticker(void);
 boolean G_Responder(event_t * ev);
+void G_FastResponder(void); // [crispy]
+void G_PrepTiccmd(void); // [crispy]
 
 void G_ScreenShot(void);
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -203,7 +203,7 @@ int lookheld;
 boolean mousearray[MAX_MOUSE_BUTTONS + 1];
 boolean *mousebuttons = &mousearray[1];
         // allow [-1]
-int mousex, mousex2, mousey;             // mouse values are used once
+int mousex, mousey;             // mouse values are used once
 int dclicktime, dclickstate, dclicks;
 int dclicktime2, dclickstate2, dclicks2;
 
@@ -939,7 +939,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         mbmlookctrl = 0;
     }
 
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
 
     if (forward > MAXPLMOVE)
         forward = MAXPLMOVE;
@@ -1070,7 +1070,7 @@ void G_DoLoadLevel(void)
 
     memset(gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
     memset(&localview, 0, sizeof(localview)); // [crispy]
     memset(&carry, 0, sizeof(carry)); // [crispy]
     memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -497,23 +497,26 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 //
     if (strafe)
     {
-        if (gamekeydown[key_right] || mousebuttons[mousebturnright])
-            side += sidemove[speed];
-        if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
-            side -= sidemove[speed];
-        if (use_analog && joyxmove)
+        if (!cmd->angleturn)
         {
-            joyxmove = joyxmove * joystick_move_sensitivity / 10;
-            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
-            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
-            side += FixedMul(sidemove[speed], joyxmove);
-        }
-        else if (joystick_move_sensitivity)
-        {
-            if (joyxmove > 0)
+            if (gamekeydown[key_right] || mousebuttons[mousebturnright])
                 side += sidemove[speed];
-            if (joyxmove < 0)
+            if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
                 side -= sidemove[speed];
+            if (use_analog && joyxmove)
+            {
+                joyxmove = joyxmove * joystick_move_sensitivity / 10;
+                joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+                joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+                side += FixedMul(sidemove[speed], joyxmove);
+            }
+            else if (joystick_move_sensitivity)
+            {
+                if (joyxmove > 0)
+                    side += sidemove[speed];
+                if (joyxmove < 0)
+                    side -= sidemove[speed];
+            }
         }
     }
     else

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -892,12 +892,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     // No mouse movement in previous frame?
 
-    if (mousex == 0)
+    mousex_angleturn = cmd->angleturn;
+
+    if (mousex_angleturn == 0)
     {
         testcontrols_mousespeed = 0;
     }
-
-    mousex_angleturn = cmd->angleturn;
 
     if (angle)
     {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -207,6 +207,18 @@ int mousex, mousex2, mousey;             // mouse values are used once
 int dclicktime, dclickstate, dclicks;
 int dclicktime2, dclickstate2, dclicks2;
 
+// [crispy] for rounding error
+typedef struct carry_s
+{
+    double angle;
+    double pitch;
+    double side;
+    double vert;
+} carry_t;
+
+static carry_t prevcarry;
+static carry_t carry;
+
 #define MAX_JOY_BUTTONS 20
 
 int joyxmove, joyymove;         // joystick values are repeated
@@ -217,6 +229,8 @@ boolean *joybuttons = &joyarray[1];     // allow [-1]
 
 int savegameslot;
 char savedescription[32];
+
+static ticcmd_t basecmd; // [crispy]
 
 int vanilla_demo_limit = 1;
 
@@ -292,6 +306,72 @@ static int G_NextWeapon(int direction)
     return weapon_order_table[i].weapon_num;
 }
 
+boolean usearti = true;
+
+boolean speedkeydown (void)
+{
+    return (key_speed < NUMKEYS && gamekeydown[key_speed]) ||
+           (joybspeed < MAX_JOY_BUTTONS && joybuttons[joybspeed]) ||
+           (mousebspeed < MAX_MOUSE_BUTTONS && mousebuttons[mousebspeed]);
+}
+
+// [crispy] for carrying rounding error
+static int CarryError(double value, const double *prevcarry, double *carry)
+{
+    const double desired = value + *prevcarry;
+    const int actual = lround(desired);
+    *carry = desired - actual;
+
+    return actual;
+}
+
+static short CarryAngle(double angle)
+{
+    return CarryError(angle, &prevcarry.angle, &carry.angle);
+}
+
+static short CarryPitch(double pitch)
+{
+    return CarryError(pitch, &prevcarry.pitch, &carry.pitch);
+}
+
+static int CarryMouseVert(double vert)
+{
+    return CarryError(vert, &prevcarry.vert, &carry.vert);
+}
+
+static int CarryMouseSide(double side)
+{
+    const double desired = side + prevcarry.side;
+    const int actual = lround(side * 0.5) * 2; // Even values only.
+    carry.side = desired - actual;
+    return actual;
+}
+
+static double CalcMouseAngle(int mousex)
+{
+    if (!mouseSensitivity)
+        return 0.0;
+
+    return (I_AccelerateMouse(mousex) * (mouseSensitivity + 5) * 8 / 10);
+}
+
+static double CalcMouseSide(int mousex)
+{
+    if (!mouseSensitivity_x2)
+        return 0.0;
+
+    return (I_AccelerateMouse(mousex) * (mouseSensitivity_x2 + 5) * 2 / 10);
+}
+
+static double CalcMouseVert(int mousey)
+{
+    if (!mouseSensitivity_y)
+        return 0.0;
+
+    return (I_AccelerateMouseY(mousey) * (mouseSensitivity_y + 5) / 10);
+}
+
 /*
 ====================
 =
@@ -304,20 +384,12 @@ static int G_NextWeapon(int direction)
 */
 
 
-boolean usearti = true;
-
-boolean speedkeydown (void)
-{
-    return (key_speed < NUMKEYS && gamekeydown[key_speed]) ||
-           (joybspeed < MAX_JOY_BUTTONS && joybuttons[joybspeed]) ||
-           (mousebspeed < MAX_MOUSE_BUTTONS && mousebuttons[mousebspeed]);
-}
-
 void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 {
     int i;
     boolean strafe, bstrafe;
     int speed, tspeed, lspeed;
+    int angle = 0; // [crispy]
     int forward, side;
     int look, arti;
     int flyheight;
@@ -327,7 +399,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     // haleyjd: removed externdriver crap
 
-    memset(cmd, 0, sizeof(*cmd));
+    // [crispy] For fast polling.
+    G_PrepTiccmd();
+    memcpy(cmd, &basecmd, sizeof(*cmd));
+    memset(&basecmd, 0, sizeof(ticcmd_t));
+
     //cmd->consistancy =
     //      consistancy[consoleplayer][(maketic*ticdup)%BACKUPTICS];
     cmd->consistancy = consistancy[consoleplayer][maketic % BACKUPTICS];
@@ -443,23 +519,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     else
     {
         if (gamekeydown[key_right] || mousebuttons[mousebturnright])
-            cmd->angleturn -= angleturn[tspeed];
+            angle -= angleturn[tspeed];
         if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
-            cmd->angleturn += angleturn[tspeed];
+            angle += angleturn[tspeed];
         if (use_analog && joyxmove)
         {
             // Cubic response curve allows for finer control when stick
             // deflection is small.
             joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
-            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+            angle -= FixedMul(angleturn[1], joyxmove);
         }
         else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
-                cmd->angleturn -= angleturn[tspeed];
+                angle -= angleturn[tspeed];
             if (joyxmove < 0)
-                cmd->angleturn += angleturn[tspeed];
+                angle += angleturn[tspeed];
         }
     }
 
@@ -797,13 +873,9 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 	}
     }
 
-    if (strafe)
+    if (strafe && !cmd->angleturn)
     {
-        side += mousex2 * 2;
-    }
-    else
-    {
-        cmd->angleturn -= mousex * 0x8;
+        side += CarryMouseSide(CalcMouseSide(mousex));
     }
 
     // No mouse movement in previous frame?
@@ -813,7 +885,14 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         testcontrols_mousespeed = 0;
     }
 
-    if (crispy->mouselook || mousebuttons[mousebmouselook])
+    if (angle)
+    {
+        const short old_angleturn = cmd->angleturn;
+        cmd->angleturn = CarryAngle(localview.rawangle + angle);
+        localview.ticangleturn = cmd->angleturn - old_angleturn;
+    }
+
+    if (cmd->lookdir)
     {
         if (demorecording || lowres_turn)
         {
@@ -821,8 +900,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             if (look != TOCENTER)
             {
                 // [crispy] Map mouse movement to look variable when recording
-                look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
-                                       :  mousey / MLOOKUNITLOWRES;
+                look += cmd->lookdir / MLOOKUNITLOWRES;
 
                 // [crispy] Limit to max speed of keyboard look up/down
                 if (look > 2)
@@ -830,10 +908,10 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
                 else if (look < -2)
                     look = -2;
             }
+            cmd->lookdir = 0;
         }
         else
         {
-            cmd->lookdir = mouse_y_invert ? -mousey : mousey;
             // [Dasperal] Allow precise vertical look with near 0 mouse movement
             if (cmd->lookdir > 0)
                 cmd->lookdir = (cmd->lookdir + MLOOKUNIT - 1) / MLOOKUNIT;
@@ -843,7 +921,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     }
     else if (!novert)
     {
-        forward += mousey;
+        forward += CarryMouseVert(CalcMouseVert(mousey));
     }
 
     // [crispy] single click on mouse look button centers view
@@ -874,6 +952,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     cmd->forwardmove += forward;
     cmd->sidemove += side;
+
+    // [crispy]
+    localview.angle = 0;
+    localview.rawangle = 0.0;
+    prevcarry = carry;
+
     if (players[consoleplayer].playerstate == PST_LIVE)
     {
         if (look < 0)
@@ -987,6 +1071,10 @@ void G_DoLoadLevel(void)
     memset(gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
     mousex = mousex2 = mousey = 0;
+    memset(&localview, 0, sizeof(localview)); // [crispy]
+    memset(&carry, 0, sizeof(carry)); // [crispy]
+    memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]
+    memset(&basecmd, 0, sizeof(basecmd)); // [crispy]
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));
     memset(joyarray, 0, sizeof(joyarray));
@@ -1265,18 +1353,8 @@ boolean G_Responder(event_t * ev)
 
         case ev_mouse:
             SetMouseButtons(ev->data1);
-            if (mouseSensitivity)
-            mousex = ev->data2 * (mouseSensitivity + 5) / 10;
-            else
-                mousex = 0; // [crispy] disable entirely
-            if (mouseSensitivity_x2)
-            mousex2 = ev->data2 * (mouseSensitivity_x2 + 5) / 10; // [crispy] separate sensitivity for strafe
-            else
-                mousex2 = 0; // [crispy] disable entirely
-            if (mouseSensitivity_y)
-            mousey = ev->data3 * (mouseSensitivity_y + 5) / 10; // [crispy] separate sensitivity for y-axis
-            else
-                mousey = 0; // [crispy] disable entirely
+            mousex += ev->data2;
+            mousey += ev->data3;
             return (true);      // eat events
 
         case ev_joystick:
@@ -1291,6 +1369,41 @@ boolean G_Responder(event_t * ev)
             break;
     }
     return (false);
+}
+
+// [crispy] For fast polling.
+void G_FastResponder (void)
+{
+    if (newfastmouse)
+    {
+        mousex += fastmouse.data2;
+        mousey += fastmouse.data3;
+
+        newfastmouse = false;
+    }
+}
+
+// [crispy]
+void G_PrepTiccmd (void)
+{
+    const boolean strafe = gamekeydown[key_strafe] ||
+        mousebuttons[mousebstrafe] || joybuttons[joybstrafe];
+
+    if (mousex && !strafe)
+    {
+        localview.rawangle -= CalcMouseAngle(mousex);
+        basecmd.angleturn = CarryAngle(localview.rawangle);
+        localview.angle = basecmd.angleturn << 16;
+        mousex = 0;
+    }
+
+    if (mousey && (crispy->mouselook || mousebuttons[mousebmouselook]))
+    {
+        const double vert = CalcMouseVert(mousey);
+        basecmd.lookdir += mouse_y_invert ?
+                            CarryPitch(-vert): CarryPitch(vert);
+        mousey = 0;
+    }
 }
 
 /*

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -327,7 +327,15 @@ static int CarryError(double value, const double *prevcarry, double *carry)
 
 static short CarryAngle(double angle)
 {
-    return CarryError(angle, &prevcarry.angle, &carry.angle);
+    if (lowres_turn && abs(angle + prevcarry.angle) < 128)
+    {
+        carry.angle = angle + prevcarry.angle;
+        return 0;
+    }
+    else
+    {
+        return CarryError(angle, &prevcarry.angle, &carry.angle);
+    }
 }
 
 static short CarryPitch(double pitch)
@@ -390,6 +398,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     boolean strafe, bstrafe;
     int speed, tspeed, lspeed;
     int angle = 0; // [crispy]
+    short mousex_angleturn; // [crispy]
     int forward, side;
     int look, arti;
     int flyheight;
@@ -888,11 +897,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         testcontrols_mousespeed = 0;
     }
 
+    mousex_angleturn = cmd->angleturn;
+
     if (angle)
     {
-        const short old_angleturn = cmd->angleturn;
-        cmd->angleturn = CarryAngle(localview.rawangle + angle);
-        localview.ticangleturn = cmd->angleturn - old_angleturn;
+        cmd->angleturn = CarryAngle(cmd->angleturn + angle);
+        localview.ticangleturn = cmd->angleturn - mousex_angleturn;
     }
 
     if (cmd->lookdir)
@@ -995,20 +1005,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         if (shortticfix)
         {
-            static signed short carry = 0;
             signed short desired_angleturn;
 
-            desired_angleturn = cmd->angleturn + carry;
+            desired_angleturn = cmd->angleturn;
 
             // round angleturn to the nearest 256 unit boundary
             // for recording demos with single byte values for turn
 
             cmd->angleturn = (desired_angleturn + 128) & 0xff00;
+            if (angle)
+            {
+                localview.ticangleturn = cmd->angleturn - mousex_angleturn;
+            }
 
             // Carry forward the error from the reduced resolution to the
             // next tic, so that successive small movements can accumulate.
 
-            carry = desired_angleturn - cmd->angleturn;
+            prevcarry.angle += desired_angleturn - cmd->angleturn;
         }
         else
         {

--- a/src/heretic/p_user.c
+++ b/src/heretic/p_user.c
@@ -198,6 +198,13 @@ void P_MovePlayer(player_t * player)
     onground = (player->mo->z <= player->mo->floorz
                 || (player->mo->flags2 & MF2_ONMOBJ));
 
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.ticangle += localview.ticangleturn << 16;
+        localview.ticangleturn = 0;
+    }
+
     if (player->chickenTics)
     {                           // Chicken speed
         if (cmd->forwardmove && (onground || player->mo->flags2 & MF2_FLY))
@@ -563,6 +570,12 @@ void P_PlayerThink(player_t * player)
     player->oldviewz = player->viewz;
     player->oldlookdir = player->lookdir;
     // player->oldrecoilpitch = player->recoilpitch;
+
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.oldticangle = localview.ticangle;
+    }
 
     // No-clip cheat
     if (player->cheats & CF_NOCLIP)

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -212,11 +212,13 @@ void R_CheckInterpolateSector(sector_t* sector)
     {
         // Interpolate between current and last floor/ceiling position.
         if (sector->floorheight != sector->oldfloorheight)
-            sector->interpfloorheight = sector->oldfloorheight + FixedMul(sector->floorheight - sector->oldfloorheight, fractionaltic);
+            sector->interpfloorheight =
+                LerpFixed(sector->oldfloorheight, sector->floorheight);
         else
             sector->interpfloorheight = sector->floorheight;
         if (sector->ceilingheight != sector->oldceilingheight)
-            sector->interpceilingheight = sector->oldceilingheight + FixedMul(sector->ceilingheight - sector->oldceilingheight, fractionaltic);
+            sector->interpceilingheight =
+                LerpFixed(sector->oldceilingheight, sector->ceilingheight);
         else
             sector->interpceilingheight = sector->ceilingheight;
     }

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -362,7 +362,38 @@ angle_t R_PointToAngleCrispy(fixed_t x, fixed_t y);
 angle_t R_PointToAngle2(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2);
 fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_ScaleFromGlobalAngle(angle_t visangle);
-angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);
+
+inline static fixed_t LerpFixed(fixed_t oldvalue, fixed_t newvalue)
+{
+    return (oldvalue + FixedMul(newvalue - oldvalue, fractionaltic));
+}
+
+inline static int LerpInt(int oldvalue, int newvalue)
+{
+    return (oldvalue + (int)((newvalue - oldvalue) * FIXED2DOUBLE(fractionaltic)));
+}
+
+// [AM] Interpolate between two angles.
+inline static angle_t LerpAngle(angle_t oangle, angle_t nangle)
+{
+    if (nangle == oangle)
+        return nangle;
+    else if (nangle > oangle)
+    {
+        if (nangle - oangle < ANG270)
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+    }
+    else // nangle < oangle
+    {
+        if (oangle - nangle < ANG270)
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+    }
+}
+
 subsector_t *R_PointInSubsector(fixed_t x, fixed_t y);
 void R_AddPointToBox(int x, int y, fixed_t * box);
 void R_ExecuteSetViewSize(void);

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -304,10 +304,19 @@ extern line_t *lines;
 extern int numsides;
 extern side_t *sides;
 
-
+// [crispy]
+typedef struct localview_s
+{
+    angle_t oldticangle;
+    angle_t ticangle;
+    short ticangleturn;
+    double rawangle;
+    angle_t angle;
+} localview_t;
 
 extern fixed_t viewx, viewy, viewz;
 extern angle_t viewangle;
+extern localview_t localview; // [crispy]
 extern player_t *viewplayer;
 
 

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -833,12 +833,11 @@ void R_SetupFrame(player_t * player)
         // Don't interpolate during a paused state
         leveltime > oldleveltime)
     {
-        viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-        viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-        viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-        viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
-        pitch = player->oldlookdir + (player->lookdir - player->oldlookdir) *
-                FIXED2DOUBLE(fractionaltic);
+        viewx = LerpFixed(player->mo->oldx, player->mo->x);
+        viewy = LerpFixed(player->mo->oldy, player->mo->y);
+        viewz = LerpFixed(player->oldviewz, player->viewz);
+        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        pitch = LerpInt(player->oldlookdir, player->lookdir);
     }
     else
     {

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -41,6 +41,7 @@ int sscount, linecount, loopcount;
 
 fixed_t viewx, viewy, viewz;
 angle_t viewangle;
+localview_t localview; // [crispy]
 fixed_t viewcos, viewsin;
 player_t *viewplayer;
 
@@ -804,6 +805,23 @@ subsector_t *R_PointInSubsector(fixed_t x, fixed_t y)
 
 }
 
+// [crispy]
+static inline boolean CheckLocalView(const player_t *player)
+{
+  return (
+    // Don't use localview if the player is spying.
+    player == &players[consoleplayer] &&
+    // Don't use localview if the player is dead.
+    player->playerstate != PST_DEAD &&
+    // Don't use localview if the player just teleported.
+    !player->mo->reactiontime &&
+    // Don't use localview if a demo is playing.
+    !demoplayback &&
+    // Don't use localview during a netgame (single-player only).
+    !netgame
+  );
+}
+
 //----------------------------------------------------------------------------
 //
 // PROC R_SetupFrame
@@ -833,10 +851,22 @@ void R_SetupFrame(player_t * player)
         // Don't interpolate during a paused state
         leveltime > oldleveltime)
     {
+        const boolean use_localview = CheckLocalView(player);
+
         viewx = LerpFixed(player->mo->oldx, player->mo->x);
         viewy = LerpFixed(player->mo->oldy, player->mo->y);
         viewz = LerpFixed(player->oldviewz, player->viewz);
-        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        if (use_localview)
+        {
+            viewangle = (player->mo->angle + localview.angle -
+                        localview.ticangle + LerpAngle(localview.oldticangle,
+                                                       localview.ticangle)) + viewangleoffset;
+        }
+        else
+        {
+            viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        }
+
         pitch = LerpInt(player->oldlookdir, player->lookdir);
     }
     else

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -526,10 +526,10 @@ void R_ProjectSprite(mobj_t * thing)
         // Don't interpolate during a paused state.
         leveltime > oldleveltime)
     {
-        interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
-        interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
-        interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
-        interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
+        interpx = LerpFixed(thing->oldx, thing->x);
+        interpy = LerpFixed(thing->oldy, thing->y);
+        interpz = LerpFixed(thing->oldz, thing->z);
+        interpangle = LerpAngle(thing->oldangle, thing->angle);
     }
 
     else
@@ -869,10 +869,10 @@ void R_DrawPSprite(pspdef_t * psp)
         if (lump == oldlump && pspr_interp)
         {
             int deltax = vis->x2 - vis->x1;
-            vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+            vis->x1 = LerpFixed(oldx1, vis->x1);
             vis->x2 = vis->x1 + deltax;
             vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
-            vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+            vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
         }
         else
         {

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -1739,8 +1739,8 @@ void AM_drawThings(int colors, int colorrange)
             // [crispy] interpolate thing triangles movement
             if (leveltime > oldleveltime)
             {
-            pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-            pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
+            pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+            pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
             }
             else
             {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -824,12 +824,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         side += CarryMouseSide(CalcMouseSide(mousex));
     }
 
-    if (mousex == 0)
+    mousex_angleturn = cmd->angleturn;
+
+    if (mousex_angleturn == 0)
     {
         testcontrols_mousespeed = 0;
     }
-
-    mousex_angleturn = cmd->angleturn;
 
     if (angle)
     {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -157,7 +157,7 @@ int lookheld;
 boolean mousearray[MAX_MOUSE_BUTTONS + 1];
 boolean *mousebuttons = &mousearray[1];
         // allow [-1]
-int mousex, mousex2, mousey;             // mouse values are used once
+int mousex, mousey;             // mouse values are used once
 int dclicktime, dclickstate, dclicks;
 int dclicktime2, dclickstate2, dclicks2;
 
@@ -871,7 +871,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         mbmlookctrl = 0;
     }
 
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
 
     if (forward > MaxPlayerMove[pClass])
     {
@@ -995,7 +995,7 @@ void G_DoLoadLevel(void)
 
     memset(gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
-    mousex = mousex2 = mousey = 0;
+    mousex = mousey = 0;
     memset(&localview, 0, sizeof(localview)); // [crispy]
     memset(&carry, 0, sizeof(carry)); // [crispy]
     memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -220,7 +220,15 @@ static int CarryError(double value, const double *prevcarry, double *carry)
 
 static short CarryAngle(double angle)
 {
-    return CarryError(angle, &prevcarry.angle, &carry.angle);
+    if (lowres_turn && abs(angle + prevcarry.angle) < 128)
+    {
+        carry.angle = angle + prevcarry.angle;
+        return 0;
+    }
+    else
+    {
+        return CarryError(angle, &prevcarry.angle, &carry.angle);
+    }
 }
 
 static short CarryPitch(double pitch)
@@ -283,6 +291,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     boolean strafe, bstrafe;
     int speed, tspeed, lspeed;
     int angle = 0; // [crispy]
+    short mousex_angleturn; // [crispy]
     int forward, side;
     int look, arti;
     int flyheight;
@@ -820,11 +829,12 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         testcontrols_mousespeed = 0;
     }
 
+    mousex_angleturn = cmd->angleturn;
+
     if (angle)
     {
-        const short old_angleturn = cmd->angleturn;
-        cmd->angleturn = CarryAngle(localview.rawangle + angle);
-        localview.ticangleturn = cmd->angleturn - old_angleturn;
+        cmd->angleturn = CarryAngle(cmd->angleturn + angle);
+        localview.ticangleturn = cmd->angleturn - mousex_angleturn;
     }
 
     if (cmd->lookdir)
@@ -940,20 +950,24 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         if (shortticfix)
         {
-            static signed short carry = 0;
             signed short desired_angleturn;
 
-            desired_angleturn = cmd->angleturn + carry;
+            desired_angleturn = cmd->angleturn;
 
             // round angleturn to the nearest 256 unit boundary
             // for recording demos with single byte values for turn
 
             cmd->angleturn = (desired_angleturn + 128) & 0xff00;
 
+            if (angle)
+            {
+                localview.ticangleturn = cmd->angleturn - mousex_angleturn;
+            }
+
             // Carry forward the error from the reduced resolution to the
             // next tic, so that successive small movements can accumulate.
 
-            carry = desired_angleturn - cmd->angleturn;
+            prevcarry.angle += desired_angleturn - cmd->angleturn;
         }
         else
         {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -395,30 +395,33 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 //
     if (strafe)
     {
-        if (gamekeydown[key_right] || mousebuttons[mousebturnright])
+        if (!cmd->angleturn)
         {
-            side += sidemove[pClass][speed];
-        }
-        if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
-        {
-            side -= sidemove[pClass][speed];
-        }
-        if (use_analog && joyxmove)
-        {
-            joyxmove = joyxmove * joystick_move_sensitivity / 10;
-            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
-            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
-            side += FixedMul(sidemove[pClass][speed], joyxmove);
-        }
-        else if (joystick_move_sensitivity)
-        {
-            if (joyxmove > 0)
+            if (gamekeydown[key_right] || mousebuttons[mousebturnright])
             {
                 side += sidemove[pClass][speed];
             }
-            if (joyxmove < 0)
+            if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
             {
                 side -= sidemove[pClass][speed];
+            }
+            if (use_analog && joyxmove)
+            {
+                joyxmove = joyxmove * joystick_move_sensitivity / 10;
+                joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+                joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+                side += FixedMul(sidemove[pClass][speed], joyxmove);
+            }
+            else if (joystick_move_sensitivity)
+            {
+                if (joyxmove > 0)
+                {
+                    side += sidemove[pClass][speed];
+                }
+                if (joyxmove < 0)
+                {
+                    side -= sidemove[pClass][speed];
+                }
             }
         }
     }

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -1087,6 +1087,13 @@ void H2_ProcessEvents(void)
 
 static void DrawAndBlit(void)
 {
+    if (crispy->uncapped)
+    {
+        I_StartDisplay();
+        G_FastResponder();
+        G_PrepTiccmd();
+    }
+
     // Change the view size if needed
     if (setsizeneeded)
     {

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -849,6 +849,8 @@ void G_WorldDone(void);
 void G_BuildTiccmd(ticcmd_t *cmd, int maketic);
 void G_Ticker(void);
 boolean G_Responder(event_t * ev);
+void G_FastResponder(void); // [crispy]
+void G_PrepTiccmd(void); // [crispy]
 
 void G_ScreenShot(void);
 

--- a/src/hexen/p_user.c
+++ b/src/hexen/p_user.c
@@ -211,6 +211,13 @@ void P_MovePlayer(player_t * player)
     onground = (player->mo->z <= player->mo->floorz
                 || (player->mo->flags2 & MF2_ONMOBJ));
 
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.ticangle += localview.ticangleturn << 16;
+        localview.ticangleturn = 0;
+    }
+
     if (cmd->forwardmove)
     {
         if (onground || player->mo->flags2 & MF2_FLY)
@@ -631,6 +638,12 @@ void P_PlayerThink(player_t * player)
     player->mo->oldangle = player->mo->angle;
     player->oldviewz = player->viewz;
     player->oldlookdir = player->lookdir;
+
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.oldticangle = localview.ticangle;
+    }
 
     // No-clip cheat
     if (player->cheats & CF_NOCLIP)

--- a/src/hexen/r_bsp.c
+++ b/src/hexen/r_bsp.c
@@ -210,11 +210,13 @@ void R_CheckInterpolateSector(sector_t* sector)
     {
         // Interpolate between current and last floor/ceiling position.
         if (sector->floorheight != sector->oldfloorheight)
-            sector->interpfloorheight = sector->oldfloorheight + FixedMul(sector->floorheight - sector->oldfloorheight, fractionaltic);
+            sector->interpfloorheight =
+                LerpFixed(sector->oldfloorheight, sector->floorheight);
         else
             sector->interpfloorheight = sector->floorheight;
         if (sector->ceilingheight != sector->oldceilingheight)
-            sector->interpceilingheight = sector->oldceilingheight + FixedMul(sector->ceilingheight - sector->oldceilingheight, fractionaltic);
+            sector->interpceilingheight =
+                LerpFixed(sector->oldceilingheight, sector->ceilingheight);
         else
             sector->interpceilingheight = sector->ceilingheight;
     }

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -350,10 +350,20 @@ extern line_t *lines;
 extern int numsides;
 extern side_t *sides;
 
+// [crispy]
+typedef struct localview_s
+{
+    angle_t oldticangle;
+    angle_t ticangle;
+    short ticangleturn;
+    double rawangle;
+    angle_t angle;
+} localview_t;
 
 
 extern fixed_t viewx, viewy, viewz;
 extern angle_t viewangle;
+extern localview_t localview; // [crispy]
 extern player_t *viewplayer;
 
 

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -406,6 +406,38 @@ angle_t R_PointToAngleCrispy(fixed_t x, fixed_t y);
 angle_t R_PointToAngle2(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2);
 fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_ScaleFromGlobalAngle(angle_t visangle);
+
+inline static fixed_t LerpFixed(fixed_t oldvalue, fixed_t newvalue)
+{
+    return (oldvalue + FixedMul(newvalue - oldvalue, fractionaltic));
+}
+
+inline static int LerpInt(int oldvalue, int newvalue)
+{
+    return (oldvalue + (int)((newvalue - oldvalue) * FIXED2DOUBLE(fractionaltic)));
+}
+
+// [AM] Interpolate between two angles.
+inline static angle_t LerpAngle(angle_t oangle, angle_t nangle)
+{
+    if (nangle == oangle)
+        return nangle;
+    else if (nangle > oangle)
+    {
+        if (nangle - oangle < ANG270)
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+    }
+    else // nangle < oangle
+    {
+        if (oangle - nangle < ANG270)
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+    }
+}
+
 angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);
 subsector_t *R_PointInSubsector(fixed_t x, fixed_t y);
 //void R_AddPointToBox (int x, int y, fixed_t *box);

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -813,12 +813,11 @@ void R_SetupFrame(player_t * player)
     // haleyjd FIXME: viewangleoffset handling?
     if (crispy->uncapped && leveltime > 1 && player->mo->interp == true && leveltime > oldleveltime)
     {
-        viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-        viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-        viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-        viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
-        pitch = player->oldlookdir + (player->lookdir - player->oldlookdir) *
-                FIXED2DOUBLE(fractionaltic);
+        viewx = LerpFixed(player->mo->oldx, player->mo->x);
+        viewy = LerpFixed(player->mo->oldy, player->mo->y);
+        viewz = LerpFixed(player->oldviewz, player->viewz);
+        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        pitch = LerpInt(player->oldlookdir, player->lookdir);
     }
     else
     {

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -522,10 +522,10 @@ void R_ProjectSprite(mobj_t * thing)
         // Don't interpolate during a paused state.
         leveltime > oldleveltime)
     {
-        interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
-        interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
-        interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
-        interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
+        interpx = LerpFixed(thing->oldx, thing->x);
+        interpy = LerpFixed(thing->oldy, thing->y);
+        interpz = LerpFixed(thing->oldz, thing->z);
+        interpangle = LerpAngle(thing->oldangle, thing->angle);
     }
 
     else
@@ -890,10 +890,10 @@ void R_DrawPSprite(pspdef_t * psp)
         if (lump == oldlump && pspr_interp)
         {
             int deltax = vis->x2 - vis->x1;
-            vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+            vis->x1 = LerpFixed(oldx1, vis->x1);
             vis->x2 = vis->x1 + deltax;
             vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
-            vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+            vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
         }
         else
         {

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -510,14 +510,15 @@ static void UpdateMouseAccel(int x, int y)
 
 }
 
-static int AccelerateMouse(int val)
+// [crispy] Change to double
+double I_AccelerateMouse(int val)
 {
     if (val < 0)
-        return -AccelerateMouse(-val);
+        return -I_AccelerateMouse(-val);
 
     if (abs(mousex.total) > mouse_threshold)
     {
-        return (int)((val - x_threshold) * mouse_acceleration + x_threshold);
+        return (val - x_threshold) * mouse_acceleration + x_threshold;
     }
     else
     {
@@ -525,15 +526,15 @@ static int AccelerateMouse(int val)
     }
 }
 
-// [crispy]
-static int AccelerateMouseY(int val)
+// [crispy] Change to double
+double I_AccelerateMouseY(int val)
 {
     if (val < 0)
-        return -AccelerateMouseY(-val);
+        return -I_AccelerateMouseY(-val);
 
     if (abs(mousey.total) > mouse_threshold_y)
     {
-        return (int)((val - y_threshold) * mouse_acceleration_y + y_threshold);
+        return (val - y_threshold) * mouse_acceleration_y + y_threshold;
     }
     else
     {
@@ -558,11 +559,11 @@ void I_ReadMouse(void)
     {
         ev.type = ev_mouse;
         ev.data1 = mouse_button_state;
-        ev.data2 = AccelerateMouse(x);
+        ev.data2 = x;
 
         if (true || !novert) // [crispy] moved to src/*/g_game.c
         {
-            ev.data3 = -AccelerateMouseY(y); // [crispy]
+            ev.data3 = -y; // [crispy]
         }
         else
         {
@@ -584,11 +585,11 @@ void I_ReadMouseUncapped(void)
 
     if (x != 0 || y != 0)
     {
-        fastmouse.data2 = AccelerateMouse(x);
+        fastmouse.data2 = x;
 
         if (true || !novert) // [crispy] moved to src/*/g_game.c
         {
-            fastmouse.data3 = -AccelerateMouseY(y); // [crispy]
+            fastmouse.data3 = -y; // [crispy]
         }
         else
         {

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -35,6 +35,10 @@ extern int mouse_y_invert; // [crispy]
 extern int novert; // [crispy]
 extern int runcentering; // [crispy]
 
+// [crispy]
+double I_AccelerateMouse(int val);
+double I_AccelerateMouseY(int val);
+
 void I_BindStrifeInputVariables(void); // [crispy]
 void I_BindInputVariables(void);
 void I_ReadMouse(void);

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -38,6 +38,7 @@ extern int runcentering; // [crispy]
 void I_BindStrifeInputVariables(void); // [crispy]
 void I_BindInputVariables(void);
 void I_ReadMouse(void);
+void I_ReadMouseUncapped(void); // [crispy]
 
 // I_StartTextInput begins text input, activating the on-screen keyboard
 // (if one is used). The caller indicates that any entered text will be

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -542,10 +542,10 @@ void I_StartTic (void)
 
 void I_StartDisplay(void) // [crispy]
 {
-    SDL_PumpEvents();
-
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     fractionaltic = I_GetFracRealTime();
+
+    SDL_PumpEvents();
 
     if (usemouse && !nomouse && window_focused)
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -540,6 +540,18 @@ void I_StartTic (void)
     }
 }
 
+void I_StartDisplay(void) // [crispy]
+{
+    SDL_PumpEvents();
+
+    // [AM] Figure out how far into the current tic we're in as a fixed_t.
+    fractionaltic = I_GetFracRealTime();
+
+    if (usemouse && !nomouse && window_focused)
+    {
+        I_ReadMouseUncapped();
+    }
+}
 
 //
 // I_UpdateNoBlit
@@ -929,9 +941,6 @@ void I_FinishUpdate (void)
                 }
             }
         }
-
-        // [AM] Figure out how far into the current tic we're in as a fixed_t.
-        fractionaltic = I_GetFracRealTime();
     }
 
     // Restore background and undo the disk indicator, if it was drawn.

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -100,6 +100,8 @@ void I_StartFrame (void);
 
 void I_StartTic (void);
 
+void I_StartDisplay (void); // [crispy]
+
 // Enable the loading disk image displayed when reading from disk.
 
 void I_EnableLoadingDisk(int xoffs, int yoffs);

--- a/src/strife/am_map.c
+++ b/src/strife/am_map.c
@@ -1718,8 +1718,8 @@ void AM_drawPlayers(void)
 	// [crispy] interpolate other player arrows
 	if (crispy->uncapped && leveltime > oldleveltime)
 	{
-	    pt.x = (p->mo->oldx + FixedMul(p->mo->x - p->mo->oldx, fractionaltic)) >> FRACTOMAPBITS;
-	    pt.y = (p->mo->oldy + FixedMul(p->mo->y - p->mo->oldy, fractionaltic)) >> FRACTOMAPBITS;
+	    pt.x = LerpFixed(p->mo->oldx, p->mo->x) >> FRACTOMAPBITS;
+	    pt.y = LerpFixed(p->mo->oldy, p->mo->y) >> FRACTOMAPBITS;
 	}
 	else
 	{
@@ -1734,7 +1734,7 @@ void AM_drawPlayers(void)
 	}
 	else
 	{
-        theirangle = R_InterpolateAngle(p->mo->oldangle, p->mo->angle, fractionaltic);
+        theirangle = LerpAngle(p->mo->oldangle, p->mo->angle);
 	}
 
 	AM_drawLineCharacter
@@ -1774,8 +1774,8 @@ void AM_drawThings(void)
             // [crispy] interpolate thing triangles movement
             if (leveltime > oldleveltime)
             {
-                pt.x = (t->oldx + FixedMul(t->x - t->oldx, fractionaltic)) >> FRACTOMAPBITS;
-                pt.y = (t->oldy + FixedMul(t->y - t->oldy, fractionaltic)) >> FRACTOMAPBITS;
+                pt.x = LerpFixed(t->oldx, t->x) >> FRACTOMAPBITS;
+                pt.y = LerpFixed(t->oldy, t->y) >> FRACTOMAPBITS;
             }
             else
             {

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -222,6 +222,13 @@ void D_Display (void)
 
     redrawsbar = false;
     
+    if (crispy->uncapped)
+    {
+        I_StartDisplay();
+        G_FastResponder();
+        G_PrepTiccmd();
+    }
+
     // change the view size if needed
     if (setsizeneeded)
     {

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -862,15 +862,15 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     if (strafe && !cmd->angleturn)
         side += CarryMouseSide(CalcMouseSide(mousex));
 
-    if (mousex == 0)
+    mousex_angleturn = cmd->angleturn;
+
+    if (mousex_angleturn == 0)
     {
         // No movement in the previous frame
 
         testcontrols_mousespeed = 0;
     }
     
-    mousex_angleturn = cmd->angleturn;
-
     if (angle)
     {
         cmd->angleturn = CarryAngle(cmd->angleturn + angle);

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -207,7 +207,6 @@ static boolean *mousebuttons = &mousearray[1];  // allow [-1]
 
 // mouse values are used once 
 int             mousex;
-int             mousex2; // [crispy]
 int             mousey;         
 
 // [crispy] for rounding error
@@ -867,7 +866,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             (old_angleturn - cmd->angleturn) : (cmd->angleturn - old_angleturn);
     }
 
-    mousex = mousex2 = mousey = 0; // [crispy]
+    mousex = mousey = 0;
 
     if (forward > MAXPLMOVE) 
         forward = MAXPLMOVE; 
@@ -971,7 +970,7 @@ void G_DoLoadLevel (void)
 
     memset (gamekeydown, 0, sizeof(gamekeydown));
     joyxmove = joyymove = joystrafemove = joylook = 0;
-    mousex = mousex2 = mousey = 0; // [crispy]
+    mousex = mousey = 0;
     memset(&localview, 0, sizeof(localview)); // [crispy]
     memset(&carry, 0, sizeof(carry)); // [crispy]
     memset(&prevcarry, 0, sizeof(prevcarry)); // [crispy]

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -588,31 +588,33 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     // let movement keys cancel each other out
     if (strafe) 
     { 
-        if (gamekeydown[key_right] || mousebuttons[mousebturnright])
+        if (!cmd->angleturn)
         {
-            // fprintf(stderr, "strafe right\n");
-            side += sidemove[speed]; 
-        }
-        if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
-        {
-            //	fprintf(stderr, "strafe left\n");
-            side -= sidemove[speed]; 
-        }
-        if (use_analog && joyxmove)
-        {
-            joyxmove = joyxmove * joystick_move_sensitivity / 10;
-            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
-            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
-            side += FixedMul(sidemove[speed], joyxmove);
-        }
-        else if (joystick_move_sensitivity)
-        {
-            if (joyxmove > 0)
+            if (gamekeydown[key_right] || mousebuttons[mousebturnright])
+            {
+                // fprintf(stderr, "strafe right\n");
                 side += sidemove[speed];
-            if (joyxmove < 0)
+            }
+            if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
+            {
+                //	fprintf(stderr, "strafe left\n");
                 side -= sidemove[speed];
+            }
+            if (use_analog && joyxmove)
+            {
+                joyxmove = joyxmove * joystick_move_sensitivity / 10;
+                joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+                joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+                side += FixedMul(sidemove[speed], joyxmove);
+            }
+            else if (joystick_move_sensitivity)
+            {
+                if (joyxmove > 0)
+                    side += sidemove[speed];
+                if (joyxmove < 0)
+                    side -= sidemove[speed];
+            }
         }
-
     } 
     else 
     { 

--- a/src/strife/g_game.h
+++ b/src/strife/g_game.h
@@ -75,6 +75,8 @@ void G_BuildTiccmd (ticcmd_t *cmd, int maketic);
 
 void G_Ticker (void);
 boolean G_Responder (event_t*	ev);
+void G_FastResponder (void); // [crispy]
+void G_PrepTiccmd (void); // [crispy]
 
 void G_ScreenShot (void);
 

--- a/src/strife/p_user.c
+++ b/src/strife/p_user.c
@@ -188,6 +188,13 @@ void P_MovePlayer (player_t* player)
     //  if not onground.
     onground = (player->mo->z <= player->mo->floorz);
 
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.ticangle += localview.ticangleturn << 16;
+        localview.ticangleturn = 0;
+    }
+
     // villsa [STRIFE] allows player to climb over things by jumping
     // haleyjd 20110205: air control thrust should be 256, not cmd->forwardmove
     if(!onground)
@@ -364,6 +371,12 @@ void P_PlayerThink (player_t* player)
     player->mo->oldangle = player->mo->angle;
     player->oldviewz = player->viewz;
     player->oldpitch = player->pitch;
+
+    // [crispy] fast polling
+    if (player == &players[consoleplayer])
+    {
+        localview.oldticangle = localview.ticangle;
+    }
 
     // [crispy] update weapon sound source coordinates
     if (player->so != player->mo)

--- a/src/strife/r_bsp.c
+++ b/src/strife/r_bsp.c
@@ -261,11 +261,13 @@ void R_CheckInterpolateSector(sector_t* sector)
     {
         // Interpolate between current and last floor/ceiling position.
         if (sector->floorheight != sector->oldfloorheight)
-            sector->interpfloorheight = sector->oldfloorheight + FixedMul(sector->floorheight - sector->oldfloorheight, fractionaltic);
+            sector->interpfloorheight =
+                LerpFixed(sector->oldfloorheight, sector->floorheight);
         else
             sector->interpfloorheight = sector->floorheight;
         if (sector->ceilingheight != sector->oldceilingheight)
-            sector->interpceilingheight = sector->oldceilingheight + FixedMul(sector->ceilingheight - sector->oldceilingheight, fractionaltic);
+            sector->interpceilingheight =
+                LerpFixed(sector->oldceilingheight, sector->ceilingheight);
         else
             sector->interpceilingheight = sector->ceilingheight;
     }

--- a/src/strife/r_main.c
+++ b/src/strife/r_main.c
@@ -75,6 +75,7 @@ fixed_t			viewz;
 int                     viewpitch;  // villsa [STRIFE]
 
 angle_t			viewangle;
+localview_t		localview; // [crispy]
 
 fixed_t			viewcos;
 fixed_t			viewsin;
@@ -1019,6 +1020,23 @@ void R_SetupPitch(int pitch)
     }
 }
 
+// [crispy]
+static inline boolean CheckLocalView(const player_t *player)
+{
+  return (
+    // Don't use localview if the player is spying.
+    player == &players[consoleplayer] &&
+    // Don't use localview if the player is dead.
+    player->playerstate != PST_DEAD &&
+    // Don't use localview if the player just teleported.
+    !player->mo->reactiontime &&
+    // Don't use localview if a demo is playing.
+    !demoplayback &&
+    // Don't use localview during a netgame (single-player only).
+    !netgame
+  );
+}
+
 
 //
 // R_SetupFrame
@@ -1034,10 +1052,22 @@ void R_SetupFrame (player_t* player)
     if (crispy->uncapped && leveltime > 1 && player->mo->interp == true &&
         leveltime > oldleveltime && !screenwipe)
     {
+        const boolean use_localview = CheckLocalView(player);
+
         viewx = LerpFixed(player->mo->oldx, player->mo->x);
         viewy = LerpFixed(player->mo->oldy, player->mo->y);
         viewz = LerpFixed(player->oldviewz, player->viewz);
-        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        if (use_localview)
+        {
+            viewangle = (player->mo->angle + localview.angle -
+                        localview.ticangle + LerpAngle(localview.oldticangle,
+                                                       localview.ticangle)) + viewangleoffset;
+        }
+        else
+        {
+            viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        }
+
         pitch = LerpInt(player->oldpitch, player->pitch);
     }
     else

--- a/src/strife/r_main.c
+++ b/src/strife/r_main.c
@@ -1034,11 +1034,11 @@ void R_SetupFrame (player_t* player)
     if (crispy->uncapped && leveltime > 1 && player->mo->interp == true &&
         leveltime > oldleveltime && !screenwipe)
     {
-        viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-        viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-        viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-        viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
-        pitch = player->oldpitch + (player->pitch - player->oldpitch) * FIXED2DOUBLE(fractionaltic);
+        viewx = LerpFixed(player->mo->oldx, player->mo->x);
+        viewy = LerpFixed(player->mo->oldy, player->mo->y);
+        viewz = LerpFixed(player->oldviewz, player->viewz);
+        viewangle = LerpAngle(player->mo->oldangle, player->mo->angle) + viewangleoffset;
+        pitch = LerpInt(player->oldpitch, player->pitch);
     }
     else
     {

--- a/src/strife/r_main.h
+++ b/src/strife/r_main.h
@@ -152,6 +152,36 @@ R_AddPointToBox
   int		y,
   fixed_t*	box );
 
+inline static fixed_t LerpFixed(fixed_t oldvalue, fixed_t newvalue)
+{
+    return (oldvalue + FixedMul(newvalue - oldvalue, fractionaltic));
+}
+
+inline static int LerpInt(int oldvalue, int newvalue)
+{
+    return (oldvalue + (int)((newvalue - oldvalue) * FIXED2DOUBLE(fractionaltic)));
+}
+
+// [AM] Interpolate between two angles.
+inline static angle_t LerpAngle(angle_t oangle, angle_t nangle)
+{
+    if (nangle == oangle)
+        return nangle;
+    else if (nangle > oangle)
+    {
+        if (nangle - oangle < ANG270)
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+    }
+    else // nangle < oangle
+    {
+        if (oangle - nangle < ANG270)
+            return oangle - (angle_t)((oangle - nangle) * FIXED2DOUBLE(fractionaltic));
+        else // Wrapped around
+            return oangle + (angle_t)((nangle - oangle) * FIXED2DOUBLE(fractionaltic));
+    }
+}
 
 // [AM] Interpolate between two angles.
 angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);

--- a/src/strife/r_state.h
+++ b/src/strife/r_state.h
@@ -90,6 +90,15 @@ extern line_t*		lines;
 extern int		numsides;
 extern side_t*		sides;
 
+// [crispy]
+typedef struct localview_s
+{
+    angle_t oldticangle;
+    angle_t ticangle;
+    short ticangleturn;
+    double rawangle;
+    angle_t angle;
+} localview_t;
 
 //
 // POV data.
@@ -99,6 +108,7 @@ extern fixed_t		viewy;
 extern fixed_t		viewz;
 
 extern angle_t		viewangle;
+extern localview_t      localview; // [crispy]
 extern player_t*	viewplayer;
 
 

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -537,10 +537,10 @@ void R_ProjectSprite (mobj_t* thing)
     // [AM] Interpolate between current and last position, if prudent.
     if (crispy->uncapped && thing->interp == true && leveltime > oldleveltime)
     {
-        interpx = thing->oldx + FixedMul(thing->x - thing->oldx, fractionaltic);
-        interpy = thing->oldy + FixedMul(thing->y - thing->oldy, fractionaltic);
-        interpz = thing->oldz + FixedMul(thing->z - thing->oldz, fractionaltic);
-        interpangle = R_InterpolateAngle(thing->oldangle, thing->angle, fractionaltic);
+        interpx = LerpFixed(thing->oldx, thing->x);
+        interpy = LerpFixed(thing->oldy, thing->y);
+        interpz = LerpFixed(thing->oldz, thing->z);
+        interpangle = LerpAngle(thing->oldangle, thing->angle);
     }
     else
     {
@@ -860,10 +860,10 @@ void R_DrawPSprite (pspdef_t* psp, psprnum_t psprnum) // [crispy] read psprnum
         if (lump == oldlump && pspr_interp)
         {
             int deltax = vis->x2 - vis->x1;
-            vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+            vis->x1 = LerpFixed(oldx1, vis->x1);
             vis->x2 = vis->x1 + deltax;
             vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
-            vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+            vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
         }
         else
         {


### PR DESCRIPTION
This is my humble attempt to port to Crispy the fine work that @ceski-1 did for Woof. It's not ready yet but I thought it might be prudent to go ahead and get it out there for early review and testing.

EDIT: Calling this one complete. We are still missing vertical mouse and gamepad, but those can come later. The vertical mouse implementation in particular needs some careful study and refactoring across the four games.

This is not as sophisticated as the current implementation in Woof! but I think it stands on its own as a solid improvement to mousefeel for typical KB + M players.