### PR TITLE
Doom: fix blinking of drawing Tower of Babel on intermission screen

### DIFF
--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -552,7 +552,7 @@ void WI_initAnimatedBack(boolean firstcall)
 	// init variables
 	// [crispy] Do not reset animation timers upon switching to "Entering" state
 	// via WI_initShowNextLoc. Fixes notable blinking of Tower of Babel drawing
-	// and animations from being reset.
+	// and the rest of animations from being restarted.
 	if (firstcall)
 	a->ctr = -1;
 


### PR DESCRIPTION
This is a very, very minor thing, but once you'll notice, it can't be unseen. Fortunately, the fix is very easy - we have to initialize animation variables (`a->ctr = -1;`) just once, when we are entering tally screen, and don't touch them when switching to "Entering" screen.

However! This fixes not only Tower of Babel itself, but whole animations on all three episodes. But such breaks in all other animations will be hard to notice since they are small. Probably red sky in E3 background is more or less noticeable.

Easiest way to see tower's blinking is an exit from E2M7, as in this state tower is almost built and it's sprite is tall enough.

_Initial suggestion and video example: in https://github.com/JNechaevsky/international-doom/issues/122_