### PR TITLE
Various menu control improvements

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -2469,13 +2469,13 @@ boolean M_Responder (event_t* ev)
 	    if (ev->data1&1)
 	    {
 		key = key_menu_forward;
-		mousewait = I_GetTime() + 15;
+		mousewait = I_GetTime() + 5;
 	    }
 			
 	    if (ev->data1&2)
 	    {
 		key = key_menu_back;
-		mousewait = I_GetTime() + 15;
+		mousewait = I_GetTime() + 5;
 	    }
 
 	    // [crispy] scroll menus with mouse wheel

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1335,7 +1335,8 @@ void M_DrawEpisode(void)
 
 void M_VerifyNightmare(int key)
 {
-    if (key != key_menu_confirm)
+    // [crispy] allow to confirm by pressing Enter key
+    if (key != key_menu_confirm && key != key_menu_forward)
 	return;
 		
     G_DeferedInitNew(nightmare,epi+1,1);
@@ -1720,7 +1721,8 @@ void M_ChangeMessages(int choice)
 //
 void M_EndGameResponse(int key)
 {
-    if (key != key_menu_confirm)
+    // [crispy] allow to confirm by pressing Enter key
+    if (key != key_menu_confirm && key != key_menu_forward)
 	return;
 		
     // [crispy] killough 5/26/98: make endgame quit if recording or playing back demo
@@ -1812,7 +1814,8 @@ void M_QuitResponse(int key)
 {
     extern int show_endoom;
 
-    if (key != key_menu_confirm)
+    // [crispy] allow to confirm by pressing Enter key
+    if (key != key_menu_confirm && key != key_menu_forward)
 	return;
     // [crispy] play quit sound only if the ENDOOM screen is also shown
     if (!netgame && show_endoom)
@@ -2634,7 +2637,9 @@ boolean M_Responder (event_t* ev)
 	if (messageNeedsInput)
         {
             if (key != ' ' && key != KEY_ESCAPE
-             && key != key_menu_confirm && key != key_menu_abort)
+             && key != key_menu_confirm && key != key_menu_abort
+             // [crispy] allow to confirm nightmare, end game and quit by pressing Enter key
+             && key != key_menu_forward)
             {
                 return false;
             }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1052,6 +1052,11 @@ static void SetJoyButtons(unsigned int buttons_mask)
 static boolean InventoryMoveLeft()
 {
     inventoryTics = 5 * 35;
+
+    if (MenuActive)
+    {
+        return false;
+    }
     if (!inventory)
     {
         inventory = true;
@@ -1079,6 +1084,11 @@ static boolean InventoryMoveRight()
 
     plr = &players[consoleplayer];
     inventoryTics = 5 * 35;
+
+    if (MenuActive)
+    {
+        return false;
+    }
     if (!inventory)
     {
         inventory = true;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1892,6 +1892,75 @@ boolean MN_Responder(event_t * event)
             return true;
         }
     }
+    else // [crispy] allow menu control with the mouse
+    {
+        static int mousewait = 0;
+        static int mousey = 0;
+        static int lasty = 0;
+
+        if (event->type == ev_mouse && mousewait < I_GetTime())
+        {
+            // [crispy] novert disables up/down cursor movement with the mouse
+            if (!novert)
+            {
+                mousey += event->data3;
+            }
+
+            if (mousey < lasty - 30)
+            {
+                key = key_menu_down;
+                mousewait = I_GetTime() + 5;
+                mousey = lasty -= 30;
+            }
+            else if (mousey > lasty + 30)
+            {
+                key = key_menu_up;
+                mousewait = I_GetTime() + 5;
+                mousey = lasty += 30;
+            }
+
+            if (event->data1 & 1)
+            {
+                key = key_menu_forward;
+                mousewait = I_GetTime() + 5;
+            }
+
+            if (event->data1 & 2)
+            {
+                if (FileMenuKeySteal)
+                {
+                    key = KEY_ESCAPE;
+                    FileMenuKeySteal = false;
+                }
+                else
+                {
+                    key = key_menu_back;
+                }
+                mousewait = I_GetTime() + 15;
+            }
+
+            // [crispy] scroll menus with mouse wheel
+            if (event->data1 & (1 << 4))
+            {
+                key = key_menu_down;
+                mousewait = I_GetTime() + 1;
+            }
+            else
+            if (event->data1 & (1 << 3))
+            {
+                key = key_menu_up;
+                mousewait = I_GetTime() + 1;
+            }
+        }
+        else
+        {
+            if (event->type == ev_keydown)
+            {
+                key = event->data1;
+                charTyped = event->data2;
+            }
+        }
+    }
 
     if (event->type != ev_keydown && key == -1)
     {

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1938,7 +1938,9 @@ boolean MN_Responder(event_t * event)
 
     if (askforquit)
     {
-        if (key == key_menu_confirm)
+        if (key == key_menu_confirm
+        // [crispy] allow to confirm quit (1) and end game (2) by pressing Enter key
+        || (key == key_menu_forward && (typeofask == 1 || typeofask == 2)))
         {
             switch (typeofask)
             {
@@ -2178,7 +2180,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_quit)            // F10 (quit)
         {
-            if (gamestate == GS_LEVEL)
+            // [crispy] allow to invoke quit in any game state
+            // if (gamestate == GS_LEVEL)
             {
                 SCQuitGame(0);
                 S_StartSound(NULL, sfx_chat);

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1936,7 +1936,7 @@ boolean MN_Responder(event_t * event)
                 {
                     key = key_menu_back;
                 }
-                mousewait = I_GetTime() + 15;
+                mousewait = I_GetTime() + 5;
             }
 
             // [crispy] scroll menus with mouse wheel

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -977,6 +977,11 @@ static void SetJoyButtons(unsigned int buttons_mask)
 static boolean InventoryMoveLeft()
 {
     inventoryTics = 5 * 35;
+
+    if (MenuActive)
+    {
+        return false;
+    }
     if (!inventory)
     {
         inventory = true;
@@ -1004,6 +1009,11 @@ static boolean InventoryMoveRight()
 
     plr = &players[consoleplayer];
     inventoryTics = 5 * 35;
+
+    if (MenuActive)
+    {
+        return false;
+    }
     if (!inventory)
     {
         inventory = true;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1936,7 +1936,9 @@ boolean MN_Responder(event_t * event)
 
     if (askforquit)
     {
-        if (key == key_menu_confirm)
+        if (key == key_menu_confirm
+        // [crispy] allow to confirm quit (1) and end game (2) by pressing Enter key
+        || (key == key_menu_forward && (typeofask == 1 || typeofask == 2)))
         {
             switch (typeofask)
             {
@@ -2177,7 +2179,8 @@ boolean MN_Responder(event_t * event)
         }
         else if (key == key_menu_quit)           // F10 (quit)
         {
-            if (gamestate == GS_LEVEL || gamestate == GS_FINALE)
+            // [crispy] allow to invoke quit in any game state
+            // if (gamestate == GS_LEVEL || gamestate == GS_FINALE)
             {
                 SCQuitGame(0);
                 S_StartSound(NULL, SFX_CHAT);

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1885,6 +1885,75 @@ boolean MN_Responder(event_t * event)
             return true;
         }
     }
+    else // [crispy] allow menu control with the mouse
+    {
+        static int mousewait = 0;
+        static int mousey = 0;
+        static int lasty = 0;
+
+        if (event->type == ev_mouse && mousewait < I_GetTime())
+        {
+            // [crispy] novert disables up/down cursor movement with the mouse
+            if (!novert)
+            {
+                mousey += event->data3;
+            }
+
+            if (mousey < lasty - 30)
+            {
+                key = key_menu_down;
+                mousewait = I_GetTime() + 5;
+                mousey = lasty -= 30;
+            }
+            else if (mousey > lasty + 30)
+            {
+                key = key_menu_up;
+                mousewait = I_GetTime() + 5;
+                mousey = lasty += 30;
+            }
+
+            if (event->data1 & 1)
+            {
+                key = key_menu_forward;
+                mousewait = I_GetTime() + 5;
+            }
+
+            if (event->data1 & 2)
+            {
+                if (FileMenuKeySteal)
+                {
+                    key = KEY_ESCAPE;
+                    FileMenuKeySteal = false;
+                }
+                else
+                {
+                    key = key_menu_back;
+                }
+                mousewait = I_GetTime() + 15;
+            }
+
+            // [crispy] scroll menus with mouse wheel
+            if (event->data1 & (1 << 4))
+            {
+                key = key_menu_down;
+                mousewait = I_GetTime() + 1;
+            }
+            else
+            if (event->data1 & (1 << 3))
+            {
+                key = key_menu_up;
+                mousewait = I_GetTime() + 1;
+            }
+        }
+        else
+        {
+            if (event->type == ev_keydown)
+            {
+                key = event->data1;
+                charTyped = event->data2;
+            }
+        }
+    }
 
     if (event->type != ev_keydown && key == -1)
     {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1929,7 +1929,7 @@ boolean MN_Responder(event_t * event)
                 {
                     key = key_menu_back;
                 }
-                mousewait = I_GetTime() + 15;
+                mousewait = I_GetTime() + 5;
             }
 
             // [crispy] scroll menus with mouse wheel

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2373,7 +2373,7 @@ boolean M_Responder (event_t* ev)
             if (ev->data1&1)
             {
                 key = key_menu_forward;
-                mousewait = I_GetTime() + 15;
+                mousewait = I_GetTime() + 5;
                 if (menuindialog) // [crispy] fix mouse fire delay
                 {
                 mouse_fire_countdown = 5;   // villsa [STRIFE]
@@ -2383,7 +2383,7 @@ boolean M_Responder (event_t* ev)
             if (ev->data1&2)
             {
                 key = key_menu_back;
-                mousewait = I_GetTime() + 15;
+                mousewait = I_GetTime() + 5;
             }
 
             // [crispy] scroll menus with mouse wheel

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -1646,7 +1646,8 @@ void M_ChangeMessages(int choice)
 //
 void M_EndGameResponse(int key)
 {
-    if (key != key_menu_confirm)
+    // [crispy] allow to confirm by pressing Enter key
+    if (key != key_menu_confirm && key != key_menu_forward)
         return;
 
     currentMenu->lastOn = itemOn;
@@ -1747,7 +1748,8 @@ void M_QuitResponse(int key)
 {
     char buffer[20];
 
-    if (key != key_menu_confirm)
+    // [crispy] allow to confirm by pressing Enter key
+    if (key != key_menu_confirm && key != key_menu_forward)
         return;
 
     // [crispy] quit immediately if not showing exit screen
@@ -2539,7 +2541,9 @@ boolean M_Responder (event_t* ev)
         if (messageNeedsInput)
         {
             if (key != ' ' && key != KEY_ESCAPE
-                && key != key_menu_confirm && key != key_menu_abort)
+                && key != key_menu_confirm && key != key_menu_abort
+                // [crispy] allow to confirm end game and quit by pressing Enter key
+                && key != key_menu_forward)
             {
                 return false;
             }

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2336,7 +2336,8 @@ boolean M_Responder (event_t* ev)
         if (ev->type == ev_mouse && mousewait < I_GetTime())
         {
             // [crispy] Don't control Crispness menu with y-axis mouse movement.
-            if (!inhelpscreens)
+            // "novert" disables up/down cursor movement with the mouse.
+            if (!inhelpscreens && !novert)
                 mousey += ev->data3;
 
             if (mousey < lasty-30)
@@ -2383,6 +2384,19 @@ boolean M_Responder (event_t* ev)
             {
                 key = key_menu_back;
                 mousewait = I_GetTime() + 15;
+            }
+
+            // [crispy] scroll menus with mouse wheel
+            if (mousebprevweapon >= 0 && ev->data1 & (1 << mousebprevweapon))
+            {
+                key = key_menu_down;
+                mousewait = I_GetTime() + 1;
+            }
+            else
+            if (mousebnextweapon >= 0 && ev->data1 & (1 << mousebnextweapon))
+            {
+                key = key_menu_up;
+                mousewait = I_GetTime() + 1;
             }
         }
         else


### PR DESCRIPTION
Small collection of various menu control improvements.

Following actions can be confirmed by `Enter` key:
- Nightmare skill verifying (Doom only)
- End game
- Quit
- Suicide confirmation (Hexen only) is possible but not included - probably it's too dangerous, just like savegames deleting - user have to confirm such actions strictly by `Y` key.

Heretic and Hexen:
- Menus can be scrolled via mouse wheel.
- Small addition - allow to quit by pressing `F10` in any game states, so user won't need to open game menu and select "Quit Game", if the game wasn't started.

Extra:
- Slightly reduced delay between `LMB`/`RMB` clicks, so user now can go through actions like "New Game > Episode > Skill level" by faster clicking.

