### PR TITLE
Heretic and Hexen: check for valid, existing characters in font drawing functions

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -36,7 +36,7 @@ vertex_t KeyPoints[NUM_KEY_TYPES];
 
 const char *LevelNames[] = {
     // EPISODE 1 - THE CITY OF THE DAMNED
-    "e1m1:  a small [\\]^_`{|}~ text z" /*"E1M1:  THE DOCKS"*/,
+    "E1M1:  THE DOCKS",
     "E1M2:  THE DUNGEONS",
     "E1M3:  THE GATEHOUSE",
     "E1M4:  THE GUARD TOWER",

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -36,7 +36,7 @@ vertex_t KeyPoints[NUM_KEY_TYPES];
 
 const char *LevelNames[] = {
     // EPISODE 1 - THE CITY OF THE DAMNED
-    "E1M1:  THE DOCKS",
+    "e1m1:  a small [\\]^_`{|}~ text z" /*"E1M1:  THE DOCKS"*/,
     "E1M2:  THE DUNGEONS",
     "E1M3:  THE GATEHOUSE",
     "E1M4:  THE GUARD TOWER",

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -985,7 +985,7 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
 #if defined(__GNUC__)
 #  pragma GCC diagnostic pop
 #endif
-        MN_DrTextA(filedate, ORIGWIDTH / 2 - MN_TextAWidth(pagestr), y + 10);
+        MN_DrTextA(filedate, ORIGWIDTH / 2 - MN_TextAWidth(filedate) / 2, y + 10);
     }
 
     dp_translation = NULL;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -224,7 +224,7 @@ static Menu_t MainMenu = {
 };
 
 static MenuItem_t EpisodeItems[] = {
-    {ITT_EFUNC, "CITY OF THE DAMNED", SCEpisode, 1, MENU_NONE},
+    {ITT_EFUNC, "a small [\\]^_`{|}~ text z" /*"CITY OF THE DAMNED"*/, SCEpisode, 1, MENU_NONE},
     {ITT_EFUNC, "HELL'S MAW", SCEpisode, 2, MENU_NONE},
     {ITT_EFUNC, "THE DOME OF D'SPARIL", SCEpisode, 3, MENU_NONE},
     {ITT_EFUNC, "THE OSSUARY", SCEpisode, 4, MENU_NONE},
@@ -612,6 +612,31 @@ static void InitFonts(void)
     FontBBaseLump = W_GetNumForName(DEH_String("FONTB_S")) + 1;
 }
 
+// [crispy] Check if printable character is existing in FONTA/FONTB sets.
+enum {
+    big_font, small_font
+} fonttype_t;
+
+static const char MN_CheckValidChar (char ascii_index, int have_cursor)
+{
+    if ((ascii_index >= 91 + have_cursor && ascii_index <= 96) || ascii_index >= 123)
+    {
+        // Replace "\]^_`" and "{|}~" with spaces,
+        // allow [ (91, cursor) only in small fonts.
+        return 32;
+    }
+    else if (ascii_index >= 97 && ascii_index <= 122)
+    {
+        // Force lowercase "a...z" characters to uppercase "A...Z".
+        return ascii_index -= 32;
+    }
+    else
+    {
+        // Valid char, do not modify it's ASCII index.
+        return ascii_index;
+    }
+}
+
 //---------------------------------------------------------------------------
 //
 // PROC MN_DrTextA
@@ -627,7 +652,9 @@ void MN_DrTextA(const char *text, int x, int y)
 
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 91) // [crispy] fail-safe: draw patches above FONTA59 as spaces
+        c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
+        
+        if (c < 33)
         {
             x += 5;
         }
@@ -657,7 +684,9 @@ int MN_TextAWidth(const char *text)
     width = 0;
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 91) // [crispy] fail-safe: consider patches above FONTA59 as spaces
+        c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             width += 5;
         }
@@ -685,7 +714,9 @@ void MN_DrTextB(const char *text, int x, int y)
 
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 90) // [crispy] fail-safe: draw patches above FONTB58 as spaces
+        c = MN_CheckValidChar(c, big_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             x += 8;
         }
@@ -715,7 +746,9 @@ int MN_TextBWidth(const char *text)
     width = 0;
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 90) // [crispy] fail-safe: consider patches above FONTB58 as spaces
+        c = MN_CheckValidChar(c, big_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             width += 5;
         }

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -224,7 +224,7 @@ static Menu_t MainMenu = {
 };
 
 static MenuItem_t EpisodeItems[] = {
-    {ITT_EFUNC, "a small [\\]^_`{|}~ text z" /*"CITY OF THE DAMNED"*/, SCEpisode, 1, MENU_NONE},
+    {ITT_EFUNC, "CITY OF THE DAMNED", SCEpisode, 1, MENU_NONE},
     {ITT_EFUNC, "HELL'S MAW", SCEpisode, 2, MENU_NONE},
     {ITT_EFUNC, "THE DOME OF D'SPARIL", SCEpisode, 3, MENU_NONE},
     {ITT_EFUNC, "THE OSSUARY", SCEpisode, 4, MENU_NONE},
@@ -612,14 +612,16 @@ static void InitFonts(void)
     FontBBaseLump = W_GetNumForName(DEH_String("FONTB_S")) + 1;
 }
 
-// [crispy] Check if printable character is existing in FONTA/FONTB sets.
+// [crispy] Check if printable character is existing in FONTA/FONTB sets
+// and do a replacement or case correction if needed.
+
 enum {
     big_font, small_font
-} fonttype_t;
+} fontsize_t;
 
 static const char MN_CheckValidChar (char ascii_index, int have_cursor)
 {
-    if ((ascii_index >= '[' + have_cursor && ascii_index <= '`') || ascii_index >= '{')
+    if ((ascii_index > 'Z' + have_cursor && ascii_index < 'a') || ascii_index > 'z')
     {
         // Replace "\]^_`" and "{|}~" with spaces,
         // allow "[" (cursor symbol) only in small fonts.

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -655,7 +655,7 @@ void MN_DrTextA(const char *text, int x, int y)
     while ((c = *text++) != 0)
     {
         c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
-        
+
         if (c < 33)
         {
             x += 5;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -619,16 +619,16 @@ enum {
 
 static const char MN_CheckValidChar (char ascii_index, int have_cursor)
 {
-    if ((ascii_index >= 91 + have_cursor && ascii_index <= 96) || ascii_index >= 123)
+    if ((ascii_index >= '[' + have_cursor && ascii_index <= '`') || ascii_index >= '{')
     {
         // Replace "\]^_`" and "{|}~" with spaces,
-        // allow [ (91, cursor) only in small fonts.
-        return 32;
+        // allow "[" (cursor symbol) only in small fonts.
+        return ' ';
     }
-    else if (ascii_index >= 97 && ascii_index <= 122)
+    else if (ascii_index >= 'a' && ascii_index <= 'z')
     {
         // Force lowercase "a...z" characters to uppercase "A...Z".
-        return ascii_index -= 32;
+        return ascii_index + 'A' - 'a';
     }
     else
     {

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -543,6 +543,33 @@ static void InitFonts(void)
     FontBBaseLump = W_GetNumForName("FONTB_S") + 1;
 }
 
+// [crispy] Check if printable character is existing in FONTA(Y)/FONTB sets
+// and do a replacement or case correction if needed.
+
+enum {
+    big_font, small_font
+} fontsize_t;
+
+static const char MN_CheckValidChar (char ascii_index, int have_cursor)
+{
+    if ((ascii_index > 'Z' + have_cursor && ascii_index < 'a') || ascii_index > 'z')
+    {
+        // Replace "\]^_`" and "{|}~" with spaces,
+        // allow "[" (cursor symbol) only in small fonts.
+        return ' ';
+    }
+    else if (ascii_index >= 'a' && ascii_index <= 'z')
+    {
+        // Force lowercase "a...z" characters to uppercase "A...Z".
+        return ascii_index + 'A' - 'a';
+    }
+    else
+    {
+        // Valid char, do not modify it's ASCII index.
+        return ascii_index;
+    }
+}
+
 //---------------------------------------------------------------------------
 //
 // PROC MN_DrTextA
@@ -558,7 +585,9 @@ void MN_DrTextA(const char *text, int x, int y)
 
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 91) // [crispy] fail-safe: draw patches above FONTA59 as spaces
+        c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             x += 5;
         }
@@ -584,7 +613,9 @@ void MN_DrTextAYellow(const char *text, int x, int y)
 
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 91) // [crispy] fail-safe: draw patches above FONTAY59 as spaces
+        c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             x += 5;
         }
@@ -614,7 +645,9 @@ int MN_TextAWidth(const char *text)
     width = 0;
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 91) // [crispy] fail-safe: consider patches above FONTA(Y)59 as spaces
+        c = MN_CheckValidChar(c, small_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             width += 5;
         }
@@ -642,7 +675,9 @@ void MN_DrTextB(const char *text, int x, int y)
 
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 90) // [crispy] fail-safe: draw patches above FONTB58 as spaces
+        c = MN_CheckValidChar(c, big_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             x += 8;
         }
@@ -672,7 +707,9 @@ int MN_TextBWidth(const char *text)
     width = 0;
     while ((c = *text++) != 0)
     {
-        if (c < 33 || c > 90) // [crispy] fail-safe: consider patches above FONTB58 as spaces
+        c = MN_CheckValidChar(c, big_font); // [crispy] check for valid characters
+
+        if (c < 33)
         {
             width += 5;
         }


### PR DESCRIPTION
This should fix possible crashes in cases like:
* Using lowercased designation (`am/pm` instead of `AM/PM`) in savegame time. This was fixed by not drawing lowercase characters.
* Lowecased text can be used for both big and small fonts, probably good for compatibility with mods.
* Unknown characters (not existing in font graphics) are still replaced with spaces.