### PR TITLE
Strife: improve TrueColor crossfading effect

### DIFF
--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -414,7 +414,11 @@ void D_Display (void)
             nowtime = I_GetTime ();
             tics = nowtime - wipestart;
             I_Sleep(1);
+#ifndef CRISPY_TRUECOLOR
         } while (tics < 3); // haleyjd 08/23/2010: [STRIFE] Changed from == 0 to < 3
+#else
+        } while (tics <= 0); // [crispy] run tics faster in TrueColor for smoother effect
+#endif
 
         // haleyjd 08/26/10: [STRIFE] Changed to use ColorXForm wipe.
         wipestart = nowtime;

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -414,11 +414,7 @@ void D_Display (void)
             nowtime = I_GetTime ();
             tics = nowtime - wipestart;
             I_Sleep(1);
-#ifndef CRISPY_TRUECOLOR
         } while (tics < 3); // haleyjd 08/23/2010: [STRIFE] Changed from == 0 to < 3
-#else
-        } while (tics <= 0); // [crispy] run tics faster in TrueColor for smoother effect
-#endif
 
         // haleyjd 08/26/10: [STRIFE] Changed to use ColorXForm wipe.
         wipestart = nowtime;

--- a/src/strife/f_wipe.c
+++ b/src/strife/f_wipe.c
@@ -151,6 +151,13 @@ wipe_exitColorXForm
   int	height,
   int	ticks )
 {
+    // [crispy] fix memory leak - crossfade calls wipe_exitColorXForm instead of
+    // wipe_exitMelt, so we need to do a memory cleanup in this function
+    Z_Free(wipe_scr_start);
+    Z_Free(wipe_scr_end);
+#ifndef CRISPY_TRUECOLOR
+    Z_Free(wipe_scr);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
That's it, as simple as it gets. If feels slightly longer than original effect, presumably by just a few tics (yeah, inner timer is a thing), but looks absolutely fine and smooth.

TODOs:
* Not sure why `wipe_scr` wants to be `I_VideoBuffer`. Should it be `Z_Malloc`'ed like in paletted render, then effect will be notably faster in speed and less epic. Same applies to drawing solid background while crossfading effect, but it shouldn't be that CPU-expensive, as the effect itself is `gametic` based.
* ~~Memory leak is still happening. That's odd, since all `pixel_t` variables are seems to be freed.~~ Fixed!