### PR TITLE
Fix scalelight[] memory leak

### DIFF
--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -746,6 +746,7 @@ void R_InitLightTables (void)
     //  for each level / distance combination.
     for (i=0 ; i< LIGHTLEVELS ; i++)
     {
+	scalelight[i] = malloc(MAXLIGHTSCALE * sizeof(**scalelight));
 	zlight[i] = malloc(MAXLIGHTZ * sizeof(**zlight));
 
 	startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
@@ -906,7 +907,6 @@ void R_ExecuteSetViewSize (void)
     //  for each level / scale combination.
     for (i=0 ; i< LIGHTLEVELS ; i++)
     {
-	scalelight[i] = malloc(MAXLIGHTSCALE * sizeof(**scalelight));
 
 	startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
 	for (j=0 ; j<MAXLIGHTSCALE ; j++)

--- a/src/strife/r_main.c
+++ b/src/strife/r_main.c
@@ -744,6 +744,7 @@ void R_InitLightTables (void)
     //  for each level / distance combination.
     for (i=0 ; i< LIGHTLEVELS ; i++)
     {
+	scalelight[i] = malloc(MAXLIGHTSCALE * sizeof(**scalelight));
 	zlight[i] = malloc(MAXLIGHTZ * sizeof(**zlight));
 
 	startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
@@ -899,7 +900,6 @@ void R_ExecuteSetViewSize (void)
     //  for each level / scale combination.
     for (i=0 ; i< LIGHTLEVELS ; i++)
     {
-	scalelight[i] = malloc(MAXLIGHTSCALE * sizeof(**scalelight));
 
 	startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
 	for (j=0 ; j<MAXLIGHTSCALE ; j++)


### PR DESCRIPTION
This fixes memory leak (over-consumption) by toggling detail mode or changing screen size. Few remarks:
* Probably not worth a comment, as this is our own code not a Chocolate one.
* Nothing for Heretic & Hexen since there is not smooth diminished lighting. It's a must have for TrueColor to be honest, but I'm not sure how to fit it in Crispness menu.
* This approach is pretty much same to [Woof](https://github.com/fabiangreffrath/woof/blob/master/src/r_main.c#L470-L471) one.

Small note - it was barely possible to notice a leak while non-TrueColor build, obliviously because of smaller `lighttable_t` size. However, while experimenting with colored lighting and having 28 [extra colormaps](https://github.com/JNechaevsky/yaguar-doom/blob/main/src/doom/r_collit.c#L472-L502) (both `scalelight` and `zlight`, TrueColor only approach), such leak costs about ~400 kilobytes every time `R_ExecuteSetViewSize` was hit! Never thought such experiments will be that useful. 🙂