### PR TITLE
Doom & Heretic: suppress pause when a new game is started

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -807,7 +807,8 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     }
     
     // special buttons
-    if (sendpause) 
+    // [crispy] suppress pause when a new game is started
+    if (sendpause && gameaction != ga_newgame) 
     { 
 	sendpause = false; 
 	// [crispy] ignore un-pausing in menus during demo recording

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -891,7 +891,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 //
 // special buttons
 //
-    if (sendpause)
+    // [crispy] suppress pause when a new game is started
+    if (sendpause && gameaction != ga_newgame)
     {
         sendpause = false;
         cmd->buttons = BT_SPECIAL | BTS_PAUSE;


### PR DESCRIPTION
Fixes the case described in PR for Woof: https://github.com/fabiangreffrath/woof/pull/1799

Only for Doom and Heretic at the moment, since "Reload Level / Go to Next Level" keys is only available for these two games. Not sure if Hexen and Strife needs this until level keys will be implemented. 