### PR TITLE
Doom: fix sector's sound origin for large levels

### DIFF
--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -887,8 +887,17 @@ void P_GroupLines (void)
 	}
 
 	// set the degenmobj_t to the middle of the bounding box
+	if (!crispy->soundfix)
+	{
 	sector->soundorg.x = (bbox[BOXRIGHT]+bbox[BOXLEFT])/2;
 	sector->soundorg.y = (bbox[BOXTOP]+bbox[BOXBOTTOM])/2;
+	}
+	else
+	{
+	// [crispy] Andrey Budko: fix sound origin for large levels
+	sector->soundorg.x = bbox[BOXRIGHT]/2+bbox[BOXLEFT]/2;
+	sector->soundorg.y = bbox[BOXTOP]/2+bbox[BOXBOTTOM]/2;
+	}
 		
 	// adjust bounding box to map blocks
 	block = (bbox[BOXTOP]-bmaporgy+MAXRADIUS)>>MAPBLOCKSHIFT;


### PR DESCRIPTION
Thanks @kitchen-ace for [suggestion](https://www.doomworld.com/forum/topic/112333-this-is-woof-1450-apr-30-2024/?do=findComment&comment=2827653) to have a fix, and tanks @rfomin for [suggesting](https://www.doomworld.com/forum/topic/112333-this-is-woof-1450-apr-30-2024/?do=findComment&comment=2827758) a fix from PrBoom+.

Dear reader, please note: this fix is not hot-swappable and will require savegame or level reloading.