### PR TITLE
Add Unity and D1+D2 IWAD search folders

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -204,6 +204,30 @@ static registry_value_t root_path_keys[] =
         "PATH",
     },
 
+    // DOOM Unity port (not Chocolate Doom compatible)
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\2015545325",
+        "PATH"
+    },
+
+    // DOOM II Unity port (not Chocolate Doom compatible)
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1426071866",
+        "PATH"
+    },
+
+    // DOOM + DOOM II (not Chocolate Doom compatible)
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1413291984",
+        "PATH"
+    },
+
     // Strife: Veteran Edition
 
     {
@@ -274,6 +298,12 @@ static char *steam_install_subdirs[] =
     // From Doom 3: BFG Edition:
 
     "steamapps\\common\\DOOM 3 BFG Edition\\base\\wads",
+
+    // [crispy] Doom 1 + Doom 2 (not Chocolate Doom compatible):
+
+    "steamapps\\common\\Doom 2\\rerelease\\DOOM II_Data\\StreamingAssets",
+    "steamapps\\common\\Ultimate Doom\\rerelease",
+    "steamapps\\common\\Ultimate Doom\\rerelease\\DOOM_Data\\StreamingAssets",
 
     // From Strife: Veteran Edition:
 

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -204,7 +204,7 @@ static registry_value_t root_path_keys[] =
         "PATH",
     },
 
-    // DOOM Unity port (not Chocolate Doom compatible)
+    // [crispy] DOOM Unity port (not Chocolate Doom compatible)
 
     {
         HKEY_LOCAL_MACHINE,
@@ -212,7 +212,7 @@ static registry_value_t root_path_keys[] =
         "PATH"
     },
 
-    // DOOM II Unity port (not Chocolate Doom compatible)
+    // [crispy] DOOM II Unity port (not Chocolate Doom compatible)
 
     {
         HKEY_LOCAL_MACHINE,
@@ -220,7 +220,7 @@ static registry_value_t root_path_keys[] =
         "PATH"
     },
 
-    // DOOM + DOOM II (not Chocolate Doom compatible)
+    // [crispy] DOOM + DOOM II (not Chocolate Doom compatible)
 
     {
         HKEY_LOCAL_MACHINE,


### PR DESCRIPTION
Picked from Woof's [#1831](https://github.com/fabiangreffrath/woof/pull/1831). I have a feeling that we have something missing here in Crispy, but for God's sake, let's just use orthodoxal IWADs with _«(c) id Software, 1993-1994»_ on title screens...