### PR TITLE
Doom and Strife: remember cursor position in Sound Volume menu

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -2738,7 +2738,7 @@ boolean M_Responder (event_t* ev)
         {
 	    M_StartControlPanel ();
 	    currentMenu = &SoundDef;
-	    itemOn = sfx_vol;
+	    itemOn = currentMenu->lastOn; // [crispy] remember cursor position
 	    S_StartSoundOptional(NULL, sfx_mnuopn, sfx_swtchn); // [NS] Optional menu sounds.
 	    return true;
 	}

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2699,7 +2699,7 @@ boolean M_Responder (event_t* ev)
         {
             M_StartControlPanel ();
             currentMenu = &SoundDef;
-            itemOn = sfx_vol;
+            itemOn = currentMenu->lastOn; // [crispy] remember cursor position
             S_StartSound(NULL, sfx_swtchn);
             return true;
         }


### PR DESCRIPTION
Absolutely same logics to https://github.com/fabiangreffrath/woof/pull/1863. Few remarks:
* Heretic and Hexen doesn't have this issue as both of them have proper [position placement](https://github.com/fabiangreffrath/crispy-doom/blob/master/src/heretic/mn_menu.c#L2214).
* Small comment, since we have to take care about `diff` with Chocolate code base.