### PR TITLE
Use `M_stat`, safe check and fix Strife save date/time

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -873,7 +873,7 @@ static void M_DrawSaveLoadBottomLine(void)
     struct stat st;
     char filedate[32];
 
-    if (M_stat(P_SaveGameFile(itemOn), &st) != -1)
+    if (M_stat(P_SaveGameFile(itemOn), &st) == 0)
     {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -873,8 +873,8 @@ static void M_DrawSaveLoadBottomLine(void)
     struct stat st;
     char filedate[32];
 
-    stat(P_SaveGameFile(itemOn), &st);
-
+    if (M_stat(P_SaveGameFile(itemOn), &st) != -1)
+    {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -885,6 +885,7 @@ static void M_DrawSaveLoadBottomLine(void)
 #pragma GCC diagnostic pop
 #endif
     M_WriteText(ORIGWIDTH/2-M_StringWidth(filedate)/2, y + 8, filedate);
+    }
   }
 
   dp_translation = NULL;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -975,7 +975,7 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
         struct stat st;
         char filedate[32];
 
-        if (M_stat(SV_Filename(CurrentItPos), &st) != -1)
+        if (M_stat(SV_Filename(CurrentItPos), &st) == 0)
         {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -975,7 +975,8 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
         struct stat st;
         char filedate[32];
 
-        stat(SV_Filename(CurrentItPos), &st);
+        if (M_stat(SV_Filename(CurrentItPos), &st) != -1)
+        {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)
 #  pragma GCC diagnostic push
@@ -986,6 +987,7 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
 #  pragma GCC diagnostic pop
 #endif
         MN_DrTextA(filedate, ORIGWIDTH / 2 - MN_TextAWidth(filedate) / 2, y + 10);
+        }
     }
 
     dp_translation = NULL;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -953,7 +953,7 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
         char filename[100];
 
         M_snprintf(filename, sizeof(filename), "%shex%d.hxs", SavePath, CurrentItPos + (savepage * 10));
-        if (M_stat(filename, &st) != -1)
+        if (M_stat(filename, &st) == 0)
         {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -953,7 +953,8 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
         char filename[100];
 
         M_snprintf(filename, sizeof(filename), "%shex%d.hxs", SavePath, CurrentItPos + (savepage * 10));
-        stat(filename, &st);
+        if (M_stat(filename, &st) != -1)
+        {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)
 #  pragma GCC diagnostic push
@@ -964,6 +965,7 @@ static void DrawSaveLoadBottomLine(const Menu_t *menu)
 #  pragma GCC diagnostic pop
 #endif
         MN_DrTextA(filedate, ORIGWIDTH / 2 - MN_TextAWidth(filedate) / 2, y + 10);
+        }
     }
 
     dp_translation = NULL;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -302,6 +302,7 @@ int M_stat(const char *path, struct stat *buf)
     // incompatible with struct stat*. We copy only the required compatible
     // field.
     buf->st_mode = wbuf.st_mode;
+    buf->st_mtime = wbuf.st_mtime; // [crispy]
 
     free(wpath);
 

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -864,8 +864,8 @@ static void M_DrawSaveLoadBottomLine(void)
         struct stat st;
         char filedate[32];
 
-        stat(P_SaveGameFile(itemOn), &st);
-
+        if (M_stat(P_SaveGameFile(itemOn), &st) != -1)
+        {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -876,6 +876,7 @@ static void M_DrawSaveLoadBottomLine(void)
 #pragma GCC diagnostic pop
 #endif
         M_WriteText(ORIGWIDTH/2-M_StringWidth(filedate)/2, y, filedate);
+        }
     }
 }
 

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -864,7 +864,7 @@ static void M_DrawSaveLoadBottomLine(void)
         struct stat st;
         char filedate[32];
 
-        if (M_stat(P_SaveGameFile(itemOn), &st) != -1)
+        if (M_stat(P_SaveGameFile(itemOn), &st) == 0)
         {
 // [FG] suppress the most useless compiler warning ever
 #if defined(__GNUC__)

--- a/src/strife/p_saveg.c
+++ b/src/strife/p_saveg.c
@@ -72,7 +72,9 @@ char *P_SaveGameFile(int slot)
         filename = malloc(filename_size);
     }
 
-    DEH_snprintf(basename, 32, SAVEGAMENAME "%d.dsg", slot);
+    // [crispy] changed to Strife savegame file name,
+    // used by M_DrawSaveLoadBottomLine to show savegame date and time
+    DEH_snprintf(basename, 32, "strfsav%d.ssg/name", slot);
 
     M_snprintf(filename, filename_size, "%s%s", savegamedir, basename);
 


### PR DESCRIPTION
Fixes #1218. @fabiangreffrath, @rfomin, requesting your review, I'm not very familiar with `stat()` and not sure if `-1` is correct logics in this case, though it comes from [Woof logics](https://github.com/fabiangreffrath/woof/blob/387c0deb03d138632dde763ba21fe53ce9682704/src/mn_snapshot.c#L94).

Also, does `strfsav%d.ssg/name` correct for non Windows OSes?