### PR TITLE
TrueColor: smoother diminished lighting

### DIFF
--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -25,6 +25,7 @@
 #include "s_sound.h"
 #include "r_defs.h" // [crispy] laserpatch
 #include "r_sky.h" // [crispy] R_InitSkyMap()
+#include "z_zone.h" // [crispy] Z_Free()
 
 #include "m_crispy.h"
 
@@ -516,6 +517,17 @@ static void M_CrispyToggleSmoothLightingHook (void)
 {
     crispy->smoothlight = !crispy->smoothlight;
 
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] zero out colormaps[] array so it can be
+    // reallocated and recalculated in R_InitColormaps()
+    if (colormaps != NULL)
+    {
+        Z_Free(colormaps);
+        colormaps = NULL;
+    }
+    // [crispy] re-calculate light tables and amount of colormaps
+    R_InitColormaps();
+#endif
     // [crispy] re-calculate the zlight[][] array
     R_InitLightTables();
     // [crispy] re-calculate the scalelight[][] array

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -2789,7 +2789,6 @@ boolean M_Responder (event_t* ev)
             I_SetPalette (W_CacheLumpName (DEH_String("PLAYPAL"),PU_CACHE));
 #else
             {
-		extern void R_InitColormaps (void);
 		I_SetPalette (0);
 		R_InitColormaps();
 		inhelpscreens = true;

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -34,7 +34,12 @@
 
 
 // Index of the special effects (INVUL inverse) map.
+#ifndef CRISPY_TRUECOLOR
 #define INVERSECOLORMAP		32
+#else
+// [crispy] parameterized for smooth diminishing lighting
+int INVERSECOLORMAP;
+#endif
 
 
 //

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1196,6 +1196,21 @@ void R_InitColormaps (void)
 	byte *const playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 	byte *const colormap = W_CacheLumpName("COLORMAP", PU_STATIC);
 
+	// [crispy] Smoother diminished lighting.
+	// Compiled in but not enabled TrueColor mode
+	// can't use more than original 32 colormaps.
+	if (crispy->truecolor && crispy->smoothlight)
+	{
+		NUMCOLORMAPS = 256;
+	}
+	else
+	{
+		NUMCOLORMAPS = 32;
+	}
+	// [crispy] Regardless of the number of color maps,
+	// invulnerability is always the last one.
+	INVERSECOLORMAP = NUMCOLORMAPS;
+
 	if (!colormaps)
 	{
 		colormaps = (lighttable_t*) Z_Malloc((NUMCOLORMAPS + 1) * 256 * sizeof(lighttable_t), PU_STATIC, 0);

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -111,6 +111,9 @@ lighttable_t***		zlight = NULL;
 int			extralight;			
 
 // [crispy] parameterized for smooth diminishing lighting
+#ifdef CRISPY_TRUECOLOR
+int NUMCOLORMAPS;
+#endif
 int LIGHTLEVELS;
 int LIGHTSEGSHIFT;
 int LIGHTBRIGHT;
@@ -699,13 +702,38 @@ void R_InitLightTables (void)
    // [crispy] smooth diminishing lighting
     if (crispy->smoothlight)
     {
-	LIGHTLEVELS = 32;
-	LIGHTSEGSHIFT = 3;
-	LIGHTBRIGHT = 2;
-	MAXLIGHTSCALE = 48;
-	LIGHTSCALESHIFT = 12;
-	MAXLIGHTZ = 1024;
-	LIGHTZSHIFT = 17;
+#ifndef CRISPY_TRUECOLOR
+		LIGHTLEVELS = 32;
+		LIGHTSEGSHIFT = 3;
+		LIGHTBRIGHT = 2;
+		MAXLIGHTSCALE = 48;
+		LIGHTSCALESHIFT = 12;
+		MAXLIGHTZ = 1024;
+		LIGHTZSHIFT = 17;
+#else
+		if (crispy->truecolor)
+		{
+		// [crispy] if in TrueColor mode, use smoothest diminished lighting
+		LIGHTLEVELS = 256;
+		LIGHTSEGSHIFT = 0;
+		LIGHTBRIGHT = 15;
+		MAXLIGHTSCALE = 376;
+		LIGHTSCALESHIFT = 9;
+		MAXLIGHTZ = 1024;
+		LIGHTZSHIFT = 17;
+		}
+		else
+		{
+		// [crispy] else, use paletted paletted approach
+		LIGHTLEVELS = 32;
+		LIGHTSEGSHIFT = 3;
+		LIGHTBRIGHT = 2;
+		MAXLIGHTSCALE = 48;
+		LIGHTSCALESHIFT = 12;
+		MAXLIGHTZ = 1024;
+		LIGHTZSHIFT = 17;
+		}
+#endif
     }
     else
     {

--- a/src/doom/r_main.h
+++ b/src/doom/r_main.h
@@ -80,7 +80,13 @@ extern lighttable_t*	fixedcolormap;
 
 // Number of diminishing brightness levels.
 // There a 0-31, i.e. 32 LUT in the COLORMAP lump.
+#ifndef CRISPY_TRUECOLOR
 #define NUMCOLORMAPS		32
+#else
+// [crispy] parameterized for smooth diminishing lighting
+extern int NUMCOLORMAPS;
+extern int INVERSECOLORMAP;
+#endif
 
 // Blocky/low detail mode.
 //B remove this?
@@ -200,6 +206,7 @@ void R_Init (void);
 // Called by M_Responder.
 void R_SetViewSize (int blocks, int detail);
 
+void R_InitColormaps(void);
 void R_ExecuteSetViewSize(void);
 
 


### PR DESCRIPTION
Just as promised. Having a `16 777 216` colors at hand allows to have nearly perfectly smoothed diminished lighting, nearly close to hardware renderers. Few remarks and notes, as always:

* Doesn't impact performance, at least on average results of `-timedemo` runs.
* Costs about ~4 megabytes of memory.
* Values has been empirically verified to represent original Doom lighting model.
* Inspired by [this line of code](https://github.com/JNechaevsky/jaguar-doom/blob/master/r_local.h#L34) from Jaguar Doom.
* Fake contrast is killing all impressions...

Testing map: [epiclight.zip](https://github.com/user-attachments/files/16855006/epiclight.zip)

Screenshots:

<details>

No smoothing:
![image](https://github.com/user-attachments/assets/25d3285f-0761-41b8-9789-65f9c5e60b7e)

Smoothing:
![image](https://github.com/user-attachments/assets/3483c0ef-668e-43ef-8fdd-02aae35d3b91)

</details>

@fabiangreffrath, few explanations:
* Ideally to avoid using extra macroses `#ifndef CRISPY_TRUECOLOR` to have one logic for everything, but in this case it may lead to some confusion while comparing to Chocolate Doom code base. It's like a "smaller diff vs. cleaner code" game. Not sure what will be better.
* When TrueColor compiled in, but disabled via config-file (it is possible to make it hot-swappable, but needs thinking how to fit it in Crispness menu), it is impossible to use more than original 32 colormaps. This is not limitation of implementation, this is how colormaps are working for emulated paletted render. So, this feature require TrueColor-in + TrueColor-on to be set.
* Any thoughts, recommendations and suggestions are highly appreciated!