### PR TITLE
Heretic: fix for possible incorrect status bar shading in TrueColor

### DIFF
--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -450,7 +450,7 @@ static void ShadeLine(int x, int y, int height, int shade)
 #ifndef CRISPY_TRUECOLOR
     shades = colormaps + 9 * 256 + shade * 2 * 256;
 #else
-    shade = 0xFF - (((9 + shade * 2) << 8) / NUMCOLORMAPS);
+    shade = 0xFF - (((9 + shade * 2) << 8) / 32); // [crispy] shade to darkest 32nd COLORMAP row
 #endif
     dest = I_VideoBuffer + y * SCREENWIDTH + x + (WIDESCREENDELTA << crispy->hires);
     while (height--)


### PR DESCRIPTION
Fixes small shading issue on TrueColor + smooth diminished lighting, described in https://github.com/fabiangreffrath/crispy-doom/pull/1220#issuecomment-2345308283.