### PR TITLE
TrueColor: add ingame toggler

### DIFF
--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -573,6 +573,32 @@ void M_CrispyToggleTranslucency(int choice)
     ChangeSettingEnum(&crispy->translucency, choice, NUM_TRANSLUCENCY);
 }
 
+#ifdef CRISPY_TRUECOLOR
+static void M_CrispyToggleTrueColorHook (void)
+{
+    crispy->truecolor = !crispy->truecolor;
+
+    I_SetPalette (0); // [JN] TODO - Could be externalized st_palette?
+    // [crispy] re-calculate amount of colormaps and light tables
+    R_InitColormaps();
+    // [crispy] re-calculate the zlight[][] array
+    R_InitLightTables();
+    // [crispy] re-calculate the scalelight[][] array
+    R_ExecuteSetViewSize();
+    // [crispy] re-calculate fake contrast
+    P_SegLengths(true);
+    // [crispy] re-draw bezel
+    R_FillBackScreen();
+}
+
+void M_CrispyToggleTrueColor(int choice)
+{
+    choice = 0;
+
+    crispy->post_rendering_hook = M_CrispyToggleTrueColorHook;
+}
+#endif
+
 void M_CrispyToggleUncapped(int choice)
 {
     choice = 0;

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -578,7 +578,6 @@ static void M_CrispyToggleTrueColorHook (void)
 {
     crispy->truecolor = !crispy->truecolor;
 
-    I_SetPalette (0); // [JN] TODO - Could be externalized st_palette?
     // [crispy] re-calculate amount of colormaps and light tables
     R_InitColormaps();
     // [crispy] re-calculate the zlight[][] array
@@ -587,8 +586,6 @@ static void M_CrispyToggleTrueColorHook (void)
     R_ExecuteSetViewSize();
     // [crispy] re-calculate fake contrast
     P_SegLengths(true);
-    // [crispy] re-draw bezel
-    R_FillBackScreen();
 }
 
 void M_CrispyToggleTrueColor(int choice)

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -84,6 +84,7 @@ extern void M_CrispyToggleSoundfixes(int choice);
 extern void M_CrispyToggleSoundMono(int choice);
 extern void M_CrispyToggleStatsFormat(int choice);
 extern void M_CrispyToggleTranslucency(int choice);
+extern void M_CrispyToggleTrueColor(int choice);
 extern void M_CrispyToggleUncapped(int choice);
 extern void M_CrispyToggleVsync(int choice);
 extern void M_CrispyToggleWidescreen(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -462,13 +462,15 @@ static menu_t  MouseDef =
 enum
 {
     crispness_sep_rendering,
+#ifdef CRISPY_TRUECOLOR
+    crispness_truecolor,
+#endif
     crispness_hires,
     crispness_widescreen,
     crispness_uncapped,
     crispness_fpslimit,
     crispness_vsync,
     crispness_smoothscaling,
-    crispness_sep_rendering_,
 
     crispness_sep_visual,
     crispness_coloredhud,
@@ -487,13 +489,15 @@ enum
 static menuitem_t Crispness1Menu[]=
 {
     {-1,"",0,'\0'},
+#ifdef CRISPY_TRUECOLOR
+    {3,"",	M_CrispyToggleTrueColor,'t'},
+#endif
     {3,"",	M_CrispyToggleHires,'h'},
     {3,"",	M_CrispyToggleWidescreen,'w'},
     {3,"",	M_CrispyToggleUncapped,'u'},
     {4,"",	M_CrispyToggleFpsLimit,'f'},
     {3,"",	M_CrispyToggleVsync,'v'},
     {3,"",	M_CrispyToggleSmoothScaling,'s'},
-    {-1,"",0,'\0'},
     {-1,"",0,'\0'},
     {3,"",	M_CrispyToggleColoredhud,'c'},
     {3,"",	M_CrispyToggleTranslucency,'e'},
@@ -523,7 +527,6 @@ enum
     crispness_soundfix,
     crispness_sndchannels,
     crispness_soundmono,
-    crispness_sep_audible_,
 
     crispness_sep_navigational,
     crispness_extautomap,
@@ -547,7 +550,6 @@ static menuitem_t Crispness2Menu[]=
     {3,"",	M_CrispyToggleSoundfixes,'m'},
     {3,"",	M_CrispyToggleSndChannels,'s'},
     {3,"",	M_CrispyToggleSoundMono,'m'},
-    {-1,"",0,'\0'},
     {-1,"",0,'\0'},
     {3,"",	M_CrispyToggleExtAutomap,'e'},
     {3,"",	M_CrispyToggleSmoothMap,'m'},
@@ -581,7 +583,6 @@ enum
     crispness_pitch,
     crispness_neghealth,
     crispness_defaultskill,
-    crispness_sep_tactical_,
 
     crispness_sep_crosshair,
     crispness_crosshair,
@@ -605,7 +606,6 @@ static menuitem_t Crispness3Menu[]=
     {3,"",	M_CrispyTogglePitch,'w'},
     {3,"",	M_CrispyToggleNeghealth,'n'},
     {3,"",	M_CrispyToggleDefaultSkill,'d'},
-    {-1,"",0,'\0'},
     {-1,"",0,'\0'},
     {3,"",	M_CrispyToggleCrosshair,'d'},
     {3,"",	M_CrispyToggleCrosshairtype,'c'},
@@ -632,7 +632,6 @@ enum
     crispness_freeaim,
     crispness_jumping,
     crispness_overunder,
-    crispness_sep_physical_,
 
     crispness_sep_demos,
     crispness_demotimer,
@@ -653,7 +652,6 @@ static menuitem_t Crispness4Menu[]=
     {3,"",	M_CrispyToggleFreeaim,'v'},
     {3,"",	M_CrispyToggleJumping,'a'},
     {3,"",	M_CrispyToggleOverunder,'w'},
-    {-1,"",0,'\0'},
     {-1,"",0,'\0'},
     {3,"",	M_CrispyToggleDemoTimer,'v'},
     {3,"",	M_CrispyToggleDemoTimerDir,'a'},
@@ -1564,6 +1562,9 @@ static void M_DrawCrispness1(void)
     M_DrawCrispnessHeader("Crispness 1/4");
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
+#ifdef CRISPY_TRUECOLOR
+    M_DrawCrispnessItem(crispness_truecolor, "TrueColor Rendering", crispy->truecolor, true);
+#endif
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
     M_DrawCrispnessMultiItem(crispness_widescreen, "Aspect Ratio", multiitem_widescreen, crispy->widescreen, aspect_ratio_correct == 1);
     M_DrawCrispnessItem(crispness_uncapped, "Uncapped Framerate", crispy->uncapped, true);

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -45,6 +45,7 @@
 #define LEFT_DIR 0
 #define RIGHT_DIR 1
 #define ENTER_NUMBER 2 // [crispy] numeric entry
+#define ITEM_HEIGHT_SML 10 // [crispy] smaller vertical spacing for small font
 #define ITEM_HEIGHT 20
 #define SELECTOR_XOFFSET (-28)
 #define SELECTOR_YOFFSET (-1)
@@ -882,7 +883,7 @@ void MN_Drawer(void)
             if (CurrentMenu->drawFunc == DrawCrispness)
             {
             // [JN] Crispness menu: use 10px vertical spacing for small font
-            y += ITEM_HEIGHT/2;
+            y += ITEM_HEIGHT_SML;
             }
             else
             {
@@ -894,7 +895,7 @@ void MN_Drawer(void)
         {
         // [JN] Crispness menu: use small blue gem instead of big red arrow.
         // Blinks a bit faster and shifted right, closer to the text.
-        y = CurrentMenu->y + (CurrentItPos * (ITEM_HEIGHT/2)) + SELECTOR_YOFFSET;
+        y = CurrentMenu->y + (CurrentItPos * (ITEM_HEIGHT_SML)) + SELECTOR_YOFFSET;
         selName = DEH_String(MenuTime & 8 ? "INVGEMR1" : "INVGEMR2");
         V_DrawPatch(x + (SELECTOR_XOFFSET/2), y,
                     W_CacheLumpName(selName, PU_CACHE));
@@ -3014,7 +3015,7 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispness1(void)
 {
-    int y_shift = 0;
+    int line_shift = 0;
 
     DrawCrispnessHeader("CRISPNESS 1/2");
 
@@ -3023,42 +3024,42 @@ static void DrawCrispness1(void)
 #ifdef CRISPY_TRUECOLOR
     // TrueColor rendering
     DrawCrispnessItem(crispy->truecolor, 217, 35);
-    y_shift += 10;
+    line_shift += ITEM_HEIGHT_SML;
 #endif
 
     // Hires rendering
-    DrawCrispnessItem(crispy->hires, 254, 35 + y_shift);
+    DrawCrispnessItem(crispy->hires, 254, 35 + line_shift);
 
     // Widescreen
-    DrawCrispnessMultiItem(crispy->widescreen, 164, 45 + y_shift, multiitem_widescreen, false);
+    DrawCrispnessMultiItem(crispy->widescreen, 164, 45 + line_shift, multiitem_widescreen, false);
 
     // Smooth pixel scaling
-    DrawCrispnessItem(crispy->smoothscaling, 216, 55 + y_shift);
+    DrawCrispnessItem(crispy->smoothscaling, 216, 55 + line_shift);
 
     // Uncapped framerate
-    DrawCrispnessItem(crispy->uncapped, 217, 65 + y_shift);
+    DrawCrispnessItem(crispy->uncapped, 217, 65 + line_shift);
 
     // Framerate limit
-    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75 + y_shift, "NONE", !crispy->uncapped, "35");
+    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75 + line_shift, "NONE", !crispy->uncapped, "35");
 
     // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 85 + y_shift);
+    DrawCrispnessItem(crispy->vsync, 167, 85 + line_shift);
 
-    DrawCrispnessSubheader("VISUAL", 95 + y_shift);
+    DrawCrispnessSubheader("VISUAL", 95 + line_shift);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 213, 105 + y_shift, multiitem_brightmaps, false);
+    DrawCrispnessMultiItem(crispy->brightmaps, 213, 105 + line_shift, multiitem_brightmaps, false);
 
     // Smooth Diminishing Lighting
-    DrawCrispnessItem(crispy->smoothlight, 257, 115 + y_shift);
+    DrawCrispnessItem(crispy->smoothlight, 257, 115 + line_shift);
 
-    DrawCrispnessSubheader("AUDIBLE", 125 + y_shift);
+    DrawCrispnessSubheader("AUDIBLE", 125 + line_shift);
 
     // Mono SFX
-    DrawCrispnessItem(crispy->soundmono, 137, 135 + y_shift);
+    DrawCrispnessItem(crispy->soundmono, 137, 135 + line_shift);
 
     // Sound Channels
-    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 145 + y_shift, multiitem_sndchannels, false);
+    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 145 + line_shift, multiitem_sndchannels, false);
 }
 
 static void DrawCrispness2(void)

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1595,7 +1595,6 @@ static void ChangeSettingEnum(int *setting, int option, int num_values)
 static void CrispyTrueColorHook(void)
 {
     crispy->truecolor = !crispy->truecolor;
-    I_SetPalette(0);
     // [crispy] re-calculate amount of colormaps and light tables
     R_InitColormaps();
     // [crispy] re-calculate the zlight[][] array
@@ -1604,8 +1603,6 @@ static void CrispyTrueColorHook(void)
     R_ExecuteSetViewSize();
     // [crispy] re-calculate fake contrast
     P_SegLengths(true);
-    // [crispy] refresh the status bar
-    SB_state = -1;
 }
 
 static boolean CrispyTrueColor(int option)

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -127,6 +127,9 @@ static boolean SCSaveGame(int option);
 static boolean SCMessages(int option);
 static boolean SCEndGame(int option);
 static boolean SCInfo(int option);
+#ifdef CRISPY_TRUECOLOR
+static boolean CrispyTrueColor(int option);
+#endif
 static boolean CrispyHires(int option);
 static boolean CrispyToggleWidescreen(int option);
 static boolean CrispySmoothing(int option);
@@ -361,7 +364,16 @@ static int crispnessmenupage;
 
 #define NUM_CRISPNESS_MENUS 2
 
+#ifndef CRISPY_TRUECOLOR
+#define NUM_CRISPNESS1_ITEMS 14
+#else
+#define NUM_CRISPNESS1_ITEMS 15
+#endif
+
 static MenuItem_t Crispness1Items[] = {
+#ifdef CRISPY_TRUECOLOR
+    {ITT_LRFUNC2, "TRUECOLOR RENDERING:", CrispyTrueColor, 0, MENU_NONE},
+#endif
     {ITT_LRFUNC2, "HIGH RESOLUTION RENDERING:", CrispyHires, 0, MENU_NONE},
     {ITT_LRFUNC2, "ASPECT RATIO:", CrispyToggleWidescreen, 0, MENU_NONE},
     {ITT_LRFUNC2, "SMOOTH PIXEL SCALING:", CrispySmoothing, 0, MENU_NONE},
@@ -369,10 +381,8 @@ static MenuItem_t Crispness1Items[] = {
     {ITT_NUMFUNC, "FRAMERATE LIMIT:", CrispyFpsLimit, 0, MENU_NONE},
     {ITT_LRFUNC2, "ENABLE VSYNC:", CrispyVsync, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "APPLY BRIGHTMAPS TO:", CrispyBrightmaps, 0, MENU_NONE},
     {ITT_LRFUNC2, "SMOOTH DIMINISHING LIGHTING:", CrispySmoothLighting, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "MONO SFX:", CrispySoundMono, 0, MENU_NONE},
     {ITT_LRFUNC2, "SOUND CHANNELS:", CrispySndChannels, 0, MENU_NONE},
@@ -383,7 +393,7 @@ static MenuItem_t Crispness1Items[] = {
 static Menu_t Crispness1Menu = {
     68, 35,
     DrawCrispness,
-    16, Crispness1Items,
+    NUM_CRISPNESS1_ITEMS, Crispness1Items,
     0,
     MENU_OPTIONS
 };
@@ -393,7 +403,6 @@ static MenuItem_t Crispness2Items[] = {
     {ITT_LRFUNC2, "SHOW LEVEL TIME:", CrispyLevelTime, 0, MENU_NONE},
     {ITT_LRFUNC2, "SHOW PLAYER COORDS:", CrispyPlayerCoords, 0, MENU_NONE},
     {ITT_LRFUNC2, "REPORT REVEALED SECRETS:", CrispySecretMessage, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "FREELOOK MODE:", CrispyFreelook, 0, MENU_NONE},
     {ITT_LRFUNC2, "PERMANENT MOUSELOOK:", CrispyMouselook, 0, MENU_NONE},
@@ -407,7 +416,7 @@ static MenuItem_t Crispness2Items[] = {
 static Menu_t Crispness2Menu = {
     68, 35,
     DrawCrispness,
-    13, Crispness2Items,
+    12, Crispness2Items,
     0,
     MENU_OPTIONS
 };
@@ -1580,6 +1589,31 @@ static void ChangeSettingEnum(int *setting, int option, int num_values)
 
     *setting %= num_values;
 }
+
+#ifdef CRISPY_TRUECOLOR
+static void CrispyTrueColorHook(void)
+{
+    crispy->truecolor = !crispy->truecolor;
+    I_SetPalette(0);
+    // [crispy] re-calculate amount of colormaps and light tables
+    R_InitColormaps();
+    // [crispy] re-calculate the zlight[][] array
+    R_InitLightTables();
+    // [crispy] re-calculate the scalelight[][] array
+    R_ExecuteSetViewSize();
+    // [crispy] re-calculate fake contrast
+    P_SegLengths(true);
+    // [crispy] refresh the status bar
+    SB_state = -1;
+}
+
+static boolean CrispyTrueColor(int option)
+{
+    crispy->post_rendering_hook = CrispyTrueColorHook;
+
+    return true;
+}
+#endif
 
 static void CrispyHiresHook(void)
 {
@@ -2980,43 +3014,51 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispness1(void)
 {
+    int y_shift = 0;
+
     DrawCrispnessHeader("CRISPNESS 1/2");
 
     DrawCrispnessSubheader("RENDERING", 25);
 
+#ifdef CRISPY_TRUECOLOR
+    // TrueColor rendering
+    DrawCrispnessItem(crispy->truecolor, 217, 35);
+    y_shift += 10;
+#endif
+
     // Hires rendering
-    DrawCrispnessItem(crispy->hires, 254, 35);
+    DrawCrispnessItem(crispy->hires, 254, 35 + y_shift);
 
     // Widescreen
-    DrawCrispnessMultiItem(crispy->widescreen, 164, 45, multiitem_widescreen, false);
+    DrawCrispnessMultiItem(crispy->widescreen, 164, 45 + y_shift, multiitem_widescreen, false);
 
     // Smooth pixel scaling
-    DrawCrispnessItem(crispy->smoothscaling, 216, 55);
+    DrawCrispnessItem(crispy->smoothscaling, 216, 55 + y_shift);
 
     // Uncapped framerate
-    DrawCrispnessItem(crispy->uncapped, 217, 65);
+    DrawCrispnessItem(crispy->uncapped, 217, 65 + y_shift);
 
     // Framerate limit
-    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75, "NONE", !crispy->uncapped, "35");
+    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75 + y_shift, "NONE", !crispy->uncapped, "35");
 
     // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 85);
+    DrawCrispnessItem(crispy->vsync, 167, 85 + y_shift);
 
-    DrawCrispnessSubheader("VISUAL", 105);
+    DrawCrispnessSubheader("VISUAL", 95 + y_shift);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 213, 115, multiitem_brightmaps, false);
+    DrawCrispnessMultiItem(crispy->brightmaps, 213, 105 + y_shift, multiitem_brightmaps, false);
 
     // Smooth Diminishing Lighting
-    DrawCrispnessItem(crispy->smoothlight, 257, 125);
+    DrawCrispnessItem(crispy->smoothlight, 257, 115 + y_shift);
 
-    DrawCrispnessSubheader("AUDIBLE", 145);
+    DrawCrispnessSubheader("AUDIBLE", 125 + y_shift);
 
     // Mono SFX
-    DrawCrispnessItem(crispy->soundmono, 137, 155);
+    DrawCrispnessItem(crispy->soundmono, 137, 135 + y_shift);
 
     // Sound Channels
-    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 165, multiitem_sndchannels, false);
+    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 145 + y_shift, multiitem_sndchannels, false);
 }
 
 static void DrawCrispness2(void)
@@ -3036,21 +3078,21 @@ static void DrawCrispness2(void)
     // Show secret message
     DrawCrispnessMultiItem(crispy->secretmessage, 250, 65, multiitem_secretmessage, false);
 
-    DrawCrispnessSubheader("TACTICAL", 85);
+    DrawCrispnessSubheader("TACTICAL", 75);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 95, multiitem_freelook_hh, false);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 85, multiitem_freelook_hh, false);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 105);
+    DrawCrispnessItem(crispy->mouselook, 220, 95);
 
     // Bobfactor
-    DrawCrispnessMultiItem(crispy->bobfactor, 265, 115, multiitem_bobfactor, false);
+    DrawCrispnessMultiItem(crispy->bobfactor, 265, 105, multiitem_bobfactor, false);
 
     // Weapon attack alignment
-    DrawCrispnessMultiItem(crispy->centerweapon, 245, 125, multiitem_centerweapon,
+    DrawCrispnessMultiItem(crispy->centerweapon, 245, 115, multiitem_centerweapon,
             crispy->bobfactor == BOBFACTOR_OFF);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 135, multiitem_difficulties, false);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 125, multiitem_difficulties, false);
 }

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -44,6 +44,7 @@
 #define LEFT_DIR 0
 #define RIGHT_DIR 1
 #define ENTER_NUMBER 2 // [crispy] numeric entry
+#define ITEM_HEIGHT_SML 10 // [crispy] smaller vertical spacing for small font
 #define ITEM_HEIGHT 20
 #define SELECTOR_XOFFSET (-28)
 #define SELECTOR_YOFFSET (-1)
@@ -130,6 +131,9 @@ static void SCSfxVolume(int option);
 static void SCMusicVolume(int option);
 static void SCScreenSize(int option);
 static boolean SCNetCheck(int option);
+#ifdef CRISPY_TRUECOLOR
+static void CrispyTrueColor(int option);
+#endif
 static void CrispyHires(int option);
 static void CrispyToggleWidescreen(int option);
 static void CrispySmoothing(int option);
@@ -360,7 +364,16 @@ static int crispnessmenupage;
 
 #define NUM_CRISPNESS_MENUS 2
 
+#ifndef CRISPY_TRUECOLOR
+#define NUM_CRISPNESS1_ITEMS 14
+#else
+#define NUM_CRISPNESS1_ITEMS 15
+#endif
+
 static MenuItem_t Crispness1Items[] = {
+#ifdef CRISPY_TRUECOLOR
+    {ITT_LRFUNC2, "TRUECOLOR RENDERING:", CrispyTrueColor, 0, MENU_NONE},
+#endif
     {ITT_LRFUNC2, "HIGH RESOLUTION RENDERING:", CrispyHires, 0, MENU_NONE},
     {ITT_LRFUNC2, "ASPECT RATIO:", CrispyToggleWidescreen, 0, MENU_NONE},
     {ITT_LRFUNC2, "SMOOTH PIXEL SCALING:", CrispySmoothing, 0, MENU_NONE},
@@ -368,10 +381,8 @@ static MenuItem_t Crispness1Items[] = {
     {ITT_NUMFUNC, "FRAMERATE LIMIT:", CrispyFpsLimit, 0, MENU_NONE},
     {ITT_LRFUNC2, "ENABLE VSYNC:", CrispyVsync, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "BRIGHTMAPS:", CrispyBrightmaps, 0, MENU_NONE},
     {ITT_LRFUNC2, "SMOOTH DIMINISHING LIGHTING:", CrispySmoothLighting, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "MONO SFX:", CrispySoundMono, 0, MENU_NONE},
     {ITT_LRFUNC2, "SOUND CHANNELS:", CrispySndChannels, 0, MENU_NONE},
@@ -382,14 +393,13 @@ static MenuItem_t Crispness1Items[] = {
 static Menu_t Crispness1Menu = {
     68, 35,
     DrawCrispnessMenu,
-    16, Crispness1Items,
+    NUM_CRISPNESS1_ITEMS, Crispness1Items,
     0,
     MENU_OPTIONS
 };
 
 static MenuItem_t Crispness2Items[] = {
     {ITT_LRFUNC2, "SHOW PLAYER COORDS:", CrispyPlayerCoords, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "FREELOOK MODE:", CrispyFreelook, 0, MENU_NONE},
     {ITT_LRFUNC2, "PERMANENT MOUSELOOK:", CrispyMouselook, 0, MENU_NONE},
@@ -403,7 +413,7 @@ static MenuItem_t Crispness2Items[] = {
 static Menu_t Crispness2Menu = {
     68, 35,
     DrawCrispnessMenu,
-    10, Crispness2Items,
+    9, Crispness2Items,
     0,
     MENU_OPTIONS
 };
@@ -830,7 +840,7 @@ void MN_Drawer(void)
             if (CurrentMenu->drawFunc == DrawCrispnessMenu)
             {
                 // [crispy] use 10px vertical spacing for small font
-                y += ITEM_HEIGHT/2;
+                y += ITEM_HEIGHT_SML;
             }
             else
             {
@@ -841,7 +851,7 @@ void MN_Drawer(void)
         if (CurrentMenu->drawFunc == DrawCrispnessMenu)
         {
             // [crispy] use small blue gem instead of big red arrow
-            y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT/2) + SELECTOR_YOFFSET;
+            y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT_SML) + SELECTOR_YOFFSET;
             selName = MenuTime & 8 ? "INVGEMR1" : "INVGEMR2";
             V_DrawPatch(x + (SELECTOR_XOFFSET/2), y,
                         W_CacheLumpName(selName, PU_CACHE));
@@ -1614,6 +1624,27 @@ static void ChangeSettingEnum(int *setting, int option, int num_values)
 
     *setting %= num_values;
 }
+
+#ifdef CRISPY_TRUECOLOR
+static void CrispyTrueColorHook(void)
+{
+    crispy->truecolor = !crispy->truecolor;
+    I_SetPalette(0);
+    // [crispy] re-calculate amount of colormaps and light tables
+    R_InitTrueColormaps(LevelUseFullBright ? "COLORMAP" : "FOGMAP");
+    // [crispy] re-calculate the zlight[][] array
+    R_InitLightTables();
+    // [crispy] re-calculate the scalelight[][] array
+    R_ExecuteSetViewSize();
+    // [crispy] refresh the status bar
+    SB_state = -1;
+}
+
+static void CrispyTrueColor(int option)
+{
+    crispy->post_rendering_hook = CrispyTrueColorHook;
+}
+#endif
 
 static void CrispyHiresHook(void)
 {
@@ -2966,43 +2997,51 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispness1(void)
 {
+    int line_shift = 0;
+
     DrawCrispnessHeader("CRISPNESS 1/2");
 
     DrawCrispnessSubheader("RENDERING", 25);
 
+#ifdef CRISPY_TRUECOLOR
+    // TrueColor rendering
+    DrawCrispnessItem(crispy->truecolor, 217, 35);
+    line_shift += ITEM_HEIGHT_SML;
+#endif
+
     // Hires rendering
-    DrawCrispnessItem(crispy->hires, 254, 35);
+    DrawCrispnessItem(crispy->hires, 254, 35 + line_shift);
 
     // Widescreen
-    DrawCrispnessMultiItem(crispy->widescreen, 164, 45, multiitem_widescreen, false);
+    DrawCrispnessMultiItem(crispy->widescreen, 164, 45 + line_shift, multiitem_widescreen, false);
 
     // Smooth pixel scaling
-    DrawCrispnessItem(crispy->smoothscaling, 216, 55);
+    DrawCrispnessItem(crispy->smoothscaling, 216, 55 + line_shift);
 
     // Uncapped framerate
-    DrawCrispnessItem(crispy->uncapped, 217, 65);
+    DrawCrispnessItem(crispy->uncapped, 217, 65 + line_shift);
 
     // Framerate limit
-    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75, "NONE", !crispy->uncapped, "35");
+    DrawCrispnessNumericItem(crispy->fpslimit, 181, 75 + line_shift, "NONE", !crispy->uncapped, "35");
 
     // Vsync
-    DrawCrispnessItem(crispy->vsync, 167, 85);
+    DrawCrispnessItem(crispy->vsync, 167, 85 + line_shift);
 
-    DrawCrispnessSubheader("VISUAL", 105);
+    DrawCrispnessSubheader("VISUAL", 95 + line_shift);
 
     // Brightmaps
-    DrawCrispnessMultiItem(crispy->brightmaps, 150, 115, multiitem_brightmaps, false);
+    DrawCrispnessMultiItem(crispy->brightmaps, 150, 105 + line_shift, multiitem_brightmaps, false);
 
     // Smooth Diminishing Lighting
-    DrawCrispnessItem(crispy->smoothlight, 257, 125);
+    DrawCrispnessItem(crispy->smoothlight, 257, 115 + line_shift);
 
-    DrawCrispnessSubheader("AUDIBLE", 145);
+    DrawCrispnessSubheader("AUDIBLE", 125 + line_shift);
 
     // Mono SFX
-    DrawCrispnessItem(crispy->soundmono, 137, 155);
+    DrawCrispnessItem(crispy->soundmono, 137, 135 + line_shift);
 
     // Sound Channels
-    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 165, multiitem_sndchannels, false);
+    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 145 + line_shift, multiitem_sndchannels, false);
 }
 
 static void DrawCrispness2(void)
@@ -3014,21 +3053,21 @@ static void DrawCrispness2(void)
     // Player coordinates
     DrawCrispnessMultiItem(crispy->playercoords, 211, 35, multiitem_widgets, false);
 
-    DrawCrispnessSubheader("TACTICAL", 55);
+    DrawCrispnessSubheader("TACTICAL", 45);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 65, multiitem_freelook_hh, false);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 55, multiitem_freelook_hh, false);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 75);
+    DrawCrispnessItem(crispy->mouselook, 220, 65);
 
     // Bobfactor
-    DrawCrispnessMultiItem(crispy->bobfactor, 265, 85, multiitem_bobfactor, false);
+    DrawCrispnessMultiItem(crispy->bobfactor, 265, 75, multiitem_bobfactor, false);
 
     // Weapon attack alignment
-    DrawCrispnessMultiItem(crispy->centerweapon, 245, 95, multiitem_centerweapon,
+    DrawCrispnessMultiItem(crispy->centerweapon, 245, 85, multiitem_centerweapon,
             crispy->bobfactor == BOBFACTOR_OFF);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 105, multiitem_difficulties, false);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 95, multiitem_difficulties, false);
 }

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1629,15 +1629,12 @@ static void ChangeSettingEnum(int *setting, int option, int num_values)
 static void CrispyTrueColorHook(void)
 {
     crispy->truecolor = !crispy->truecolor;
-    I_SetPalette(0);
     // [crispy] re-calculate amount of colormaps and light tables
     R_InitTrueColormaps(LevelUseFullBright ? "COLORMAP" : "FOGMAP");
     // [crispy] re-calculate the zlight[][] array
     R_InitLightTables();
     // [crispy] re-calculate the scalelight[][] array
     R_ExecuteSetViewSize();
-    // [crispy] refresh the status bar
-    SB_state = -1;
 }
 
 static void CrispyTrueColor(int option)

--- a/src/strife/m_crispy.c
+++ b/src/strife/m_crispy.c
@@ -321,7 +321,6 @@ static void M_CrispyToggleTrueColorHook (void)
 {
     crispy->truecolor = !crispy->truecolor;
 
-    I_SetPalette (0); // [JN] TODO - Could be externalized st_palette?
     // [crispy] re-calculate amount of colormaps and light tables
     R_InitColormaps();
     // [crispy] re-calculate the zlight[][] array
@@ -330,8 +329,6 @@ static void M_CrispyToggleTrueColorHook (void)
     R_ExecuteSetViewSize();
     // [crispy] re-calculate fake contrast
     P_SegLengths(true);
-    // [crispy] re-draw bezel
-    R_FillBackScreen();
 }
 
 void M_CrispyToggleTrueColor(int choice)

--- a/src/strife/m_crispy.c
+++ b/src/strife/m_crispy.c
@@ -316,6 +316,32 @@ void M_CrispyToggleSoundMono(int choice)
     S_UpdateStereoSeparation();
 }
 
+#ifdef CRISPY_TRUECOLOR
+static void M_CrispyToggleTrueColorHook (void)
+{
+    crispy->truecolor = !crispy->truecolor;
+
+    I_SetPalette (0); // [JN] TODO - Could be externalized st_palette?
+    // [crispy] re-calculate amount of colormaps and light tables
+    R_InitColormaps();
+    // [crispy] re-calculate the zlight[][] array
+    R_InitLightTables();
+    // [crispy] re-calculate the scalelight[][] array
+    R_ExecuteSetViewSize();
+    // [crispy] re-calculate fake contrast
+    P_SegLengths(true);
+    // [crispy] re-draw bezel
+    R_FillBackScreen();
+}
+
+void M_CrispyToggleTrueColor(int choice)
+{
+    choice = 0;
+
+    crispy->post_rendering_hook = M_CrispyToggleTrueColorHook;
+}
+#endif
+
 void M_CrispyToggleUncapped(int choice)
 {
     choice = 0;

--- a/src/strife/m_crispy.h
+++ b/src/strife/m_crispy.h
@@ -53,6 +53,7 @@ void M_CrispyToggleSmoothScaling(int choice);
 void M_CrispyToggleSndChannels(int choice);
 void M_CrispyToggleSoundfixes(int choice);
 void M_CrispyToggleSoundMono(int choice);
+void M_CrispyToggleTrueColor(int choice);
 void M_CrispyToggleUncapped(int choice);
 void M_CrispyToggleVsync(int choice);
 void M_CrispyToggleWidescreen(int choice);

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -430,13 +430,15 @@ static menu_t MouseDef =
 enum
 {
     crispness_sep_rendering,
+#ifdef CRISPY_TRUECOLOR
+    crispness_truecolor,
+#endif
     crispness_hires,
     crispness_widescreen,
     crispness_smoothscaling,
     crispness_uncapped,
     crispness_fpslimit,
     crispness_vsync,
-    crispness_sep_rendering_,
 
     crispness_sep_visual,
     crispness_smoothlight,
@@ -450,13 +452,15 @@ enum
 static menuitem_t Crispness1Menu[] =
 {
     {-1, "", 0, '\0'},
+#ifdef CRISPY_TRUECOLOR
+    {2, "", M_CrispyToggleTrueColor, 't'},
+#endif
     {2, "", M_CrispyToggleHires, 'h'},
     {2, "", M_CrispyToggleWidescreen, 'w'},
     {2, "", M_CrispyToggleSmoothScaling, 's'},
     {2, "", M_CrispyToggleUncapped, 'u'},
     {3, "", M_CrispyToggleFpsLimit, 'f'},
     {2, "", M_CrispyToggleVsync, 'v'},
-    {-1, "", 0, '\0'},
     {-1, "", 0, '\0'},
     {2, "", M_CrispyToggleSmoothLighting, 's'},
     {-1, "", 0, '\0'},
@@ -481,7 +485,6 @@ enum
     crispness_soundfix,
     crispness_sndchannels,
     crispness_soundmono,
-    crispness_sep_audible_,
 
     crispness_sep_navigational,
     crispness_smoothmap,
@@ -501,7 +504,6 @@ static menuitem_t Crispness2Menu[] =
     {2, "", M_CrispyToggleSoundfixes, 'm'},
     {2, "", M_CrispyToggleSndChannels, 's'},
     {2, "", M_CrispyToggleSoundMono, 'm'},
-    {-1, "", 0, '\0'},
     {-1, "", 0, '\0'},
     {2, "", M_CrispyToggleSmoothMap, 'm'},
     {2, "", M_CrispyToggleLeveltime, 'l'},
@@ -530,7 +532,6 @@ enum
     crispness_bobfactor,
     crispness_centerweapon,
     crispness_defaultskill,
-    crispness_sep_tactical_,
 
     crispness_sep_crosshair,
     crispness_crosshair,
@@ -551,7 +552,6 @@ static menuitem_t Crispness3Menu[] =
     {2, "", M_CrispyToggleBobfactor, 'p'},
     {2, "", M_CrispyToggleCenterweapon, 'c'},
     {2, "", M_CrispyToggleDefaultSkill, 'd'},
-    {-1, "", 0, '\0'},
     {-1, "", 0, '\0'},
     {2, "", M_CrispyToggleCrosshair, 'd'},
     {2, "", M_CrispyToggleCrosshairHealth, 'c'},
@@ -1510,6 +1510,9 @@ static void M_DrawCrispness1(void)
     M_DrawCrispnessHeader("Crispness 1/3");
 
     M_DrawCrispnessSeparator(crispness_sep_rendering, "Rendering");
+#ifdef CRISPY_TRUECOLOR
+    M_DrawCrispnessItem(crispness_truecolor, "TrueColor Rendering", crispy->truecolor, true);
+#endif
     M_DrawCrispnessItem(crispness_hires, "High Resolution Rendering", crispy->hires, true);
     M_DrawCrispnessMultiItem(crispness_widescreen, "Aspect Ratio", multiitem_widescreen, crispy->widescreen, aspect_ratio_correct == 1);
     M_DrawCrispnessItem(crispness_smoothscaling, "Smooth Pixel Scaling", crispy->smoothscaling, !force_software_renderer);


### PR DESCRIPTION
This adds simple ingame toggler for "TrueColor Rendering". Few remarks:
* It doesn't add back full revert to paletted renderer, so translucency effects are still expensive and no support for custom `PLAYPAL` tinting effects.
* I was forced to remove extra line break after subheaders to don't separate menus. From another hand, it gives some extra vertical space for easier adding possible new features.
* Might be not that useful for two builds, but probably will be handy for later.