### PR TITLE
hexen: Fix wrong save being deleted

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2094,7 +2094,8 @@ void G_LoadGame(int slot)
 void G_DoLoadGame(void)
 {
     gameaction = ga_nothing;
-    SV_LoadGame(GameLoadSlot);
+    // [crispy] support multiple pages of saves
+    SV_LoadGame(GameLoadSlot + savepage * 10);
     if (!netgame)
     {                           // Copy the base slot to the reborn slot
         SV_UpdateRebornSlot();
@@ -2127,7 +2128,8 @@ void G_SaveGame(int slot, char *description)
 
 void G_DoSaveGame(void)
 {
-    SV_SaveGame(savegameslot, savedescription);
+    // [crispy] support multiple pages of saves
+    SV_SaveGame(savegameslot + savepage * 10, savedescription);
     gameaction = ga_nothing;
     savedescription[0] = 0;
     P_SetMessage(&players[consoleplayer], TXT_GAMESAVED, true);

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -181,6 +181,8 @@ int InfoType;
 int messageson = true;
 boolean mn_SuicideConsole;
 
+int savepage; // [crispy] support 8 pages of savegames
+
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
 static int FontABaseLump;
@@ -1263,7 +1265,7 @@ static void SCDeleteGame(int option)
         return;
     }
 
-    SV_ClearSaveSlot(option);
+    SV_ClearSaveSlot(option + savepage * 10);
     CurrentMenu->oldItPos = CurrentItPos;
     MN_LoadSlotText();
     BorderNeedRefresh = true;

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -132,6 +132,7 @@ static void SV_WriteByte(byte val);
 static void SV_WriteWord(unsigned short val);
 static void SV_WriteLong(unsigned int val);
 static void SV_WritePtr(void *ptr);
+static void ClearSaveSlot(int slot); // [crispy]
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
 
@@ -2028,7 +2029,7 @@ void SV_SaveGame(int slot, const char *description)
     SV_SaveMap(true);           // true = save player info
 
     // Clear all save files at destination slot
-    SV_ClearSaveSlot(slot);
+    ClearSaveSlot(slot);
 
     // Copy base slot to destination slot
     CopySaveSlot(BASE_SLOT, slot);
@@ -3279,16 +3280,11 @@ static void AssertSegment(gameArchiveSegment_t segType)
 //
 //==========================================================================
 
-void SV_ClearSaveSlot(int slot)
+// [crispy] Add wrapper to handle multiple save pages
+static void ClearSaveSlot(int slot)
 {
     int i;
     char fileName[100];
-
-    // [crispy] get expanded save slot number
-    if (slot != BASE_SLOT && slot != REBORN_SLOT)
-    {
-        slot += savepage * 10;
-    }
 
     for (i = 0; i < MAX_MAPS; i++)
     {
@@ -3298,6 +3294,16 @@ void SV_ClearSaveSlot(int slot)
     }
     M_snprintf(fileName, sizeof(fileName), "%shex%d.hxs", SavePath, slot);
     M_remove(fileName);
+}
+
+void SV_ClearSaveSlot(int slot)
+{
+    if (slot != BASE_SLOT && slot != REBORN_SLOT)
+    {
+        slot += savepage * 10;
+    }
+
+    ClearSaveSlot(slot);
 }
 
 //==========================================================================

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -132,7 +132,6 @@ static void SV_WriteByte(byte val);
 static void SV_WriteWord(unsigned short val);
 static void SV_WriteLong(unsigned int val);
 static void SV_WritePtr(void *ptr);
-static void ClearSaveSlot(int slot); // [crispy]
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
 
@@ -143,8 +142,6 @@ static void ClearSaveSlot(int slot); // [crispy]
 char *SavePath = DEFAULT_SAVEPATH;
 
 int vanilla_savegame_limit = 1;
-
-int savepage; // [crispy] support 8 pages of savegames
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
@@ -1981,12 +1978,6 @@ void SV_SaveGame(int slot, const char *description)
     char versionText[HXS_VERSION_TEXT_LENGTH];
     unsigned int i;
 
-    // [crispy] get expanded save slot number
-    if (slot != BASE_SLOT && slot != REBORN_SLOT)
-    {
-        slot += savepage * 10;
-    }
-
     // Open the output file
     M_snprintf(fileName, sizeof(fileName), "%shex%d.hxs", SavePath, BASE_SLOT);
     SV_OpenWrite(fileName);
@@ -2029,7 +2020,7 @@ void SV_SaveGame(int slot, const char *description)
     SV_SaveMap(true);           // true = save player info
 
     // Clear all save files at destination slot
-    ClearSaveSlot(slot);
+    SV_ClearSaveSlot(slot);
 
     // Copy base slot to destination slot
     CopySaveSlot(BASE_SLOT, slot);
@@ -2092,12 +2083,6 @@ void SV_LoadGame(int slot)
     player_t *p; // [crispy]
 
     p = &players[consoleplayer]; // [crispy]
-
-    // [crispy] get expanded save slot number
-    if (slot != BASE_SLOT && slot != REBORN_SLOT)
-    {
-        slot += savepage * 10;
-    }
 
     // Copy all needed save files to the base slot
     if (slot != BASE_SLOT)
@@ -3280,8 +3265,7 @@ static void AssertSegment(gameArchiveSegment_t segType)
 //
 //==========================================================================
 
-// [crispy] Add wrapper to handle multiple save pages
-static void ClearSaveSlot(int slot)
+void SV_ClearSaveSlot(int slot)
 {
     int i;
     char fileName[100];
@@ -3294,16 +3278,6 @@ static void ClearSaveSlot(int slot)
     }
     M_snprintf(fileName, sizeof(fileName), "%shex%d.hxs", SavePath, slot);
     M_remove(fileName);
-}
-
-void SV_ClearSaveSlot(int slot)
-{
-    if (slot != BASE_SLOT && slot != REBORN_SLOT)
-    {
-        slot += savepage * 10;
-    }
-
-    ClearSaveSlot(slot);
 }
 
 //==========================================================================


### PR DESCRIPTION
I was prompted to look into this code again after I saw [this post](https://www.doomworld.com/forum/post/2844695) on DW. I found an issue where saving a savefile on pages 1, 2 or 3 can potentially delete the save in the corresponding slot on page 2, 4 or 6 respectively. Not sure if this has any relation to the issue reported by the user on DW, but this bug should certainly be fixed regardless.