### PR TITLE
TrueColor: fix translucency blending

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1631,6 +1631,10 @@ static void SetVideoMode(void)
     if (argbbuffer == NULL)
     {
 #ifdef CRISPY_TRUECOLOR
+        int bpp;
+
+        SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ARGB8888, &bpp,
+                                   &rmask, &gmask, &bmask, &amask);
         argbbuffer = SDL_CreateRGBSurfaceWithFormat(
                      0, SCREENWIDTH, SCREENHEIGHT, 32, SDL_PIXELFORMAT_ARGB8888);
 


### PR DESCRIPTION
This fixes TrueColor's translucency blending, broken by recent `i_video.c` update, where all translucent pixels were drawn with solid black color, regardless of blending function and palette indexes. One remark:
* Ideally to don't have `int bpp`, it does not do anything, but needed for `SDL_PixelFormatEnumToMasks()` itself. A bit confusing, but now it's guarded by both `if (argbbuffer == NULL)` condition and `#ifdef CRISPY_TRUECOLOR` macro.