### PR TITLE
TrueColor: turn mask variables into macroses

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -100,7 +100,6 @@ static SDL_Texture *bluepane = NULL;
 static SDL_Texture *graypane = NULL;
 static SDL_Texture *orngpane = NULL;
 static int pane_alpha;
-static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
 extern pixel_t* pal_color; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];
@@ -1631,10 +1630,6 @@ static void SetVideoMode(void)
     if (argbbuffer == NULL)
     {
 #ifdef CRISPY_TRUECOLOR
-        int bpp;
-
-        SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ARGB8888, &bpp,
-                                   &rmask, &gmask, &bmask, &amask);
         argbbuffer = SDL_CreateRGBSurfaceWithFormat(
                      0, SCREENWIDTH, SCREENHEIGHT, 32, SDL_PIXELFORMAT_ARGB8888);
 
@@ -2112,6 +2107,11 @@ void I_BindVideoVariables(void)
 }
 
 #ifdef CRISPY_TRUECOLOR
+#define amask (0xFF000000U)
+#define rmask (0x00FF0000U)
+#define gmask (0x0000FF00U)
+#define bmask (0x000000FFU)
+
 const pixel_t I_BlendAdd (const pixel_t bg, const pixel_t fg)
 {
 	uint32_t r, g, b;


### PR DESCRIPTION
Done as suggested in comment https://github.com/fabiangreffrath/crispy-doom/commit/3201b93e38ead144f42d0779bee411a3a4455250#r146753091. This will help to get rid of unnecessary variables by turning them into macroses.