### PR TITLE
TrueColor: implement optional tablified translucency

### DIFF
--- a/src/crispy.c
+++ b/src/crispy.c
@@ -31,6 +31,7 @@ static crispy_t crispy_s = {
 #ifdef CRISPY_TRUECOLOR
 	.smoothlight = 1,
 	.truecolor = 1,
+    .blendquality = 1,
 #endif
 	.vsync = 1,
 	.widescreen = 1, // match screen by default

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -81,6 +81,7 @@ typedef struct
 	int translucency;
 #ifdef CRISPY_TRUECOLOR
 	int truecolor;
+    int blendquality;
 #endif
 	int uncapped;
 	int vsync;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -483,6 +483,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_translucency",    &crispy->translucency);
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+    M_BindIntVariable("crispy_blendquality",    &crispy->blendquality);
 #endif
     M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1353,7 +1353,7 @@ void R_InitData (void)
 #else
     // [crispy] Initialize blending maps for tablified additive and
     // overlay translucency, used by TrueColor renderer.
-    R_InitBlendMaps();
+    R_InitBlendMaps(doom);
     // [crispy] Set pointers to blending functions.
     R_InitBlendQuality();
 #endif

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1354,6 +1354,8 @@ void R_InitData (void)
     // [crispy] Initialize blending maps for tablified additive and
     // overlay translucency, used by TrueColor renderer.
     R_InitBlendMaps();
+    // [crispy] Set pointers to blending functions.
+    R_InitBlendQuality();
 #endif
 }
 

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1350,6 +1350,10 @@ void R_InitData (void)
     R_InitHSVColors ();
 #ifndef CRISPY_TRUECOLOR
     R_InitTranMap(); // [crispy] prints a mark itself
+#else
+    // [crispy] Initialize blending maps for tablified additive and
+    // overlay translucency, used by TrueColor renderer.
+    R_InitBlendMaps();
 #endif
 }
 

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -817,7 +817,7 @@ void R_ProjectSprite (mobj_t* thing)
     // [crispy] translucent sprites
     if (thing->flags & MF_TRANSLUCENT)
     {
-	vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAdd : I_BlendOverTranmap;
+	vis->blendfunc = (thing->frame & FF_FULLBRIGHT) ? I_BlendAddFunc : I_BlendOverTranmap;
     }
 #endif
 }

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -886,6 +886,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+    M_BindIntVariable("crispy_blendquality",    &crispy->blendquality);
 #endif
     M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -874,6 +874,13 @@ void R_InitData(void)
     R_InitColormaps();
     // [crispy] Initialize color translation and color string tables.
     R_InitHSVColors();
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] Initialize blending maps for tablified 
+    // overlay translucency (normal and "alt"), used by TrueColor renderer.
+    R_InitBlendMaps(heretic);
+    // [crispy] Set pointers to blending functions.
+    R_InitBlendQuality();
+#endif
 }
 
 

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -211,6 +211,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+    M_BindIntVariable("crispy_blendquality",    &crispy->blendquality);
 #endif
     M_BindIntVariable("crispy_smoothlight",     &crispy->smoothlight);
     M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -811,6 +811,13 @@ void R_InitData(void)
 #endif
     // [crispy] initialize color translation and color string tables
     R_InitHSVColors();
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] Initialize blending maps for tablified overlay
+    // translucency (normal and "alt"), used by TrueColor renderer.
+    R_InitBlendMaps(hexen);
+    // [crispy] Set pointers to blending functions.
+    R_InitBlendQuality();
+#endif
 }
 
 //=============================================================================

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -47,11 +47,11 @@ const uint32_t (*I_BlendOverFunc) (const uint32_t bg_i, const uint32_t fg_i, con
 //const uint32_t (*I_BlendOverAltFunc) (const uint32_t bg_i, const uint32_t fg_i);
 
 // [JN] Different blending alpha values for different games
-#define OVERLAY_ALPHA_TRANMAP     168  // Doom: TRANMAP, 66% opacity
-#define OVERLAY_ALPHA_TINTTAB     96   // Raven: TINTTAB, 38% opacity
-#define OVERLAY_ALPHA_ALTTINTTAB  142  // Raven: TINTTAB "Alt", 56% opacity
-#define OVERLAY_ALPHA_XLATAB      192  // Strife: XLATAB, 75% opacity
-#define OVERLAY_ALPHA_ALTXLATAB   64   // Strife: XLATAB "Alt", 25% opacity
+#define OVERLAY_ALPHA_TRANMAP     0xA8  // Doom: TRANMAP, 168 (66% opacity)
+#define OVERLAY_ALPHA_TINTTAB     0x60  // Raven: TINTTAB, 96 (38% opacity)
+#define OVERLAY_ALPHA_TINTTABALT  0x8E  // Raven: TINTTAB, 142 (56% opacity, "Alt")
+#define OVERLAY_ALPHA_XLATAB      0xC0  // Strife: XLATAB, 192 (75% opacity)
+#define OVERLAY_ALPHA_XLATABALT   0x40  // Strife: XLATAB, 64 (25% opacity, "Alt")
 
 
 // [JN] Initialize blending maps for tablified additive and overlay translucency.
@@ -180,31 +180,31 @@ const uint32_t I_BlendOverLow (const uint32_t bg_i, const uint32_t fg_i, const i
 // [crispy] TRANMAP blending emulation, used for Doom
 const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOverFunc(bg, fg, 0xA8); // 168 (66% opacity)
+    return I_BlendOverFunc(bg, fg, OVERLAY_ALPHA_TRANMAP);
 }
 
 // [crispy] TINTTAB blending emulation, used for Heretic and Hexen
 const uint32_t I_BlendOverTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
+    return I_BlendOver(bg, fg, OVERLAY_ALPHA_TINTTAB);
 }
 
 // [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
 const uint32_t I_BlendOverAltTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
+    return I_BlendOver(bg, fg, OVERLAY_ALPHA_TINTTABALT);
 }
 
 // [crispy] More opaque XLATAB blending emulation, used for Strife
 const uint32_t I_BlendOverXlatab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0xC0); // 192 (75% opacity)
+    return I_BlendOver(bg, fg, OVERLAY_ALPHA_XLATAB);
 }
 
 // [crispy] Less opaque ("Alt") XLATAB blending emulation, used for Strife
 const uint32_t I_BlendOverAltXlatab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0x40); // 64 (25% opacity)
+    return I_BlendOver(bg, fg, OVERLAY_ALPHA_XLATABALT);
 }
 
 // [JN] Set pointers to blending functions.

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -65,20 +65,26 @@ void R_InitBlendMaps (GameMission_t mission)
     switch (mission)
     {
         default: // Doom and derivatives
+        {
             overlay_alpha = OVERLAY_ALPHA_TRANMAP;
             overlay_alt_alpha = 0; // "alt" blending is not used
-        break;
+            break;
+        }
 
         case heretic:
         case hexen:
+        {
             overlay_alpha = OVERLAY_ALPHA_TINTTAB;
             overlay_alt_alpha = OVERLAY_ALPHA_TINTTABALT;
-        break;
+            break;
+        }
 
         case strife:
+        {
             overlay_alpha = OVERLAY_ALPHA_XLATAB;
             overlay_alt_alpha = OVERLAY_ALPHA_XLATABALT;
-        break;
+            break;
+        }
     }
 
     // Shortcut: these variables are always same in tablified approach

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -42,6 +42,10 @@ static uint32_t blendAddLUT[512][512];      // Additive blending
 static uint32_t blendOverLUT[512][512];     // Overlay blending
 static uint32_t blendOverAltLUT[512][512];  // Overlay "alt" blending
 
+const uint32_t (*I_BlendAddFunc) (const uint32_t bg_i, const uint32_t fg_i);
+const uint32_t (*I_BlendOverFunc) (const uint32_t bg_i, const uint32_t fg_i, const int amount);
+//const uint32_t (*I_BlendOverAltFunc) (const uint32_t bg_i, const uint32_t fg_i);
+
 // [JN] Different blending alpha values for different games
 #define OVERLAY_ALPHA_TRANMAP     168  // Doom: TRANMAP, 66% opacity
 #define OVERLAY_ALPHA_TINTTAB     96   // Raven: TINTTAB, 38% opacity
@@ -176,7 +180,7 @@ const uint32_t I_BlendOverLow (const uint32_t bg_i, const uint32_t fg_i, const i
 // [crispy] TRANMAP blending emulation, used for Doom
 const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0xA8); // 168 (66% opacity)
+    return I_BlendOverFunc(bg, fg, 0xA8); // 168 (66% opacity)
 }
 
 // [crispy] TINTTAB blending emulation, used for Heretic and Hexen
@@ -201,6 +205,23 @@ const uint32_t I_BlendOverXlatab (const uint32_t bg, const uint32_t fg)
 const uint32_t I_BlendOverAltXlatab (const uint32_t bg, const uint32_t fg)
 {
     return I_BlendOver(bg, fg, 0x40); // 64 (25% opacity)
+}
+
+// [JN] Set pointers to blending functions.
+void R_InitBlendQuality (void)
+{
+    if (crispy->blendquality)
+    {
+        I_BlendAddFunc = I_BlendAdd;
+        I_BlendOverFunc = I_BlendOver;
+        // I_BlendOverAltFunc = I_BlendOverAlt;
+    }
+    else
+    {
+        I_BlendAddFunc = I_BlendAddLow;
+        I_BlendOverFunc = I_BlendOverLow;
+        // I_BlendOverAltFunc = I_BlendOverAltLow;
+    }
 }
 
 #endif

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -25,10 +25,11 @@
 #ifdef CRISPY_TRUECOLOR
 
 #include <stdint.h>
+#include "d_mode.h" // GameMission_t
 
 extern const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg);
 
-extern void R_InitBlendMaps (void);
+extern void R_InitBlendMaps (GameMission_t mission);
 extern void R_InitBlendQuality (void);
 extern const uint32_t (*I_BlendAddFunc) (const uint32_t bg_i, const uint32_t fg_i);
 extern const uint32_t (*I_BlendOverFunc) (const uint32_t bg_i, const uint32_t fg_i, const int amount);

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -29,6 +29,9 @@
 extern const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg);
 
 extern void R_InitBlendMaps (void);
+extern void R_InitBlendQuality (void);
+extern const uint32_t (*I_BlendAddFunc) (const uint32_t bg_i, const uint32_t fg_i);
+extern const uint32_t (*I_BlendOverFunc) (const uint32_t bg_i, const uint32_t fg_i, const int amount);
 
 const uint32_t I_BlendAdd (const uint32_t bg_i, const uint32_t fg_i);
 const uint32_t I_BlendDark (const uint32_t bg_i, const int d);

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -28,6 +28,8 @@
 
 extern const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg);
 
+extern void R_InitBlendMaps (void);
+
 const uint32_t I_BlendAdd (const uint32_t bg_i, const uint32_t fg_i);
 const uint32_t I_BlendDark (const uint32_t bg_i, const int d);
 const uint32_t I_BlendOver (const uint32_t bg_i, const uint32_t fg_i, const int amount);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2606,6 +2606,14 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(crispy_truecolor),
+
+    //!
+    // @game doom
+    //
+    // Quality of translucency blending.
+    //
+
+    CONFIG_VARIABLE_INT(crispy_blendquality),
 #endif
 
     //!

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -91,6 +91,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_translucency",    &crispy->translucency);
 #ifdef CRISPY_TRUECOLOR
         M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+        M_BindIntVariable("crispy_blendquality",    &crispy->blendquality);
 #endif
         M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
         M_BindIntVariable("crispy_vsync",           &crispy->vsync);

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -550,6 +550,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
+    M_BindIntVariable("crispy_blendquality",    &crispy->blendquality);
 #endif
     M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
     M_BindIntVariable("crispy_vsync",           &crispy->vsync);

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -852,6 +852,13 @@ void R_InitData (void)
     // R_InitColormaps ();
     // [crispy] Initialize color translation and color string tables.
     R_InitHSVColors ();
+#ifdef CRISPY_TRUECOLOR
+    // [crispy] Initialize blending maps for tablified overlay
+    // translucency (normal and "alt"), used by TrueColor renderer.
+    R_InitBlendMaps(strife);
+    // [crispy] Set pointers to blending functions.
+    R_InitBlendQuality();
+#endif
 }
 
 


### PR DESCRIPTION
This is slightly faster than fully dynamic and may look more consistent when TrueColor mode is off. Few remarks:

* Fast LUT generating, takes about 2-4 milliseconds at program startup.
* No `malloc` needed.
* 512, not 256 colors for slightly better look.
* Not limited by `PLAYPAL` colors.