### PR TITLE
Adding Quick Reverse Key to Hexen / Heretic

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -445,6 +445,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     int		look;
     player_t *const player = &players[consoleplayer];
     static char playermessage[48];
+    static boolean keyrevstate = false; // [crispy]
 
     // [crispy] For fast polling.
     G_PrepTiccmd();
@@ -506,9 +507,15 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        angle += ANG180 >> FRACBITS;
-        gamekeydown[key_reverse] = false;
-        mousebuttons[mousebreverse] = false;
+        if(!keyrevstate)
+        {
+            angle += ANG180 >> FRACBITS;
+            keyrevstate = true;
+        }
+    }
+    else
+    {
+        keyrevstate = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -445,7 +445,6 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     int		look;
     player_t *const player = &players[consoleplayer];
     static char playermessage[48];
-    static boolean keyrevstate = false; // [crispy]
 
     // [crispy] For fast polling.
     G_PrepTiccmd();
@@ -507,15 +506,9 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        if(!keyrevstate)
-        {
-            angle += ANG180 >> FRACBITS;
-            keyrevstate = true;
-        }
-    }
-    else
-    {
-        keyrevstate = false;
+        angle += ANG180 >> FRACBITS;
+        gamekeydown[key_reverse] = false;
+        mousebuttons[mousebreverse] = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -463,6 +463,14 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         lspeed = 2;
     }
 
+    // [crispy] add quick 180° reverse
+    if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
+    {
+        angle += ANG180 >> FRACBITS;
+        gamekeydown[key_reverse] = false;
+        mousebuttons[mousebreverse] = false;
+    }
+
     // [crispy] toggle "always run"
     if (gamekeydown[key_toggleautorun])
     {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -405,7 +405,6 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     static unsigned int mbmlookctrl = 0; // [crispy]
     static unsigned int kbdlookctrl = 0; // [crispy]
-    static boolean keyrevstate = false; // [crispy]
 
     // haleyjd: removed externdriver crap
 
@@ -467,15 +466,9 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        if(!keyrevstate)
-        {
-            angle += ANG180 >> FRACBITS;
-            keyrevstate = true;
-        }
-    }
-    else
-    {
-        keyrevstate = false;
+        angle += ANG180 >> FRACBITS;
+        gamekeydown[key_reverse] = false;
+        mousebuttons[mousebreverse] = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -405,6 +405,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     static unsigned int mbmlookctrl = 0; // [crispy]
     static unsigned int kbdlookctrl = 0; // [crispy]
+    static boolean keyrevstate = false; // [crispy]
 
     // haleyjd: removed externdriver crap
 
@@ -466,9 +467,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        angle += ANG180 >> FRACBITS;
-        gamekeydown[key_reverse] = false;
-        mousebuttons[mousebreverse] = false;
+        if(!keyrevstate)
+        {
+            angle += ANG180 >> FRACBITS;
+            keyrevstate = true;
+        }
+    }
+    else
+    {
+        keyrevstate = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -361,6 +361,14 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         lspeed = 2;             // 5;
     }
 
+    // [crispy] add quick 180° reverse
+    if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
+    {
+        angle += ANG180 >> FRACBITS;
+        gamekeydown[key_reverse] = false;
+        mousebuttons[mousebreverse] = false;
+    }
+
     // [crispy] toggle "always run"
     if (gamekeydown[key_toggleautorun])
     {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -299,6 +299,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     static unsigned int mbmlookctrl = 0; // [crispy]
     static unsigned int kbdlookctrl = 0; // [crispy]
+    static boolean keyrevstate = false; // [crispy]
 
     // haleyjd: removed externdriver crap
 
@@ -364,9 +365,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        angle += ANG180 >> FRACBITS;
-        gamekeydown[key_reverse] = false;
-        mousebuttons[mousebreverse] = false;
+        if(!keyrevstate)
+        {
+            angle += ANG180 >> FRACBITS;
+            keyrevstate = true;
+        }
+    }
+    else
+    {
+        keyrevstate = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -299,7 +299,6 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     static unsigned int mbmlookctrl = 0; // [crispy]
     static unsigned int kbdlookctrl = 0; // [crispy]
-    static boolean keyrevstate = false; // [crispy]
 
     // haleyjd: removed externdriver crap
 
@@ -365,15 +364,9 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // [crispy] add quick 180° reverse
     if (gamekeydown[key_reverse] || mousebuttons[mousebreverse])
     {
-        if(!keyrevstate)
-        {
-            angle += ANG180 >> FRACBITS;
-            keyrevstate = true;
-        }
-    }
-    else
-    {
-        keyrevstate = false;
+        angle += ANG180 >> FRACBITS;
+        gamekeydown[key_reverse] = false;
+        mousebuttons[mousebreverse] = false;
     }
 
     // [crispy] toggle "always run"

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -508,7 +508,7 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(mouseb_mouselook),
 
     //!
-    // @game doom
+    // @game doom heretic hexen
     //
     // Quick 180° reverse.
     //
@@ -2251,7 +2251,7 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_multi_msgplayer8),
 
     //!
-    // @game doom
+    // @game doom heretic hexen
     // Quick 180° reverse.
     //
 

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -246,6 +246,7 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         AddKeyControl(table, "Strafe Right (alt.)", &key_alt_straferight);
         AddKeyControl(table, "Toggle always run", &key_toggleautorun);
         AddKeyControl(table, "Toggle vert. mouse", &key_togglenovert);
+        AddKeyControl(table, "Quick Reverse", &key_reverse);
         }
 
         if (gamemission == heretic || gamemission == hexen)

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -160,6 +160,7 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     
     if (gamemission == heretic || gamemission == hexen)
     {
+      AddMouseControl(buttons_table, "Quick Reverse", &mousebreverse);
       AddMouseControl(buttons_table, "Mouselook", &mousebmouselook);
       AddMouseControl(buttons_table, "Inventory left", &mousebinvleft);
       AddMouseControl(buttons_table, "Inventory right", &mousebinvright);


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1239

**Change Summary**

- Adding Quick Reverse Button (mouse and keyboard) to Heretic and Hexen.
