### PR TITLE
Heretic: Adding a11y-Option - Flickering Sector Lighting

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -37,6 +37,7 @@
 #include "i_system.h"
 #include "i_timer.h"
 #include "i_video.h"
+#include "a11y.h" // [crispy] A11Y
 #include "m_argv.h"
 #include "m_config.h"
 #include "m_controls.h"
@@ -852,6 +853,7 @@ void D_BindVariables(void)
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
     M_BindIntVariable("screenblocks",           &screenblocks);
     M_BindIntVariable("snd_channels",           &snd_Channels);
+    M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/p_lights.c
+++ b/src/heretic/p_lights.c
@@ -56,6 +56,8 @@ void T_LightFlash(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -118,6 +120,8 @@ void T_StrobeFlash(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+	flash->sector->rlightlevel = flash->maxlight;
 }
 
 //==================================================================
@@ -277,6 +281,8 @@ void T_Glow(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	g->sector->rlightlevel = g->sector->lightlevel;
+    else
+	g->sector->rlightlevel = g->maxlight;
 }
 
 void P_SpawnGlowingLight(sector_t * sector)

--- a/src/heretic/p_lights.c
+++ b/src/heretic/p_lights.c
@@ -205,7 +205,7 @@ void EV_TurnTagLightsOff(line_t * line)
             }
             sector->lightlevel = min;
             // [crispy] A11Y
-	        sector->rlightlevel = sector->lightlevel;
+            sector->rlightlevel = sector->lightlevel;
         }
 }
 
@@ -245,7 +245,7 @@ void EV_LightTurnOn(line_t * line, int bright)
             }
             sector->lightlevel = bright;
             // [crispy] A11Y
-	        sector->rlightlevel = sector->lightlevel;
+            sector->rlightlevel = sector->lightlevel;
         }
 }
 

--- a/src/heretic/p_lights.c
+++ b/src/heretic/p_lights.c
@@ -17,6 +17,7 @@
 #include "m_random.h"
 #include "p_local.h"
 #include "v_video.h"
+#include "a11y.h" // [crispy] A11Y
 
 //==================================================================
 //==================================================================
@@ -52,6 +53,9 @@ void T_LightFlash(thinker_t *thinker)
         flash->count = (P_Random() & flash->maxtime) + 1;
     }
 
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+	flash->sector->rlightlevel = flash->sector->lightlevel;
 }
 
 
@@ -111,6 +115,9 @@ void T_StrobeFlash(thinker_t *thinker)
         flash->count = flash->darktime;
     }
 
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+	flash->sector->rlightlevel = flash->sector->lightlevel;
 }
 
 //==================================================================
@@ -193,6 +200,8 @@ void EV_TurnTagLightsOff(line_t * line)
                     min = tsec->lightlevel;
             }
             sector->lightlevel = min;
+            // [crispy] A11Y
+	        sector->rlightlevel = sector->lightlevel;
         }
 }
 
@@ -231,6 +240,8 @@ void EV_LightTurnOn(line_t * line, int bright)
                 }
             }
             sector->lightlevel = bright;
+            // [crispy] A11Y
+	        sector->rlightlevel = sector->lightlevel;
         }
 }
 
@@ -262,6 +273,10 @@ void T_Glow(thinker_t *thinker)
             }
             break;
     }
+
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+	g->sector->rlightlevel = g->sector->lightlevel;
 }
 
 void P_SpawnGlowingLight(sector_t * sector)

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -1667,6 +1667,7 @@ void P_UnArchiveWorld(void)
         sec->floorpic = SV_ReadWord();
         sec->ceilingpic = SV_ReadWord();
         sec->lightlevel = SV_ReadWord();
+        sec->rlightlevel = sec->lightlevel; // [crispy] A11Y
         sec->special = SV_ReadWord();  // needed?
         sec->tag = SV_ReadWord();      // needed?
         sec->specialdata = 0;

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -1616,6 +1616,7 @@ void P_ArchiveWorld(void)
         SV_WriteWord(sec->floorpic);
         SV_WriteWord(sec->ceilingpic);
         SV_WriteWord(sec->lightlevel);
+        SV_WriteWord(sec->rlightlevel); // [crispy] A11Y
         SV_WriteWord(sec->special);     // needed?
         SV_WriteWord(sec->tag); // needed?
     }
@@ -1667,7 +1668,7 @@ void P_UnArchiveWorld(void)
         sec->floorpic = SV_ReadWord();
         sec->ceilingpic = SV_ReadWord();
         sec->lightlevel = SV_ReadWord();
-        sec->rlightlevel = sec->lightlevel; // [crispy] A11Y
+        sec->rlightlevel = SV_ReadWord(); // [crispy] A11Y
         sec->special = SV_ReadWord();  // needed?
         sec->tag = SV_ReadWord();      // needed?
         sec->specialdata = 0;

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -1616,7 +1616,6 @@ void P_ArchiveWorld(void)
         SV_WriteWord(sec->floorpic);
         SV_WriteWord(sec->ceilingpic);
         SV_WriteWord(sec->lightlevel);
-        SV_WriteWord(sec->rlightlevel); // [crispy] A11Y
         SV_WriteWord(sec->special);     // needed?
         SV_WriteWord(sec->tag); // needed?
     }
@@ -1668,7 +1667,6 @@ void P_UnArchiveWorld(void)
         sec->floorpic = SV_ReadWord();
         sec->ceilingpic = SV_ReadWord();
         sec->lightlevel = SV_ReadWord();
-        sec->rlightlevel = SV_ReadWord(); // [crispy] A11Y
         sec->special = SV_ReadWord();  // needed?
         sec->tag = SV_ReadWord();      // needed?
         sec->specialdata = 0;

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -282,7 +282,7 @@ void P_LoadSectors(int lump)
         ss->ceilingpic = R_FlatNumForName(ms->ceilingpic);
         ss->lightlevel = SHORT(ms->lightlevel);
         // [crispy] A11Y light level used for rendering
-	    ss->rlightlevel = ss->lightlevel;
+        ss->rlightlevel = ss->lightlevel;
         ss->special = SHORT(ms->special);
         ss->tag = SHORT(ms->tag);
         ss->thinglist = NULL;

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -281,6 +281,8 @@ void P_LoadSectors(int lump)
         ss->floorpic = R_FlatNumForName(ms->floorpic);
         ss->ceilingpic = R_FlatNumForName(ms->ceilingpic);
         ss->lightlevel = SHORT(ms->lightlevel);
+        // [crispy] A11Y light level used for rendering
+	    ss->rlightlevel = ss->lightlevel;
         ss->special = SHORT(ms->special);
         ss->tag = SHORT(ms->tag);
         ss->thinglist = NULL;

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -469,7 +469,7 @@ void R_Subsector(int num)
                                  frontsector->floorpic == skyflatnum &&
                                  frontsector->sky & PL_SKYFLAT ? frontsector->sky :
                                  frontsector->floorpic,
-                                 frontsector->lightlevel,
+                                 frontsector->rlightlevel, // [crispy] A11Y
                                  frontsector->special);
     else
         floorplane = NULL;
@@ -480,7 +480,8 @@ void R_Subsector(int num)
                                    frontsector->ceilingpic == skyflatnum &&
                                    frontsector->sky & PL_SKYFLAT ? frontsector->sky :
                                    frontsector->ceilingpic,
-                                   frontsector->lightlevel, 0);
+                                   frontsector->rlightlevel, // [crispy] A11Y
+                                   0);
     else
         ceilingplane = NULL;
 

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -313,7 +313,7 @@ void R_AddLine(seg_t * line)
 // reject empty lines used for triggers and special events
     if (backsector->ceilingpic == frontsector->ceilingpic
         && backsector->floorpic == frontsector->floorpic
-        && backsector->lightlevel == frontsector->lightlevel
+        && backsector->rlightlevel == frontsector->rlightlevel
         && backsector->special == frontsector->special // [crispy] check for special as well
         && curline->sidedef->midtexture == 0)
         return;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -123,6 +123,9 @@ typedef struct
     //      the renderer.
     fixed_t	interpfloorheight;
     fixed_t	interpceilingheight;
+
+    // [crispy] A11Y light level used for rendering
+    short	rlightlevel;
 } sector_t;
 
 typedef struct

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -676,7 +676,7 @@ void R_StoreWallRange(int start, int stop)
 
         if (worldlow != worldbottom
             || backsector->floorpic != frontsector->floorpic
-            || backsector->lightlevel != frontsector->lightlevel
+            || backsector->rlightlevel != frontsector->rlightlevel
             || backsector->special != frontsector->special) // [crispy] check for special as well
             markfloor = true;
         else
@@ -684,7 +684,7 @@ void R_StoreWallRange(int start, int stop)
 
         if (worldhigh != worldtop
             || backsector->ceilingpic != frontsector->ceilingpic
-            || backsector->lightlevel != frontsector->lightlevel)
+            || backsector->rlightlevel != frontsector->rlightlevel)
             markceiling = true;
         else
             markceiling = false;        // same plane on both sides

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -187,7 +187,8 @@ void R_RenderMaskedSegRange(drawseg_t * ds, int x1, int x2)
     backsector = curline->backsector;
     texnum = texturetranslation[curline->sidedef->midtexture];
 
-    lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (frontsector->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
+
     // [crispy] smoother fake contrast
     lightnum += curline->fakecontrast;
 /*
@@ -748,7 +749,8 @@ void R_StoreWallRange(int start, int stop)
         if (!fixedcolormap)
         {
             lightnum =
-                (frontsector->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+                (frontsector->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
+
             // [crispy] smoother fake contrast
             lightnum += curline->fakecontrast;
             /*

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -695,7 +695,8 @@ void R_AddSprites(sector_t * sec)
 
     sec->validcount = validcount;
 
-    lightnum = (sec->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (sec->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
+
     if (lightnum < 0)
         spritelights = scalelight[0];
     else if (lightnum >= LIGHTLEVELS)
@@ -903,7 +904,7 @@ void R_DrawPlayerSprites(void)
 // get light level
 //
     lightnum =
-        (viewplayer->mo->subsector->sector->lightlevel >> LIGHTSEGSHIFT) +
+        (viewplayer->mo->subsector->sector->rlightlevel >> LIGHTSEGSHIFT) + // [crispy] A11Y
         (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
     if (lightnum < 0)
         spritelights = scalelight[0];

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -40,25 +40,36 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
 
     TXT_SetWindowHelpURL(window, WINDOW_HELP_URL);
 
-    TXT_AddWidgets(window,
-                   TXT_NewCheckBox("Flickering Sector Lighting",
-                                   &a11y_sector_lighting),
-                   TXT_NewCheckBox("Weapon Flash Lighting",
-                                   &a11y_weapon_flash),
-                   TXT_NewCheckBox("Weapon Flash Sprite",
-                                   &a11y_weapon_pspr),
-                   TXT_NewCheckBox("Palette Changes",
-                                   &a11y_palette_changes),
-                   TXT_NewCheckBox("Invulnerability Colormap",
-                                   &a11y_invul_colormap),
-                   NULL);
+    if (gamemission == doom || gamemission == heretic)
+    {
+        TXT_AddWidget(window, 
+                      TXT_NewCheckBox("Flickering Sector Lighting",
+                                      &a11y_sector_lighting));
+    }
+    
+    if (gamemission == doom)
+    {
+        TXT_AddWidgets(window,
+                      TXT_NewCheckBox("Weapon Flash Lighting",
+                                      &a11y_weapon_flash),
+                      TXT_NewCheckBox("Weapon Flash Sprite",
+                                      &a11y_weapon_pspr),
+                      TXT_NewCheckBox("Palette Changes",
+                                      &a11y_palette_changes),
+                      TXT_NewCheckBox("Invulnerability Colormap",
+                                      &a11y_invul_colormap),
+                      NULL);
+    }
 
     TXT_SetTableColumns(window, 2);
 
-    TXT_AddWidgets(window,
-                   TXT_NewLabel("Extra Lighting"),
-                   TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
-                   NULL);
+    if (gamemission == doom)
+    {
+        TXT_AddWidgets(window,
+                    TXT_NewLabel("Extra Lighting"),
+                    TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
+                    NULL);
+    }
 
 }
 

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -236,7 +236,7 @@ void MainMenu(void)
                        (TxtWidgetSignalFunc) CompatibilitySettings, NULL),
 */
     // [crispy]
-    if (gamemission == doom)
+    if (gamemission == doom || gamemission == heretic)
     {
         TXT_AddWidget(window,
             TXT_NewButton2("Accessibility",


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1244

**Changes Summary**

- Added Accessibility Option to Heretic Setup for Flickering Sector Lighting.
- Ported solution from Crispy-Doom for the actual disabling.
- Fixed issue having static strobe/glow/flash lightlevel != maxlight when loading save-files.
- Fixed issue having flickering-glitches in some level segment compositions (E1M1, E2M7).

Verified on E1M1 and E2M7 that no further flickering-glitches remain. Checked vanilla compatibility using 4 Demos (E1M1, E2M7, E4M1, E4M7), no deviation seen. No indication in the source-code found that lightlevel impacts player-detection by enemies. 