### PR TITLE
Doom: a11y Flickering Option Improvements

### DIFF
--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -236,11 +236,10 @@ static void P_ReadOldSpecial (const char *key)
 	}
 }
 
-// sector->rlightlevel - no longer required
+// sector->rlightlevel
 
 static void P_WriteRLightlevel (const char *key)
 {
-/* 	
 	int i;
 	sector_t *sector;
 
@@ -254,13 +253,11 @@ static void P_WriteRLightlevel (const char *key)
 			           (int)sector->rlightlevel);
 			fputs(line, save_stream);
 		}
-	} 
-*/
+	}
 }
 
 static void P_ReadRLightlevel (const char *key)
 {
-/* 	
 	int sector, rlightlevel;
 
 	if (sscanf(line, "%s %d %d\n",
@@ -270,8 +267,7 @@ static void P_ReadRLightlevel (const char *key)
 	    !strncmp(string, key, MAX_STRING_LEN))
 	{
 		sectors[sector].rlightlevel = (short)rlightlevel;
-	} 
-*/
+	}
 }
 
 // buttonlist[]

--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -32,6 +32,7 @@
 #include "s_sound.h"
 #include "s_musinfo.h"
 #include "z_zone.h"
+#include "a11y.h""
 
 #define MAX_LINE_LEN 260
 #define MAX_STRING_LEN 80
@@ -164,6 +165,9 @@ static void P_ReadFireFlicker (const char *key)
 
 		flick->thinker.function.acp1 = (actionf_p1)T_FireFlicker;
 
+		if (!a11y_sector_lighting)
+			flick->sector->rlightlevel = flick->maxlight;
+
 		P_AddThinker(&flick->thinker);
 	}
 }
@@ -233,40 +237,6 @@ static void P_ReadOldSpecial (const char *key)
 	    !strncmp(string, key, MAX_STRING_LEN))
 	{
 		sectors[sector].oldspecial = oldspecial;
-	}
-}
-
-// sector->rlightlevel
-
-static void P_WriteRLightlevel (const char *key)
-{
-	int i;
-	sector_t *sector;
-
-	for (i = 0, sector = sectors; i < numsectors; i++, sector++)
-	{
-		if (sector->rlightlevel != sector->lightlevel)
-		{
-			M_snprintf(line, MAX_LINE_LEN, "%s %d %d\n",
-			           key,
-			           i,
-			           (int)sector->rlightlevel);
-			fputs(line, save_stream);
-		}
-	}
-}
-
-static void P_ReadRLightlevel (const char *key)
-{
-	int sector, rlightlevel;
-
-	if (sscanf(line, "%s %d %d\n",
-	           string,
-	           &sector,
-	           &rlightlevel) == 3 &&
-	    !strncmp(string, key, MAX_STRING_LEN))
-	{
-		sectors[sector].rlightlevel = (short)rlightlevel;
 	}
 }
 
@@ -484,7 +454,6 @@ static const extsavegdata_t extsavegdata[] =
 	{"fireflicker", P_WriteFireFlicker, P_ReadFireFlicker, 1},
 	{"soundtarget", P_WriteSoundTarget, P_ReadSoundTarget, 1},
 	{"oldspecial", P_WriteOldSpecial, P_ReadOldSpecial, 1},
-	{"rlightlevel", P_WriteRLightlevel, P_ReadRLightlevel, 1},
 	{"button", P_WriteButton, P_ReadButton, 1},
 	{"braintarget", P_WriteBrainTarget, P_ReadBrainTarget, 1},
 	{"markpoints", P_WriteMarkPoints, P_ReadMarkPoints, 1},

--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -236,10 +236,11 @@ static void P_ReadOldSpecial (const char *key)
 	}
 }
 
-// sector->rlightlevel
+// sector->rlightlevel - no longer required
 
 static void P_WriteRLightlevel (const char *key)
 {
+/* 	
 	int i;
 	sector_t *sector;
 
@@ -253,11 +254,13 @@ static void P_WriteRLightlevel (const char *key)
 			           (int)sector->rlightlevel);
 			fputs(line, save_stream);
 		}
-	}
+	} 
+*/
 }
 
 static void P_ReadRLightlevel (const char *key)
 {
+/* 	
 	int sector, rlightlevel;
 
 	if (sscanf(line, "%s %d %d\n",
@@ -267,7 +270,8 @@ static void P_ReadRLightlevel (const char *key)
 	    !strncmp(string, key, MAX_STRING_LEN))
 	{
 		sectors[sector].rlightlevel = (short)rlightlevel;
-	}
+	} 
+*/
 }
 
 // buttonlist[]

--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -32,7 +32,7 @@
 #include "s_sound.h"
 #include "s_musinfo.h"
 #include "z_zone.h"
-#include "a11y.h""
+#include "a11y.h"
 
 #define MAX_LINE_LEN 260
 #define MAX_STRING_LEN 80

--- a/src/doom/p_lights.c
+++ b/src/doom/p_lights.c
@@ -56,6 +56,8 @@ void T_FireFlicker (fireflicker_t* flick)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flick->sector->rlightlevel = flick->sector->lightlevel;
+    else
+	flick->sector->rlightlevel = flick->maxlight;
 }
 
 
@@ -112,6 +114,8 @@ void T_LightFlash (lightflash_t* flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -172,6 +176,8 @@ void T_StrobeFlash (strobe_t*		flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -347,6 +353,8 @@ void T_Glow(glow_t*	g)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	g->sector->rlightlevel = g->sector->lightlevel;
+    else
+	g->sector->rlightlevel = g->maxlight;
 }
 
 

--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -26,6 +26,7 @@
 #include "z_zone.h"
 #include "p_local.h"
 #include "p_saveg.h"
+#include "a11y.h"
 
 // State.
 #include "doomstat.h"
@@ -1283,6 +1284,9 @@ static void saveg_read_lightflash_t(lightflash_t *str)
 
     // int mintime;
     str->mintime = saveg_read32();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_lightflash_t(lightflash_t *str)
@@ -1338,6 +1342,9 @@ static void saveg_read_strobe_t(strobe_t *str)
 
     // int brighttime;
     str->brighttime = saveg_read32();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_strobe_t(strobe_t *str)
@@ -1387,6 +1394,9 @@ static void saveg_read_glow_t(glow_t *str)
 
     // int direction;
     str->direction = saveg_read32();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_glow_t(glow_t *str)

--- a/src/doom/r_bsp.c
+++ b/src/doom/r_bsp.c
@@ -374,7 +374,7 @@ void R_AddLine (seg_t*	line)
     // and no middle texture.
     if (backsector->ceilingpic == frontsector->ceilingpic
 	&& backsector->floorpic == frontsector->floorpic
-	&& backsector->lightlevel == frontsector->lightlevel
+	&& backsector->rlightlevel == frontsector->rlightlevel
 	&& curline->sidedef->midtexture == 0)
     {
 	return;

--- a/src/doom/r_segs.c
+++ b/src/doom/r_segs.c
@@ -728,7 +728,7 @@ R_StoreWallRange
 			
 	if (worldlow != worldbottom 
 	    || backsector->floorpic != frontsector->floorpic
-	    || backsector->lightlevel != frontsector->lightlevel)
+	    || backsector->rlightlevel != frontsector->rlightlevel)
 	{
 	    markfloor = true;
 	}
@@ -741,7 +741,7 @@ R_StoreWallRange
 			
 	if (worldhigh != worldtop 
 	    || backsector->ceilingpic != frontsector->ceilingpic
-	    || backsector->lightlevel != frontsector->lightlevel)
+	    || backsector->rlightlevel != frontsector->rlightlevel)
 	{
 	    markceiling = true;
 	}


### PR DESCRIPTION
**Changes Summary**

- Fixed issue having static strobe/glow/flash lightlevel != maxlight when changing the option to disable sector flickering and loading a previously stored save-file.
- Fixed issue having flickering-glitches in some levels when it should be disabled.

Verified on Doom1 - E1M5 and E2M4 & Doom2 Lvl 09 - no further flickering-glitches seen. Checked vanilla compatibility using 3 regular Demos (start of maps Doom2 Lvl 02, 05, 24) and 2 Demos loading from savegames (Doom 2 LVL 05), no deviation seen. No indication in the source-code found that lightlevel impacts player-detection by enemies. 
