### PR TITLE
Doom/Heretic: A11y Flickering - Correct Lightlevel in case of competing Strobe Thinkers

### DIFF
--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -165,7 +165,7 @@ static void P_ReadFireFlicker (const char *key)
 
 		flick->thinker.function.acp1 = (actionf_p1)T_FireFlicker;
 
-		if (!a11y_sector_lighting)
+		if (!a11y_sector_lighting && flick->sector->rlightlevel < flick->maxlight)
 			flick->sector->rlightlevel = flick->maxlight;
 
 		P_AddThinker(&flick->thinker);

--- a/src/doom/p_extsaveg.c
+++ b/src/doom/p_extsaveg.c
@@ -165,7 +165,7 @@ static void P_ReadFireFlicker (const char *key)
 
 		flick->thinker.function.acp1 = (actionf_p1)T_FireFlicker;
 
-		if (!a11y_sector_lighting && flick->sector->rlightlevel < flick->maxlight)
+		if (!a11y_sector_lighting)
 			flick->sector->rlightlevel = flick->maxlight;
 
 		P_AddThinker(&flick->thinker);

--- a/src/doom/p_lights.c
+++ b/src/doom/p_lights.c
@@ -56,8 +56,6 @@ void T_FireFlicker (fireflicker_t* flick)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flick->sector->rlightlevel = flick->sector->lightlevel;
-    else
-	flick->sector->rlightlevel = flick->maxlight;
 }
 
 
@@ -114,8 +112,6 @@ void T_LightFlash (lightflash_t* flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -176,8 +172,6 @@ void T_StrobeFlash (strobe_t*		flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -353,8 +347,6 @@ void T_Glow(glow_t*	g)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	g->sector->rlightlevel = g->sector->lightlevel;
-    else
-	g->sector->rlightlevel = g->maxlight;
 }
 
 

--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -1285,7 +1285,7 @@ static void saveg_read_lightflash_t(lightflash_t *str)
     // int mintime;
     str->mintime = saveg_read32();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1343,7 +1343,7 @@ static void saveg_read_strobe_t(strobe_t *str)
     // int brighttime;
     str->brighttime = saveg_read32();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1395,7 +1395,7 @@ static void saveg_read_glow_t(glow_t *str)
     // int direction;
     str->direction = saveg_read32();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 

--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -1285,7 +1285,7 @@ static void saveg_read_lightflash_t(lightflash_t *str)
     // int mintime;
     str->mintime = saveg_read32();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1343,7 +1343,8 @@ static void saveg_read_strobe_t(strobe_t *str)
     // int brighttime;
     str->brighttime = saveg_read32();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting && 
+            str->sector->rlightlevel < str->maxlight) // [crispy] Ensure maxlight among competing thinkers. 
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1395,7 +1396,7 @@ static void saveg_read_glow_t(glow_t *str)
     // int direction;
     str->direction = saveg_read32();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting)
         str->sector->rlightlevel = str->maxlight;
 }
 

--- a/src/heretic/p_lights.c
+++ b/src/heretic/p_lights.c
@@ -56,8 +56,6 @@ void T_LightFlash(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-	flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -120,8 +118,6 @@ void T_StrobeFlash(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-	flash->sector->rlightlevel = flash->maxlight;
 }
 
 //==================================================================
@@ -281,8 +277,6 @@ void T_Glow(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
 	g->sector->rlightlevel = g->sector->lightlevel;
-    else
-	g->sector->rlightlevel = g->maxlight;
 }
 
 void P_SpawnGlowingLight(sector_t * sector)

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -1420,7 +1420,7 @@ static void saveg_read_lightflash_t(lightflash_t *str)
     // int mintime;
     str->mintime = SV_ReadLong();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1479,7 +1479,8 @@ static void saveg_read_strobe_t(strobe_t *str)
     // int brighttime;
     str->brighttime = SV_ReadLong();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting && 
+            str->sector->rlightlevel < str->maxlight) // [crispy] Ensure maxlight among competing thinkers. 
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1532,7 +1533,7 @@ static void saveg_read_glow_t(glow_t *str)
     // int direction;
     str->direction = SV_ReadLong();
 
-    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+    if (!a11y_sector_lighting)
         str->sector->rlightlevel = str->maxlight;
 }
 

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -24,6 +24,7 @@
 #include "m_misc.h"
 #include "p_local.h"
 #include "v_video.h"
+#include "a11y.h"
 
 static FILE *SaveGameFP;
 
@@ -1418,6 +1419,9 @@ static void saveg_read_lightflash_t(lightflash_t *str)
 
     // int mintime;
     str->mintime = SV_ReadLong();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_lightflash_t(lightflash_t *str)
@@ -1474,6 +1478,9 @@ static void saveg_read_strobe_t(strobe_t *str)
 
     // int brighttime;
     str->brighttime = SV_ReadLong();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_strobe_t(strobe_t *str)
@@ -1524,6 +1531,9 @@ static void saveg_read_glow_t(glow_t *str)
 
     // int direction;
     str->direction = SV_ReadLong();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_glow_t(glow_t *str)

--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -1420,7 +1420,7 @@ static void saveg_read_lightflash_t(lightflash_t *str)
     // int mintime;
     str->mintime = SV_ReadLong();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1479,7 +1479,7 @@ static void saveg_read_strobe_t(strobe_t *str)
     // int brighttime;
     str->brighttime = SV_ReadLong();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 
@@ -1532,7 +1532,7 @@ static void saveg_read_glow_t(glow_t *str)
     // int direction;
     str->direction = SV_ReadLong();
 
-    if (!a11y_sector_lighting)
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
         str->sector->rlightlevel = str->maxlight;
 }
 


### PR DESCRIPTION
Related Issue:
None - I can open one if required. 

### Bug description

Observed behavior:
In Heretic E1M6 (Hall with Dragonclaw) I still noticed flickering, even though it was disabled in the accessibility menu. After having a look at the map in Doom-Builder, there are trigger based actions to spawn strobelights for 4 linedefs refering the same sectors (97, 116). When a strobelight is spawned, the current sector lightlevel is stored in the maxlight. Since those spawns are not done simultaneously (the player triggers them by walking around), the second to forth spawn will take an already modified lightlevel and the maxlight will thus be "incorrect". Afterwards, they overwrite the sector lightlevel with their maxlights and thus reintroduce a strobing effect.

Expected behavior:
rlightlevel should be the highest maxlight amongst those competitors, both after loading a savegame and during runtime. 

**Changes Summary**

- I introduced a check when reading back the strobelight in saveg to ensure the highest light value is taken for the sector. Since glow, fire and flash thinkers are only spawned on level setup, they take the correct (unmodified) lightlevel at spawn. The code to restore maxlight during runtime in p_lights has been reverted (if it shall be kept, the above mentioned check needs to be added here aswell - but I think it is not needed anymore). 
- Aligning Heretic with Doom.


![grafik](https://github.com/user-attachments/assets/4b7aa2fd-6b2a-426d-b104-31ad12e70016)
