### PR TITLE
Add clangd gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ GTAGS
 # VSCode settings
 
 /.vscode/
+
+# clangd ignores
+/.cache/clangd/
+compile_commands.json


### PR DESCRIPTION
This adds .cache/clangd and compile_commands.json to gitignore for those who use clangd (vscodium, nvim)