### PR TITLE
Heretic: Adding A11Y Features: Weapon Flash Lighting & Sprite, Palette Changes, Invul Colormap, Extra Lighting

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -855,6 +855,7 @@ void D_BindVariables(void)
     M_BindIntVariable("screenblocks",           &screenblocks);
     M_BindIntVariable("snd_channels",           &snd_Channels);
     M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting);
+    M_BindIntVariable("a11y_extra_lighting",    &a11y_extra_lighting);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -858,6 +858,7 @@ void D_BindVariables(void)
     M_BindIntVariable("a11y_extra_lighting",    &a11y_extra_lighting);
     M_BindIntVariable("a11y_weapon_flash",      &a11y_weapon_flash);
     M_BindIntVariable("a11y_weapon_pspr",       &a11y_weapon_pspr);
+    M_BindIntVariable("a11y_palette_changes",   &a11y_palette_changes);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -856,6 +856,7 @@ void D_BindVariables(void)
     M_BindIntVariable("snd_channels",           &snd_Channels);
     M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting);
     M_BindIntVariable("a11y_extra_lighting",    &a11y_extra_lighting);
+    M_BindIntVariable("a11y_weapon_flash",      &a11y_weapon_flash);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -859,6 +859,7 @@ void D_BindVariables(void)
     M_BindIntVariable("a11y_weapon_flash",      &a11y_weapon_flash);
     M_BindIntVariable("a11y_weapon_pspr",       &a11y_weapon_pspr);
     M_BindIntVariable("a11y_palette_changes",   &a11y_palette_changes);
+    M_BindIntVariable("a11y_invul_colormap",    &a11y_invul_colormap);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -857,6 +857,7 @@ void D_BindVariables(void)
     M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting);
     M_BindIntVariable("a11y_extra_lighting",    &a11y_extra_lighting);
     M_BindIntVariable("a11y_weapon_flash",      &a11y_weapon_flash);
+    M_BindIntVariable("a11y_weapon_pspr",       &a11y_weapon_pspr);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -914,6 +914,7 @@ void R_SetupFrame(player_t * player)
     int tableAngle;
     int tempCentery;
     int pitch; // [crispy]
+    int tmpColormap; // [crispy]
 
     //drawbsp = 1;
     viewplayer = player;
@@ -992,7 +993,14 @@ void R_SetupFrame(player_t * player)
     sscount = 0;
     if (player->fixedcolormap)
     {
-        fixedcolormap = colormaps + player->fixedcolormap
+        tmpColormap = player->fixedcolormap;
+        if ((!a11y_invul_colormap && player->powers[pw_invulnerability]) ||
+            (!a11y_weapon_flash && player->powers[pw_infrared]))
+        {
+            tmpColormap = 1; // [crispy] A11Y 
+        }
+
+        fixedcolormap = colormaps + tmpColormap
             * (NUMCOLORMAPS / 32) // [crispy] smooth diminishing lighting
             * 256 /* * sizeof(lighttable_t)*/;
         walllights = scalelightfixed;

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -995,7 +995,7 @@ void R_SetupFrame(player_t * player)
     {
         tmpColormap = player->fixedcolormap;
         if ((!a11y_invul_colormap && player->powers[pw_invulnerability]) ||
-            (!a11y_weapon_flash && player->powers[pw_infrared]))
+            (!a11y_weapon_flash && player->powers[pw_infrared] && !player->powers[pw_invulnerability]))
         {
             tmpColormap = 1; // [crispy] A11Y 
         }

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -914,7 +914,7 @@ void R_SetupFrame(player_t * player)
     int tableAngle;
     int tempCentery;
     int pitch; // [crispy]
-    int tmpColormap; // [crispy]
+    int tmpColormap; // [crispy] to overwrite colormap
 
     //drawbsp = 1;
     viewplayer = player;
@@ -994,10 +994,11 @@ void R_SetupFrame(player_t * player)
     if (player->fixedcolormap)
     {
         tmpColormap = player->fixedcolormap;
+        // [crispy] A11Y - overwrite to disable invul-colormap or torch flickering
         if ((!a11y_invul_colormap && player->powers[pw_invulnerability]) ||
             (!a11y_weapon_flash && player->powers[pw_infrared] && !player->powers[pw_invulnerability]))
         {
-            tmpColormap = 1; // [crispy] A11Y 
+            tmpColormap = 1; // [crispy] A11Y - static infrared map
         }
 
         fixedcolormap = colormaps + tmpColormap

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -22,6 +22,7 @@
 #include "r_local.h"
 #include "tables.h"
 #include "v_video.h" // [crispy] V_DrawFilledBox for HOM detector
+#include "a11y.h" // [crispy] A11Y
 
 int viewangleoffset;
 
@@ -967,6 +968,10 @@ void R_SetupFrame(player_t * player)
     }
 
     extralight = player->extralight;
+
+    // [crispy] A11Y
+    extralight += a11y_extra_lighting;
+
     // [crispy] apply new yslope[] whenever "lookdir", "detailshift" or
     // "screenblocks" change
     tempCentery = viewheight / 2 + (pitch * (1 << crispy->hires)) *

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -967,8 +967,13 @@ void R_SetupFrame(player_t * player)
         viewy += player->chickenPeck * finesine[tableAngle];
     }
 
+    // [crispy] A11Y
+    if (a11y_weapon_flash)
+    {
     extralight = player->extralight;
-
+    }
+    else
+        extralight = 0;
     // [crispy] A11Y
     extralight += a11y_extra_lighting;
 

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -950,7 +950,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
 void R_DrawPlayerSprites(void)
 {
     int i, lightnum;
-    int tmpframe, offset, translucent = 0; // [crispy] temps for drawing translucent psrites
+    int tmpframe, offset, drawbase = 0; // [crispy] for drawing base frames
     pspdef_t *psp;
 
 //
@@ -978,12 +978,12 @@ void R_DrawPlayerSprites(void)
     {
         if (psp->state)
         {
-            // [crispy] Draw offset base frame and translucent current frame
+            // [crispy] draw base frame for transparent or deactivated weapon flashes
             if (!a11y_weapon_pspr ||
                     (crispy->translucency & TRANSLUCENCY_ITEM &&
                     !(viewplayer->powers[pw_invisibility] > 4*32 || viewplayer->powers[pw_invisibility] & 8)))
             {
-                translucent = 1;
+                drawbase = 1;
                 tmpframe = psp->state->frame;
 
                 switch (psp->state->sprite)
@@ -998,7 +998,7 @@ void R_DrawPlayerSprites(void)
                         if (tmpframe == 3)
                             offset = spriteoffsets[SPR_GWND_F3].offset;
                         else
-                            translucent = 0;
+                            drawbase = 0;
                         break;
                     case SPR_BLSR:
                         if (tmpframe == 1)
@@ -1010,7 +1010,7 @@ void R_DrawPlayerSprites(void)
                         if (tmpframe == 3)
                             offset = spriteoffsets[SPR_BLSR_F3].offset;
                         else
-                            translucent = 0;
+                            drawbase = 0;
                         break;
                     case SPR_HROD:
                         if (tmpframe == 1)
@@ -1022,7 +1022,7 @@ void R_DrawPlayerSprites(void)
                         if (tmpframe == 6)
                             offset = spriteoffsets[SPR_HROD_F6].offset;
                         else
-                            translucent = 0;
+                            drawbase = 0;
                         break;
                     case SPR_PHNX:
                         if (tmpframe == 1)
@@ -1034,23 +1034,23 @@ void R_DrawPlayerSprites(void)
                         if (tmpframe == 3)
                             offset = spriteoffsets[SPR_PHNX_F3].offset;
                         else
-                            translucent = 0;
+                            drawbase = 0;
                         break;
                     default:
                         offset = 0x0;
-                        translucent = 0;
+                        drawbase = 0;
                         break;
                 }
-                if (translucent && psp->state->sprite != SPR_GAUN)
+                if (drawbase && psp->state->sprite != SPR_GAUN)
                 {
-                    psp->state->frame = 0; // draw base frame
+                    psp->state->frame = 0; // set base frame
                     R_DrawPSprite(psp, offset, 0);
-                    psp->state->frame = tmpframe; // restore frame
+                    psp->state->frame = tmpframe; // restore attack frame
                 }
             }
-            if (!a11y_weapon_pspr && translucent)
-                continue; // [crispy] A11Y don't draw weapon attack frame
-            R_DrawPSprite(psp, 0x0, translucent);
+            if (!a11y_weapon_pspr && drawbase) 
+                continue; // [crispy] A11Y no weapon flash, use base instead
+            R_DrawPSprite(psp, 0x0, drawbase); // [crispy] translucent when base was drawn
         }      
     }
 }

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -23,6 +23,7 @@
 #include "r_bmaps.h"
 #include "r_local.h"
 #include "v_trans.h" // [crispy] blending functions
+#include "a11y.h" // [crispy] A11Y
 
 typedef struct
 {
@@ -978,8 +979,9 @@ void R_DrawPlayerSprites(void)
         if (psp->state)
         {
             // [crispy] Draw offset base frame and translucent current frame
-            if (crispy->translucency & TRANSLUCENCY_ITEM &&
-                    !(viewplayer->powers[pw_invisibility] > 4*32 || viewplayer->powers[pw_invisibility] & 8))
+            if (!a11y_weapon_pspr ||
+                    (crispy->translucency & TRANSLUCENCY_ITEM &&
+                    !(viewplayer->powers[pw_invisibility] > 4*32 || viewplayer->powers[pw_invisibility] & 8)))
             {
                 translucent = 1;
                 tmpframe = psp->state->frame;
@@ -1046,6 +1048,8 @@ void R_DrawPlayerSprites(void)
                     psp->state->frame = tmpframe; // restore frame
                 }
             }
+            if (!a11y_weapon_pspr && translucent)
+                continue; // [crispy] A11Y don't draw weapon attack frame
             R_DrawPSprite(psp, 0x0, translucent);
         }      
     }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -30,6 +30,7 @@
 #ifdef CRISPY_TRUECOLOR
 #include "v_trans.h" // [crispy] I_BlendDark()
 #endif
+#include "a11y.h" // [crispy] A11Y
 
 // Types
 
@@ -816,7 +817,12 @@ void SB_PaletteFlash(void)
 
     CPlayer = &players[consoleplayer];
 
-    if (CPlayer->damagecount)
+    // [crispy] A11Y
+    if (!a11y_palette_changes)
+    {
+	    palette = 0;
+    }
+    else if (CPlayer->damagecount)
     {
         palette = (CPlayer->damagecount + 7) >> 3;
         if (palette >= NUMREDPALS)

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -820,7 +820,7 @@ void SB_PaletteFlash(void)
     // [crispy] A11Y
     if (!a11y_palette_changes)
     {
-	    palette = 0;
+        palette = 0;
     }
     else if (CPlayer->damagecount)
     {

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -47,14 +47,14 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                                       &a11y_sector_lighting),
                       TXT_NewCheckBox("Weapon Flash Lighting",
                                       &a11y_weapon_flash),
+                      TXT_NewCheckBox("Weapon Flash Sprite",
+                                      &a11y_weapon_pspr),
                       NULL);
     }
 
     if (gamemission == doom)
     {
         TXT_AddWidgets(window,
-                      TXT_NewCheckBox("Weapon Flash Sprite",
-                                      &a11y_weapon_pspr),
                       TXT_NewCheckBox("Palette Changes",
                                       &a11y_palette_changes),
                       TXT_NewCheckBox("Invulnerability Colormap",

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -51,14 +51,9 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                                       &a11y_weapon_pspr),
                       TXT_NewCheckBox("Palette Changes",
                                       &a11y_palette_changes),
-                      NULL);
-    }
-
-    if (gamemission == doom)
-    {
-        TXT_AddWidgets(window,
                       TXT_NewCheckBox("Invulnerability Colormap",
                                       &a11y_invul_colormap),
+                                      
                       NULL);
     }
 

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -63,7 +63,7 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
 
     TXT_SetTableColumns(window, 2);
 
-    if (gamemission == doom)
+    if (gamemission == doom || gamemission == heretic)
     {
         TXT_AddWidgets(window,
                     TXT_NewLabel("Extra Lighting"),

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -52,8 +52,7 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                       TXT_NewCheckBox("Palette Changes",
                                       &a11y_palette_changes),
                       TXT_NewCheckBox("Invulnerability Colormap",
-                                      &a11y_invul_colormap),
-                                      
+                                      &a11y_invul_colormap),                                      
                       NULL);
     }
 
@@ -62,9 +61,9 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
     if (gamemission == doom || gamemission == heretic)
     {
         TXT_AddWidgets(window,
-                    TXT_NewLabel("Extra Lighting"),
-                    TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
-                    NULL);
+                      TXT_NewLabel("Extra Lighting"),
+                      TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
+                      NULL);
     }
 
 }

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -49,14 +49,14 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                                       &a11y_weapon_flash),
                       TXT_NewCheckBox("Weapon Flash Sprite",
                                       &a11y_weapon_pspr),
+                      TXT_NewCheckBox("Palette Changes",
+                                      &a11y_palette_changes),
                       NULL);
     }
 
     if (gamemission == doom)
     {
         TXT_AddWidgets(window,
-                      TXT_NewCheckBox("Palette Changes",
-                                      &a11y_palette_changes),
                       TXT_NewCheckBox("Invulnerability Colormap",
                                       &a11y_invul_colormap),
                       NULL);

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -52,7 +52,7 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                       TXT_NewCheckBox("Palette Changes",
                                       &a11y_palette_changes),
                       TXT_NewCheckBox("Invulnerability Colormap",
-                                      &a11y_invul_colormap),                                      
+                                      &a11y_invul_colormap),
                       NULL);
     }
 

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -42,16 +42,17 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
 
     if (gamemission == doom || gamemission == heretic)
     {
-        TXT_AddWidget(window, 
+        TXT_AddWidgets(window,
                       TXT_NewCheckBox("Flickering Sector Lighting",
-                                      &a11y_sector_lighting));
+                                      &a11y_sector_lighting),
+                      TXT_NewCheckBox("Weapon Flash Lighting",
+                                      &a11y_weapon_flash),
+                      NULL);
     }
-    
+
     if (gamemission == doom)
     {
         TXT_AddWidgets(window,
-                      TXT_NewCheckBox("Weapon Flash Lighting",
-                                      &a11y_weapon_flash),
                       TXT_NewCheckBox("Weapon Flash Sprite",
                                       &a11y_weapon_pspr),
                       TXT_NewCheckBox("Palette Changes",


### PR DESCRIPTION
Related Issue:
None - I can open one if required. 

**Changes Summary**
Added the following A11Y Features in Crispy-Heretic (to align with Crispy-Doom):

- Weapon Flash Lighting (also disables Torch Flickering)
- Weapon Flash Sprite
- Palette Changes
- Invulnerability Colormap
- Extra Lighting

The Blinking of diminishing Powers (Torch, Invul) remains active as an indicator for the player.

