### PR TITLE
Hexen/Heretic: Support Color-Translation in V_DrawTLPatch

### DIFF
--- a/src/v_video.c
+++ b/src/v_video.c
@@ -209,6 +209,13 @@ static const inline pixel_t drawtinttab (const pixel_t dest, const pixel_t sourc
 #else
 {return I_BlendOverTinttab(dest, pal_color[source]);}
 #endif
+// V_DrawTLPatch Translated Option (translucent patch, color-translated)
+static const inline pixel_t drawtrtinttab (const pixel_t dest, const pixel_t source)
+#ifndef CRISPY_TRUECOLOR
+{return tinttable[dest+(dp_translation[source]<<8)];}
+#else
+{return I_BlendOverTinttab(dest, pal_color[dp_translation[source]]);}
+#endif
 // V_DrawAltTLPatch (translucent patch, no coloring or color-translation are used)
 static const inline pixel_t drawalttinttab (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
@@ -227,6 +234,7 @@ static const inline pixel_t drawxlatab (const pixel_t dest, const pixel_t source
 // [crispy] array of function pointers holding the different rendering functions
 typedef const pixel_t drawpatchpx_t (const pixel_t dest, const pixel_t source);
 static drawpatchpx_t *const drawpatchpx_a[2][2] = {{drawpatchpx11, drawpatchpx10}, {drawpatchpx01, drawpatchpx00}};
+static drawpatchpx_t *const drawpatchpx_b[2] = {drawtrtinttab, drawtinttab};
 
 static fixed_t dx, dxi, dy, dyi;
 
@@ -520,8 +528,8 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
     byte *source;
     int w;
 
-    // [crispy] translucent patch, no coloring or color-translation are used
-    drawpatchpx_t *const drawpatchpx = drawtinttab;
+    // [crispy] translucent patch with optional color-translation used
+    drawpatchpx_t *const drawpatchpx = drawpatchpx_b[!dp_translation];
 
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -234,7 +234,7 @@ static const inline pixel_t drawxlatab (const pixel_t dest, const pixel_t source
 // [crispy] array of function pointers holding the different rendering functions
 typedef const pixel_t drawpatchpx_t (const pixel_t dest, const pixel_t source);
 static drawpatchpx_t *const drawpatchpx_a[2][2] = {{drawpatchpx11, drawpatchpx10}, {drawpatchpx01, drawpatchpx00}};
-static drawpatchpx_t *const drawpatchpx_b[2] = {drawtrtinttab, drawtinttab};
+static drawpatchpx_t *const drawtlpatchpx_a[2] = {drawtrtinttab, drawtinttab};
 
 static fixed_t dx, dxi, dy, dyi;
 
@@ -529,7 +529,7 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
     int w;
 
     // [crispy] translucent patch with optional color-translation used
-    drawpatchpx_t *const drawpatchpx = drawpatchpx_b[!dp_translation];
+    drawpatchpx_t *const drawpatchpx = drawtlpatchpx_a[!dp_translation];
 
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);


### PR DESCRIPTION
Related Issue:
None

**Changes Summary**

Adding a translucent and color-translated rendering function for Heretic/Hexen to be called optionally in DrawTLPatch. It is based upon drawtinttab, so the source-color remains the dominating one (for Palette), just corrected by the translation. This allows for transparent golden center-messages. 

Translated Palette Lookup example:
![2025-02-03 17_57_51-Window](https://github.com/user-attachments/assets/8e72a8d9-51f9-43a9-b4bb-7bf545e89f25)

Translated True Color Blend example:
![2025-02-03 17_49_49-Window](https://github.com/user-attachments/assets/9530147a-9dee-4d85-921c-306ee02c6699)