### PR TITLE
Doom: A11Y Disabled Invulnerability Colormap - Blinking of diminishing powers

### DIFF
--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -491,24 +491,15 @@ void P_PlayerThink (player_t* player)
 	player->bonuscount--;
 
     
-    // [crispy] A11Y
-    if (!a11y_invul_colormap)
-    {
-	if (player->powers[pw_invulnerability] || player->powers[pw_infrared])
-	    player->fixedcolormap = 1;
-	else
-	    player->fixedcolormap = 0;
-    }
-    else
     // Handling colormaps.
     if (player->powers[pw_invulnerability])
     {
 	if (player->powers[pw_invulnerability] > 4*32
 	    || (player->powers[pw_invulnerability]&8) )
-	    player->fixedcolormap = INVERSECOLORMAP;
+	    player->fixedcolormap = a11y_invul_colormap ? INVERSECOLORMAP : 1; // [crispy] A11Y
 	else
 	    // [crispy] Visor effect when Invulnerability is fading out
-	    player->fixedcolormap = player->powers[pw_infrared] ? 1 : 0;
+	    player->fixedcolormap = player->powers[pw_infrared] && a11y_invul_colormap ? 1 : 0; // [crispy] A11Y
     }
     else if (player->powers[pw_infrared])	
     {

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -499,7 +499,7 @@ void P_PlayerThink (player_t* player)
 	    player->fixedcolormap = a11y_invul_colormap ? INVERSECOLORMAP : 1; // [crispy] A11Y
 	else
 	    // [crispy] Visor effect when Invulnerability is fading out
-	    player->fixedcolormap = player->powers[pw_infrared] && a11y_invul_colormap ? 1 : 0; // [crispy] A11Y
+	    player->fixedcolormap = (player->powers[pw_infrared] && a11y_invul_colormap) ? 1 : 0; // [crispy] A11Y
     }
     else if (player->powers[pw_infrared])	
     {


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1259

**Changes Summary**

This changes the behavior for diminishing powers when the invulnerability colormap is disabled in the A11Y settings. 

Previous Behavior:
If either or both Invul and Infrared Power was active, no blinking occurred when powers were diminishing, instead it transitioned to OFF or Invul->Infrared immediately.

New Behavior:
Every transition will results in a blinking to indicate that either Invul or Infrared is running out. This also is the case when both Invul and Infrared powers are present at the same time. 