### PR TITLE
Heretic/Hexen: Correction of Transparent HUD Elements in Heretic Truecolor

### DIFF
--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -341,12 +341,7 @@ void R_InitTranslationTables(void)
     int i;
 
 #ifndef CRISPY_TRUECOLOR
-    V_LoadTintTable(); 
-#endif
-
-#ifdef CRISPY_TRUECOLOR
-    trcopacity_normal = 0x8E; // 142 (56% opacity)
-    trcopacity_alt = 0x60; // 96 (38% opacity);
+    V_LoadTintTable();
 #endif
 
     // Allocate translation tables

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -339,10 +339,9 @@ void R_DrawTranslatedTLColumn(void)
 void R_InitTranslationTables(void)
 {
     int i;
+    GameMission_t mission = heretic;
 
-#ifndef CRISPY_TRUECOLOR
-    V_LoadTintTable();
-#endif
+    V_LoadTintTable(mission);
 
     // Allocate translation tables
     translationtables = Z_Malloc(256 * 3, PU_STATIC, 0);

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -341,7 +341,12 @@ void R_InitTranslationTables(void)
     int i;
 
 #ifndef CRISPY_TRUECOLOR
-    V_LoadTintTable();
+    V_LoadTintTable(); 
+#endif
+
+#ifdef CRISPY_TRUECOLOR
+    trcopacity_normal = 0x8E; // 142 (56% opacity)
+    trcopacity_alt = 0x60; // 96 (38% opacity);
 #endif
 
     // Allocate translation tables

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -520,7 +520,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOverTinttab;
+    blendfunc = I_BlendOverAltTinttab;
 #endif
 }
 
@@ -715,7 +715,7 @@ void R_ProjectSprite(mobj_t * thing)
     {
         // [crispy] not using additive blending (I_BlendAdd) here 
         // to preserve look & feel of original Heretic's translucency
-        vis->blendfunc = I_BlendOverTinttab;
+        vis->blendfunc = I_BlendOverAltTinttab;
     }
 #endif
 }
@@ -891,7 +891,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
                                               spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-        vis->blendfunc = I_BlendOverTinttab;
+        vis->blendfunc = I_BlendOverAltTinttab;
 #endif
     }
     else if (fixedcolormap)

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -520,7 +520,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOverTinttab;
+    blendfunc = I_BlendOverHerAltTinttab;
 #endif
 }
 
@@ -715,7 +715,7 @@ void R_ProjectSprite(mobj_t * thing)
     {
         // [crispy] not using additive blending (I_BlendAdd) here 
         // to preserve look & feel of original Heretic's translucency
-        vis->blendfunc = I_BlendOverTinttab;
+        vis->blendfunc = I_BlendOverHerAltTinttab;
     }
 #endif
 }
@@ -891,7 +891,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
                                               spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-        vis->blendfunc = I_BlendOverTinttab;
+        vis->blendfunc = I_BlendOverHerAltTinttab;
 #endif
     }
     else if (fixedcolormap)

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -520,7 +520,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOverAltTinttab;
+    blendfunc = I_BlendOverTinttab;
 #endif
 }
 
@@ -715,7 +715,7 @@ void R_ProjectSprite(mobj_t * thing)
     {
         // [crispy] not using additive blending (I_BlendAdd) here 
         // to preserve look & feel of original Heretic's translucency
-        vis->blendfunc = I_BlendOverAltTinttab;
+        vis->blendfunc = I_BlendOverTinttab;
     }
 #endif
 }
@@ -891,7 +891,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
                                               spritelights[MAXLIGHTSCALE - 1];
         vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-        vis->blendfunc = I_BlendOverAltTinttab;
+        vis->blendfunc = I_BlendOverTinttab;
 #endif
     }
     else if (fixedcolormap)

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -462,10 +462,9 @@ void R_InitTranslationTables(void)
     int i;
     byte *transLump;
     int lumpnum;
+    GameMission_t mission = hexen;
 
-#ifndef CRISPY_TRUECOLOR
-    V_LoadTintTable();
-#endif
+    V_LoadTintTable(mission);
 
     // Allocate translation tables
     translationtables = Z_Malloc(256 * 3 * (maxplayers - 1), PU_STATIC, 0);

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -467,6 +467,11 @@ void R_InitTranslationTables(void)
     V_LoadTintTable();
 #endif
 
+#ifdef CRISPY_TRUECOLOR
+    trcopacity_normal = 0x60; // 96 (38% opacity);
+    trcopacity_alt = 0x8E; // 142 (56% opacity)
+#endif
+
     // Allocate translation tables
     translationtables = Z_Malloc(256 * 3 * (maxplayers - 1), PU_STATIC, 0);
 

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -467,11 +467,6 @@ void R_InitTranslationTables(void)
     V_LoadTintTable();
 #endif
 
-#ifdef CRISPY_TRUECOLOR
-    trcopacity_normal = 0x60; // 96 (38% opacity);
-    trcopacity_alt = 0x8E; // 142 (56% opacity)
-#endif
-
     // Allocate translation tables
     translationtables = Z_Malloc(256 * 3 * (maxplayers - 1), PU_STATIC, 0);
 

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -470,7 +470,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
 
     colfunc = basecolfunc;
 #ifdef CRISPY_TRUECOLOR
-    blendfunc = I_BlendOverTinttab;
+    blendfunc = I_BlendOverHexTinttab;
 #endif
 }
 
@@ -672,12 +672,12 @@ void R_ProjectSprite(mobj_t * thing)
     // bright states to preserve look & feel of original Hexen's translucency
     if (thing->flags & MF_SHADOW)
     {
-        vis->blendfunc = I_BlendOverTinttab;
+        vis->blendfunc = I_BlendOverHexTinttab;
     }
     else
     if (thing->flags & MF_ALTSHADOW)
     {
-        vis->blendfunc = I_BlendOverAltTinttab;
+        vis->blendfunc = I_BlendOverHexAltTinttab;
     }
 #endif
 }
@@ -832,14 +832,14 @@ void R_DrawPSprite(pspdef_t * psp)
             {                   // don't draw the psprite
                 vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-                vis->blendfunc = I_BlendOverTinttab;
+                vis->blendfunc = I_BlendOverHexTinttab;
 #endif
             }
             else if (viewplayer->mo->flags & MF_SHADOW)
             {
                 vis->mobjflags |= MF_ALTSHADOW;
 #ifdef CRISPY_TRUECOLOR
-                vis->blendfunc = I_BlendOverAltTinttab;
+                vis->blendfunc = I_BlendOverHexAltTinttab;
 #endif
             }
         }
@@ -847,7 +847,7 @@ void R_DrawPSprite(pspdef_t * psp)
         {
             vis->mobjflags |= MF_SHADOW;
 #ifdef CRISPY_TRUECOLOR
-            vis->blendfunc = I_BlendOverTinttab;
+            vis->blendfunc = I_BlendOverHexTinttab;
 #endif
         }
     }

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -24,9 +24,6 @@
 #include "crispy.h"
 #include "i_truecolor.h"
 
-int trcopacity_normal = 0xA8; // [crispy] default 66% opacity
-int trcopacity_alt = 0xA8; // [crispy] default 66% opacity
-
 const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg) = I_BlendOverTranmap;
 
 typedef union
@@ -90,16 +87,16 @@ const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg)
     return I_BlendOver(bg, fg, 0xA8); // 168 (66% opacity)
 }
 
-// [crispy] TINTTAB blending emulation
+// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
 const uint32_t I_BlendOverTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, trcopacity_normal);
+    return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
 }
 
-// [crispy] ("Alt") TINTTAB blending emulation
+// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
 const uint32_t I_BlendOverAltTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, trcopacity_alt);
+    return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
 }
 
 // [crispy] More opaque XLATAB blending emulation, used for Strife

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -24,6 +24,9 @@
 #include "crispy.h"
 #include "i_truecolor.h"
 
+int trcopacity_normal = 0xA8; // [crispy] default 66% opacity
+int trcopacity_alt = 0xA8; // [crispy] default 66% opacity
+
 const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg) = I_BlendOverTranmap;
 
 typedef union
@@ -87,16 +90,16 @@ const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg)
     return I_BlendOver(bg, fg, 0xA8); // 168 (66% opacity)
 }
 
-// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
+// [crispy] TINTTAB blending emulation
 const uint32_t I_BlendOverTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
+    return I_BlendOver(bg, fg, trcopacity_normal);
 }
 
-// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
+// [crispy] ("Alt") TINTTAB blending emulation
 const uint32_t I_BlendOverAltTinttab (const uint32_t bg, const uint32_t fg)
 {
-    return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
+    return I_BlendOver(bg, fg, trcopacity_alt);
 }
 
 // [crispy] More opaque XLATAB blending emulation, used for Strife

--- a/src/i_truecolor.c
+++ b/src/i_truecolor.c
@@ -87,14 +87,26 @@ const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg)
     return I_BlendOver(bg, fg, 0xA8); // 168 (66% opacity)
 }
 
-// [crispy] TINTTAB blending emulation, used for Heretic and Hexen
-const uint32_t I_BlendOverTinttab (const uint32_t bg, const uint32_t fg)
+// [crispy] TINTTAB blending emulation, used for Heretic
+const uint32_t I_BlendOverHerTinttab (const uint32_t bg, const uint32_t fg)
+{
+    return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
+}
+
+// [crispy] Less opaque ("Alt") TINTTAB blending emulation, used for Heretic
+const uint32_t I_BlendOverHerAltTinttab (const uint32_t bg, const uint32_t fg)
 {
     return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
 }
 
-// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen's MF_ALTSHADOW drawing
-const uint32_t I_BlendOverAltTinttab (const uint32_t bg, const uint32_t fg)
+// [crispy] TINTTAB blending emulation, used for Hexen
+const uint32_t I_BlendOverHexTinttab (const uint32_t bg, const uint32_t fg)
+{
+    return I_BlendOver(bg, fg, 0x60); // 96 (38% opacity)
+}
+
+// [crispy] More opaque ("Alt") TINTTAB blending emulation, used for Hexen
+const uint32_t I_BlendOverHexAltTinttab (const uint32_t bg, const uint32_t fg)
 {
     return I_BlendOver(bg, fg, 0x8E); // 142 (56% opacity)
 }

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -26,6 +26,9 @@
 
 #include <stdint.h>
 
+extern int trcopacity_normal;
+extern int trcopacity_alt;
+
 extern const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg);
 
 const uint32_t I_BlendAdd (const uint32_t bg_i, const uint32_t fg_i);

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -33,8 +33,10 @@ const uint32_t I_BlendDark (const uint32_t bg_i, const int d);
 const uint32_t I_BlendOver (const uint32_t bg_i, const uint32_t fg_i, const int amount);
 
 const uint32_t I_BlendOverTranmap (const uint32_t bg, const uint32_t fg);
-const uint32_t I_BlendOverTinttab (const uint32_t bg, const uint32_t fg);
-const uint32_t I_BlendOverAltTinttab (const uint32_t bg, const uint32_t fg);
+const uint32_t I_BlendOverHerTinttab (const uint32_t bg, const uint32_t fg);
+const uint32_t I_BlendOverHerAltTinttab (const uint32_t bg, const uint32_t fg);
+const uint32_t I_BlendOverHexTinttab (const uint32_t bg, const uint32_t fg);
+const uint32_t I_BlendOverHexAltTinttab (const uint32_t bg, const uint32_t fg);
 const uint32_t I_BlendOverXlatab (const uint32_t bg, const uint32_t fg);
 const uint32_t I_BlendOverAltXlatab (const uint32_t bg, const uint32_t fg);
 

--- a/src/i_truecolor.h
+++ b/src/i_truecolor.h
@@ -26,9 +26,6 @@
 
 #include <stdint.h>
 
-extern int trcopacity_normal;
-extern int trcopacity_alt;
-
 extern const uint32_t (*blendfunc) (const uint32_t fg, const uint32_t bg);
 
 const uint32_t I_BlendAdd (const uint32_t bg_i, const uint32_t fg_i);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -209,6 +209,13 @@ static const inline pixel_t drawtinttab (const pixel_t dest, const pixel_t sourc
 #else
 {return I_BlendOverTinttab(dest, pal_color[source]);}
 #endif
+// V_DrawTLPatch Translated Option (translucent patch, color-translated)
+static const inline pixel_t drawtrtinttab (const pixel_t dest, const pixel_t source)
+#ifndef CRISPY_TRUECOLOR
+{return tinttable[dest+(dp_translation[source]<<8)];}
+#else
+{return I_BlendOverTinttab(dest, pal_color[dp_translation[source]]);}
+#endif
 // V_DrawAltTLPatch (translucent patch, no coloring or color-translation are used)
 static const inline pixel_t drawalttinttab (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
@@ -227,6 +234,7 @@ static const inline pixel_t drawxlatab (const pixel_t dest, const pixel_t source
 // [crispy] array of function pointers holding the different rendering functions
 typedef const pixel_t drawpatchpx_t (const pixel_t dest, const pixel_t source);
 static drawpatchpx_t *const drawpatchpx_a[2][2] = {{drawpatchpx11, drawpatchpx10}, {drawpatchpx01, drawpatchpx00}};
+static drawpatchpx_t *const drawtlpatchpx_a[2] = {drawtrtinttab, drawtinttab};
 
 static fixed_t dx, dxi, dy, dyi;
 
@@ -520,8 +528,8 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
     byte *source;
     int w;
 
-    // [crispy] translucent patch, no coloring or color-translation are used
-    drawpatchpx_t *const drawpatchpx = drawtinttab;
+    // [crispy] translucent patch with optional color-translation used
+    drawpatchpx_t *const drawpatchpx = drawtlpatchpx_a[!dp_translation];
 
     y -= SHORT(patch->topoffset);
     x -= SHORT(patch->leftoffset);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -28,6 +28,7 @@
 #include "v_patch.h"
 
 #include "w_wad.h" // [crispy] for lumpindex_t
+#include "d_mode.h" // [crispy] for heretic/hexen blendfunctions
 
 //
 // VIDEO
@@ -104,7 +105,7 @@ void V_ScreenShot(const char *format);
 // Load the lookup table for translucency calculations from the TINTTAB
 // lump.
 
-void V_LoadTintTable(void);
+void V_LoadTintTable(GameMission_t mission);
 
 // villsa [STRIFE]
 // Load the lookup table for translucency calculations from the XLATAB


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1269

**Changes Summary**
Fixing the Transparent HUD Elements in Heretic Truecolor by introducing different blendovertinttab-functions for Heretic and Hexen in truecolor. 
