### PR TITLE
Heretic: Fix Translucency Option affecting MT_MUMMYLEADERGHOST

### DIFF
--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -756,7 +756,7 @@ void R_AddSprites(sector_t * sec)
         // [crispy] draw base frame and translucent current frame for MT_MUMMYLEADER attack
         if (crispy->translucency & TRANSLUCENCY_MISSILE)
         {
-            if (thing->info->doomednum == 45 && thing->frame == (24 | FF_FULLBRIGHT))
+            if (thing->state->sprite == SPR_MUMM && !(thing->flags & MF_SHADOW) && thing->frame == (24 | FF_FULLBRIGHT))
             {
                 thing->frame = (thing->frame & FF_FRAMEMASK) - 1; // [crispy] set attack stance without fire
                 R_ProjectSprite(thing);
@@ -765,7 +765,7 @@ void R_AddSprites(sector_t * sec)
             }
         }
         R_ProjectSprite(thing);
-        if (thing->info->doomednum == 45 && thing->flags & MF_TRANSLUCENT)
+        if (thing->state->sprite == SPR_MUMM && !(thing->flags & MF_SHADOW) && thing->flags & MF_TRANSLUCENT)
         {
             thing->flags &= ~MF_TRANSLUCENT;
         }

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -753,7 +753,7 @@ void R_AddSprites(sector_t * sec)
 
     for (thing = sec->thinglist; thing; thing = thing->snext)
     {
-        // [crispy] draw base frame and translucent current frame for mummyleader attack
+        // [crispy] draw base frame and translucent current frame for MT_MUMMYLEADER attack
         if (crispy->translucency & TRANSLUCENCY_MISSILE)
         {
             if (thing->info->doomednum == 45 && thing->frame == (24 | FF_FULLBRIGHT))

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -756,7 +756,7 @@ void R_AddSprites(sector_t * sec)
         // [crispy] draw base frame and translucent current frame for mummyleader attack
         if (crispy->translucency & TRANSLUCENCY_MISSILE)
         {
-            if (thing->state->sprite == SPR_MUMM && thing->frame == (24 | FF_FULLBRIGHT))
+            if (thing->info->doomednum == 45 && thing->frame == (24 | FF_FULLBRIGHT))
             {
                 thing->frame = (thing->frame & FF_FRAMEMASK) - 1; // [crispy] set attack stance without fire
                 R_ProjectSprite(thing);
@@ -765,7 +765,7 @@ void R_AddSprites(sector_t * sec)
             }
         }
         R_ProjectSprite(thing);
-        if (thing->state->sprite == SPR_MUMM && thing->flags & MF_TRANSLUCENT)
+        if (thing->info->doomednum == 45 && thing->flags & MF_TRANSLUCENT)
         {
             thing->flags &= ~MF_TRANSLUCENT;
         }


### PR DESCRIPTION
Related Commit:
https://github.com/fabiangreffrath/crispy-doom/pull/1260/commits/23d328181796d42666870c801a9c96f94162e4ef

**Change Description**

Its a bit of a late finding, but I saw today, that the replacement of the doomednum with the sprite name in the above mentioned commit has an undesired side-effect: The sprite (and also attack-states) are both present for the `MT_MUMMYLEADER` and `MT_MUMMYLEADERGHOST`, meaning that the ghost versions now also get a base-sprite drawn when the translucency-option is active. This is not intended, so I would like to hereby revert this change and use the unique identifier again to distinguish those otherwise similar enemy-types. 