### PR TITLE
Hexen: Adding a11y-Option - Flickering Sector Lighting

### DIFF
--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -35,6 +35,7 @@
 #include "i_swap.h" // [crispy] SHORT()
 #include "i_system.h"
 #include "i_timer.h"
+#include "a11y.h" // [crispy] A11Y
 #include "m_argv.h"
 #include "m_config.h"
 #include "m_controls.h"
@@ -180,6 +181,7 @@ void D_BindVariables(void)
     M_BindIntVariable("messageson",             &messageson);
     M_BindIntVariable("screenblocks",           &screenblocks);
     M_BindIntVariable("snd_channels",           &snd_Channels);
+    M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting);
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
 

--- a/src/hexen/p_anim.c
+++ b/src/hexen/p_anim.c
@@ -256,7 +256,8 @@ static void P_LightningFlash(void)
                     }
                     tempLight++;
                 }
-                tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
+                if (a11y_sector_lighting)
+                    tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
             }
         }
         else
@@ -272,7 +273,8 @@ static void P_LightningFlash(void)
                     tempSec->lightlevel = *tempLight;
                     tempLight++;
                 }
-                tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
+                if (a11y_sector_lighting)
+                    tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
             }
             Sky1Texture = P_GetMapSky1Texture(gamemap);
         }
@@ -317,7 +319,8 @@ static void P_LightningFlash(void)
             tempLight++;
             foundSec = true;
         }
-        tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
+        if (a11y_sector_lighting)
+            tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
     }
     if (foundSec)
     {

--- a/src/hexen/p_anim.c
+++ b/src/hexen/p_anim.c
@@ -22,6 +22,7 @@
 #include "i_system.h"
 #include "p_local.h"
 #include "s_sound.h"
+#include "a11y.h" // [crispy] A11Y
 
 // MACROS ------------------------------------------------------------------
 
@@ -255,6 +256,7 @@ static void P_LightningFlash(void)
                     }
                     tempLight++;
                 }
+                tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
             }
         }
         else
@@ -270,6 +272,7 @@ static void P_LightningFlash(void)
                     tempSec->lightlevel = *tempLight;
                     tempLight++;
                 }
+                tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
             }
             Sky1Texture = P_GetMapSky1Texture(gamemap);
         }
@@ -314,6 +317,7 @@ static void P_LightningFlash(void)
             tempLight++;
             foundSec = true;
         }
+        tempSec->rlightlevel = tempSec->lightlevel; // [crispy] A11Y
     }
     if (foundSec)
     {

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -164,6 +164,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 255;
                 }
+                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_LOWERBYVALUE:
                 sec->lightlevel -= arg1;
@@ -171,6 +172,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 0;
                 }
+                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_CHANGETOVALUE:
                 sec->lightlevel = arg1;
@@ -182,6 +184,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 255;
                 }
+                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_FADE:
                 think = true;

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -103,7 +103,7 @@ void T_Light(thinker_t *thinker)
     }
     
     // [crispy] A11Y
-    if (a11y_sector_lighting)
+    if (a11y_sector_lighting || light->type == LITE_FADE)
         light->sector->rlightlevel = light->sector->lightlevel;
     // else
     //     light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
@@ -164,7 +164,6 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 255;
                 }
-                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_LOWERBYVALUE:
                 sec->lightlevel -= arg1;
@@ -172,7 +171,6 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 0;
                 }
-                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_CHANGETOVALUE:
                 sec->lightlevel = arg1;
@@ -184,7 +182,6 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     sec->lightlevel = 255;
                 }
-                light->value1 = light->sector->rlightlevel = sec->lightlevel; // [crispy] A11Y
                 break;
             case LITE_FADE:
                 think = true;
@@ -198,7 +195,6 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     light->tics2 = -1;
                 }
-                light->sector->rlightlevel = light->value1; // [crispy] A11Y
                 break;
             case LITE_GLOW:
                 think = true;
@@ -236,7 +232,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
         }
 
         // [crispy] A11Y
-        if (!a11y_sector_lighting)
+        if (!a11y_sector_lighting && type >= LITE_GLOW) // [crispy] for glow, flicker and strobe
         {
             light->sector->rlightlevel = MAX(light->sector->rlightlevel, light->value1);
         }

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -234,7 +234,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
         // [crispy] A11Y
         if (!a11y_sector_lighting)
         {
-            light->sector->rlightlevel = (light->sector->rlightlevel < light->value1) ? light->value1 : light->sector->rlightlevel;
+            light->sector->rlightlevel = MAX(light->sector->rlightlevel, light->value1);
         }
         else
         {
@@ -312,7 +312,7 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
     // [crispy] A11Y
     if (!a11y_sector_lighting)
     {
-        phase->sector->rlightlevel = (phase->sector->rlightlevel < (phase->base + MAXPHASE)) ? (phase->base + MAXPHASE) : phase->sector->rlightlevel;
+        phase->sector->rlightlevel = MAX(phase->base + MAXPHASE, phase->sector->rlightlevel);
     }
     else
     {

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -198,6 +198,7 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 {
                     light->tics2 = -1;
                 }
+                light->sector->rlightlevel = light->value1; // [crispy] A11Y
                 break;
             case LITE_GLOW:
                 think = true;

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -275,7 +275,7 @@ void T_Phase(thinker_t *thinker)
     if (a11y_sector_lighting)
         phase->sector->rlightlevel = phase->sector->lightlevel;
     else
-        phase->sector->rlightlevel = phase->base + PhaseTable[0];
+        phase->sector->rlightlevel = phase->base + MAXPHASE;
 }
 
 //==========================================================================

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -105,8 +105,6 @@ void T_Light(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting || light->type == LITE_FADE)
         light->sector->rlightlevel = light->sector->lightlevel;
-    // else
-    //     light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
 }
 
 //============================================================================
@@ -280,8 +278,6 @@ void T_Phase(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         phase->sector->rlightlevel = phase->sector->lightlevel;
-    // else
-    //     phase->sector->rlightlevel = phase->base + MAXPHASE;
 }
 
 //==========================================================================

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -105,8 +105,8 @@ void T_Light(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         light->sector->rlightlevel = light->sector->lightlevel;
-    else
-        light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
+    // else
+    //     light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
 }
 
 //============================================================================
@@ -233,9 +233,13 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
 
         // [crispy] A11Y
         if (!a11y_sector_lighting)
-            light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
+        {
+            light->sector->rlightlevel = (light->sector->rlightlevel < light->value1) ? light->value1 : light->sector->rlightlevel;
+        }
         else
+        {
             light->sector->rlightlevel = light->sector->lightlevel;
+        }            
             
         if (think)
         {
@@ -276,8 +280,8 @@ void T_Phase(thinker_t *thinker)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         phase->sector->rlightlevel = phase->sector->lightlevel;
-    else
-        phase->sector->rlightlevel = phase->base + MAXPHASE;
+    // else
+    //     phase->sector->rlightlevel = phase->base + MAXPHASE;
 }
 
 //==========================================================================
@@ -307,9 +311,13 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
    
     // [crispy] A11Y
     if (!a11y_sector_lighting)
-        phase->sector->rlightlevel = phase->base + PhaseTable[0];
+    {
+        phase->sector->rlightlevel = (phase->sector->rlightlevel < (phase->base + MAXPHASE)) ? (phase->base + MAXPHASE) : phase->sector->rlightlevel;
+    }
     else
-        phase->sector->rlightlevel = sector->lightlevel;
+    {
+        phase->sector->rlightlevel = phase->sector->lightlevel;
+    }
 
     sector->special = 0;
 }

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -230,11 +230,13 @@ boolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
                 rtn = false;
                 break;
         }
+
         // [crispy] A11Y
         if (!a11y_sector_lighting)
-        {
             light->sector->rlightlevel = (light->sector->lightlevel > light->value1) ? light->sector->lightlevel : light->value1;
-        }
+        else
+            light->sector->rlightlevel = light->sector->lightlevel;
+            
         if (think)
         {
             P_AddThinker(&light->thinker);
@@ -302,11 +304,12 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
     phase->base = base & 255;
     sector->lightlevel = phase->base + PhaseTable[phase->index];
     phase->thinker.function = T_Phase;
+   
     // [crispy] A11Y
     if (!a11y_sector_lighting)
-    {
         phase->sector->rlightlevel = phase->base + PhaseTable[0];
-    }
+    else
+        phase->sector->rlightlevel = sector->lightlevel;
 
     sector->special = 0;
 }

--- a/src/hexen/p_lights.c
+++ b/src/hexen/p_lights.c
@@ -18,6 +18,7 @@
 #include "h2def.h"
 #include "m_random.h"
 #include "p_local.h"
+#include "a11y.h" // [crispy] A11Y
 
 //============================================================================
 //
@@ -100,6 +101,12 @@ void T_Light(thinker_t *thinker)
         default:
             break;
     }
+    
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+        light->sector->rlightlevel = light->sector->lightlevel;
+    else
+        light->sector->rlightlevel = light->value1;
 }
 
 //============================================================================

--- a/src/hexen/p_local.h
+++ b/src/hexen/p_local.h
@@ -61,6 +61,8 @@
 #define MELEERANGE (64*FRACUNIT)
 #define MISSILERANGE (32*64*FRACUNIT)
 
+#define MAXPHASE 128 // [crispy] for A11Y Phase Lights
+
 typedef enum
 {
     DI_EAST,

--- a/src/hexen/p_local.h
+++ b/src/hexen/p_local.h
@@ -61,7 +61,7 @@
 #define MELEERANGE (64*FRACUNIT)
 #define MISSILERANGE (32*64*FRACUNIT)
 
-#define MAXPHASE 128 // [crispy] for A11Y Phase Lights
+#define MAXPHASE 128 // [crispy] Max value out of the p_lights.c PhaseTable
 
 typedef enum
 {

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -336,6 +336,8 @@ void P_LoadSectors(int lump)
         ss->floorpic = R_FlatNumForName(ms->floorpic);
         ss->ceilingpic = R_FlatNumForName(ms->ceilingpic);
         ss->lightlevel = SHORT(ms->lightlevel);
+        // [crispy] A11Y light level used for rendering
+        ss->rlightlevel = ss->lightlevel;
         ss->special = SHORT(ms->special);
         ss->tag = SHORT(ms->tag);
         ss->thinglist = NULL;

--- a/src/hexen/r_bsp.c
+++ b/src/hexen/r_bsp.c
@@ -311,7 +311,7 @@ void R_AddLine(seg_t * line)
 // reject empty lines used for triggers and special events
     if (backsector->ceilingpic == frontsector->ceilingpic
         && backsector->floorpic == frontsector->floorpic
-        && backsector->lightlevel == frontsector->lightlevel
+        && backsector->rlightlevel == frontsector->rlightlevel
         && backsector->special == frontsector->special
         && curline->sidedef->midtexture == 0)
         return;
@@ -467,7 +467,7 @@ void R_Subsector(int num)
     {
         floorplane = R_FindPlane(frontsector->interpfloorheight,
                                  frontsector->floorpic,
-                                 frontsector->lightlevel,
+                                 frontsector->rlightlevel, // [crispy] A11Y
                                  frontsector->special);
     }
     else
@@ -480,7 +480,8 @@ void R_Subsector(int num)
     {
         ceilingplane = R_FindPlane(frontsector->interpceilingheight,
                                    frontsector->ceilingpic,
-                                   frontsector->lightlevel, 0);
+                                   frontsector->rlightlevel, // [crispy] A11Y
+                                   0);
     }
     else
     {

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -112,6 +112,9 @@ typedef struct
     //      the renderer.
     fixed_t	interpfloorheight;
     fixed_t	interpceilingheight;
+
+    // [crispy] A11Y light level used for rendering
+    short	rlightlevel;
 } sector_t;
 
 typedef struct

--- a/src/hexen/r_segs.c
+++ b/src/hexen/r_segs.c
@@ -179,7 +179,7 @@ void R_RenderMaskedSegRange(drawseg_t * ds, int x1, int x2)
     backsector = curline->backsector;
     texnum = texturetranslation[curline->sidedef->midtexture];
 
-    lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (frontsector->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
     //if (curline->v1->y == curline->v2->y)
     //      lightnum--;
     //else if (curline->v1->x == curline->v2->x)
@@ -654,7 +654,7 @@ void R_StoreWallRange(int start, int stop)
 
         if (worldlow != worldbottom
             || backsector->floorpic != frontsector->floorpic
-            || backsector->lightlevel != frontsector->lightlevel
+            || backsector->rlightlevel != frontsector->rlightlevel
             || backsector->special != frontsector->special)
             markfloor = true;
         else
@@ -662,7 +662,7 @@ void R_StoreWallRange(int start, int stop)
 
         if (worldhigh != worldtop
             || backsector->ceilingpic != frontsector->ceilingpic
-            || backsector->lightlevel != frontsector->lightlevel)
+            || backsector->rlightlevel != frontsector->rlightlevel)
             markceiling = true;
         else
             markceiling = false;        // same plane on both sides
@@ -727,7 +727,7 @@ void R_StoreWallRange(int start, int stop)
         if (!fixedcolormap)
         {
             lightnum =
-                (frontsector->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting;
+                (frontsector->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
             //if (curline->v1->y == curline->v2->y)
             //      lightnum--;
             //else if (curline->v1->x == curline->v2->x)

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -703,7 +703,7 @@ void R_AddSprites(sector_t * sec)
 
     sec->validcount = validcount;
 
-    lightnum = (sec->lightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (sec->rlightlevel >> LIGHTSEGSHIFT) + (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
     if (lightnum < 0)
         spritelights = scalelight[0];
     else if (lightnum >= LIGHTLEVELS)
@@ -924,7 +924,7 @@ void R_DrawPlayerSprites(void)
 // get light level
 //
     lightnum =
-        (viewplayer->mo->subsector->sector->lightlevel >> LIGHTSEGSHIFT) +
+        (viewplayer->mo->subsector->sector->rlightlevel >> LIGHTSEGSHIFT) +  // [crispy] A11Y
         (extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
     if (lightnum < 0)
         spritelights = scalelight[0];

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -22,6 +22,7 @@
 #include "m_misc.h"
 #include "i_swap.h"
 #include "p_local.h"
+#include "a11y.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -1429,6 +1430,10 @@ static void StreamIn_light_t(thinker_t *thinker)
 
     // int count;
     str->count = SV_ReadLong();
+
+    if (!a11y_sector_lighting && 
+            str->sector->rlightlevel < str->value1) // [crispy] Ensure maxlight among competing thinkers. 
+        str->sector->rlightlevel = str->value1;
 }
 
 static void StreamOut_light_t(thinker_t *thinker)
@@ -2585,6 +2590,7 @@ static void UnarchiveWorld(void)
         sec->floorpic = SV_ReadWord();
         sec->ceilingpic = SV_ReadWord();
         sec->lightlevel = SV_ReadWord();
+        sec->rlightlevel = sec->lightlevel; // [crispy] A11Y
         sec->special = SV_ReadWord();
         sec->tag = SV_ReadWord();
         sec->seqType = SV_ReadWord();

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1555,7 +1555,7 @@ static void StreamIn_phase_t(thinker_t *thinker)
     str->base = SV_ReadLong();
 
     if (!a11y_sector_lighting && (str->sector->rlightlevel < (str->base + MAXPHASE))) // [crispy] A11Y - maxlight among competing thinkers. 
-        str->sector->rlightlevel = str->base + MAXPHASE;;
+        str->sector->rlightlevel = str->base + MAXPHASE;
 }
 
 static void StreamOut_phase_t(thinker_t *thinker)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1555,7 +1555,7 @@ static void StreamIn_phase_t(thinker_t *thinker)
     str->base = SV_ReadLong();
 
     if (!a11y_sector_lighting) // [crispy] A11Y
-        str->sector->rlightlevel = str->base + 128;;
+        str->sector->rlightlevel = str->base + MAXPHASE;;
 }
 
 static void StreamOut_phase_t(thinker_t *thinker)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1431,8 +1431,8 @@ static void StreamIn_light_t(thinker_t *thinker)
     // int count;
     str->count = SV_ReadLong();
 
-    if (!a11y_sector_lighting) // [crispy] A11Y
-        str->sector->rlightlevel = (str->sector->lightlevel > str->value1) ? str->sector->lightlevel : str->value1;
+    if (!a11y_sector_lighting && (str->sector->rlightlevel < str->value1)) // [crispy] A11Y - maxlight among competing thinkers. 
+        str->sector->rlightlevel = str->value1;
 }
 
 static void StreamOut_light_t(thinker_t *thinker)
@@ -1554,7 +1554,7 @@ static void StreamIn_phase_t(thinker_t *thinker)
     // int base;
     str->base = SV_ReadLong();
 
-    if (!a11y_sector_lighting) // [crispy] A11Y
+    if (!a11y_sector_lighting && (str->sector->rlightlevel < (str->base + MAXPHASE))) // [crispy] A11Y - maxlight among competing thinkers. 
         str->sector->rlightlevel = str->base + MAXPHASE;;
 }
 

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1431,9 +1431,8 @@ static void StreamIn_light_t(thinker_t *thinker)
     // int count;
     str->count = SV_ReadLong();
 
-    if (!a11y_sector_lighting && 
-            str->sector->rlightlevel < str->value1) // [crispy] Ensure maxlight among competing thinkers. 
-        str->sector->rlightlevel = str->value1;
+    if (!a11y_sector_lighting) // [crispy] A11Y
+        str->sector->rlightlevel = (str->sector->lightlevel > str->value1) ? str->sector->lightlevel : str->value1;
 }
 
 static void StreamOut_light_t(thinker_t *thinker)
@@ -1554,6 +1553,9 @@ static void StreamIn_phase_t(thinker_t *thinker)
 
     // int base;
     str->base = SV_ReadLong();
+
+    if (!a11y_sector_lighting) // [crispy] A11Y
+        str->sector->rlightlevel = str->base + 128;;
 }
 
 static void StreamOut_phase_t(thinker_t *thinker)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1431,8 +1431,8 @@ static void StreamIn_light_t(thinker_t *thinker)
     // int count;
     str->count = SV_ReadLong();
 
-    if (!a11y_sector_lighting && (str->sector->rlightlevel < str->value1)) // [crispy] A11Y - maxlight among competing thinkers. 
-        str->sector->rlightlevel = str->value1;
+    if (!a11y_sector_lighting && str->type >= LITE_GLOW) // [crispy] A11Y - maxlight among competing thinkers.
+        str->sector->rlightlevel = MAX(str->sector->rlightlevel, str->value1);
 }
 
 static void StreamOut_light_t(thinker_t *thinker)
@@ -1554,8 +1554,8 @@ static void StreamIn_phase_t(thinker_t *thinker)
     // int base;
     str->base = SV_ReadLong();
 
-    if (!a11y_sector_lighting && (str->sector->rlightlevel < (str->base + MAXPHASE))) // [crispy] A11Y - maxlight among competing thinkers. 
-        str->sector->rlightlevel = str->base + MAXPHASE;
+    if (!a11y_sector_lighting) // [crispy] A11Y - maxlight among competing thinkers.
+        str->sector->rlightlevel = MAX(str->base + MAXPHASE, str->sector->rlightlevel);
 }
 
 static void StreamOut_phase_t(thinker_t *thinker)

--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -40,11 +40,17 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
 
     TXT_SetWindowHelpURL(window, WINDOW_HELP_URL);
 
-    if (gamemission == doom || gamemission == heretic)
+    if (gamemission == doom || gamemission == heretic || gamemission == hexen)
     {
         TXT_AddWidgets(window,
                       TXT_NewCheckBox("Flickering Sector Lighting",
                                       &a11y_sector_lighting),
+                      NULL);
+    }
+
+    if (gamemission == doom || gamemission == heretic)
+    {
+        TXT_AddWidgets(window,
                       TXT_NewCheckBox("Weapon Flash Lighting",
                                       &a11y_weapon_flash),
                       TXT_NewCheckBox("Weapon Flash Sprite",

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -236,7 +236,7 @@ void MainMenu(void)
                        (TxtWidgetSignalFunc) CompatibilitySettings, NULL),
 */
     // [crispy]
-    if (gamemission == doom || gamemission == heretic)
+    if (gamemission == doom || gamemission == heretic || gamemission == hexen)
     {
         TXT_AddWidget(window,
             TXT_NewButton2("Accessibility",


### PR DESCRIPTION
Related PR for Heretic:
https://github.com/fabiangreffrath/crispy-doom/pull/1246

**Changes Summary**

- Added Accessibility Option to Hexen Setup for Flickering Sector Lighting.
- Ported solution from Crispy-Heretic for the actual disabling.
- Lightning is also disabled by this option. 

Checked vanilla compatibility using 4 Demos (MAP 01 - 03, MAP 05), no deviation seen. 