### PR TITLE
Hexen: Adding Translucency Option

### DIFF
--- a/src/hexen/a_action.c
+++ b/src/hexen/a_action.c
@@ -1338,4 +1338,6 @@ void A_TreeDeath(mobj_t *actor, player_t *player, pspdef_t *psp)
 void A_NoGravity(mobj_t *actor, player_t *player, pspdef_t *psp)
 {
     actor->flags |= MF_NOGRAVITY;
+    if (actor->type == MT_THROWINGBOMB)
+        actor->flags |= MF_TRANSLUCENT; // [crispy] make exploding throwingbombs translucent
 }

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -211,6 +211,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_mouselook",       &crispy->mouselook);
     M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
     M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
+    M_BindIntVariable("crispy_translucency",    &crispy->translucency);
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("crispy_truecolor",       &crispy->truecolor);
 #endif

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -293,6 +293,7 @@ typedef struct
 //#define       MF_TRANSLATION  0xc000000       // if 0x4 0x8 or 0xc, use a translation
 #define	MF_TRANSLATION	0x1c000000      // use a translation table (>>MF_TRANSHIFT)
 #define	MF_TRANSSHIFT	26      // table for player colormaps
+#define MF_TRANSLUCENT  0x80000000 // [crispy] translucent sprite
 
 
 // --- mobj.flags2 ---

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -3426,7 +3426,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOBLOCKMAP | MF_TRANSLUCENT,   // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOBLOCKMAP,   // flags
      MF2_NOTELEPORT             // flags2
      },
 

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -9420,7 +9420,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_SPECIAL | MF_NOGRAVITY | MF_TRANSLUCENT, // flags
+     MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
 
@@ -9798,7 +9798,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_SPECIAL | MF_NOGRAVITY | MF_TRANSLUCENT, // flags
+     MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
 

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -3642,7 +3642,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10001,                     // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3669,7 +3669,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3696,7 +3696,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3723,7 +3723,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3750,7 +3750,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -3777,7 +3777,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -3804,7 +3804,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -8988,7 +8988,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9015,7 +9015,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9042,7 +9042,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
+     MF_NOBLOCKMAP | MF_NOSECTOR | MF_TRANSLUCENT,       // flags
      0                          // flags2
      },
 

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -3858,7 +3858,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3885,7 +3885,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3912,7 +3912,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
 

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -2994,7 +2994,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -3156,7 +3156,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_ICEDAMAGE     // flags2
      },
 
@@ -3426,7 +3426,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOBLOCKMAP,   // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOBLOCKMAP | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3534,7 +3534,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10001,                     // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3561,7 +3561,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10001,                     // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3588,7 +3588,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10001,                     // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3615,7 +3615,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10001,                     // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
+     MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3669,7 +3669,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3696,7 +3696,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3723,7 +3723,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3750,7 +3750,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -3777,7 +3777,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -3804,7 +3804,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -3858,7 +3858,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3885,7 +3885,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -3912,7 +3912,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -4074,7 +4074,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4101,7 +4101,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4128,7 +4128,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4155,7 +4155,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4182,7 +4182,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4209,7 +4209,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4236,7 +4236,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4263,7 +4263,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4290,7 +4290,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4317,7 +4317,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -4371,7 +4371,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -9150,7 +9150,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9231,7 +9231,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10,                        // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
 
@@ -9285,7 +9285,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9366,7 +9366,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9420,7 +9420,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_SPECIAL | MF_NOGRAVITY, // flags
+     MF_SPECIAL | MF_NOGRAVITY | MF_TRANSLUCENT, // flags
      0                          // flags2
      },
 
@@ -9447,7 +9447,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9474,7 +9474,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9501,7 +9501,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      0                          // flags2
      },
 
@@ -9528,7 +9528,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -9555,7 +9555,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_DONTDRAW | MF2_FIREDAMAGE   // flags2
      },
 
@@ -9663,7 +9663,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_MISSILE,    // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -9717,7 +9717,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH | MF2_NODMGTHRUST  // flags2
      },
 
@@ -9771,7 +9771,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_RIP | MF2_IMPACT | MF2_PCROSS | MF2_NODMGTHRUST | MF2_CANNOTPUSH      // flags2
      },
 
@@ -9798,7 +9798,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_SPECIAL | MF_NOGRAVITY, // flags
+     MF_SPECIAL | MF_NOGRAVITY | MF_TRANSLUCENT, // flags
      0                          // flags2
      },
 
@@ -9825,7 +9825,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9852,7 +9852,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9879,7 +9879,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      0                          // flags2
      },
 
@@ -9906,7 +9906,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      6,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_RIP | MF2_IMPACT | MF2_PCROSS        // flags2
      },
 
@@ -9933,7 +9933,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_IMPACT | MF2_PCROSS | MF2_SEEKERMISSILE      // flags2
      },
 
@@ -10257,7 +10257,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_ICEDAMAGE   // flags2
      },
 
@@ -10635,7 +10635,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -10878,7 +10878,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
 
@@ -11067,7 +11067,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
 
@@ -11148,7 +11148,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FLOORCLIP | MF2_FIREDAMAGE  // flags2
      },
 
@@ -11175,7 +11175,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF,        // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_TRANSLUCENT,        // flags
      MF2_NOTELEPORT | MF2_FLOORCLIP     // flags2
      },
 
@@ -11202,7 +11202,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT | MF2_FLOORCLIP     // flags2
      },
 
@@ -11229,7 +11229,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -11256,7 +11256,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -11310,7 +11310,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      3,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -11337,7 +11337,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -11364,7 +11364,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -11499,7 +11499,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -11742,7 +11742,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_SEEKERMISSILE // flags2
      },
 
@@ -11796,7 +11796,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      6,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -12525,7 +12525,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      16,                        // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -12552,7 +12552,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      16,                        // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -12579,7 +12579,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      16,                        // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -12606,7 +12606,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      16,                        // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -12633,7 +12633,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      16,                        // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -12660,7 +12660,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      15,                        // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FLOORCLIP | MF2_FIREDAMAGE  // flags2
      },
 
@@ -12714,7 +12714,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT | MF2_ICEDAMAGE     // flags2
      },
 
@@ -12768,7 +12768,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_TRANSLUCENT,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_ICEDAMAGE        // flags2
      },
 
@@ -12984,7 +12984,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13011,7 +13011,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13038,7 +13038,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13065,7 +13065,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE,        // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_TRANSLUCENT,        // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13092,7 +13092,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13146,7 +13146,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE,        // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_TRANSLUCENT,        // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13200,7 +13200,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_NOGRAVITY, // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_NOGRAVITY | MF_TRANSLUCENT, // flags
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13227,7 +13227,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF,        // flags
+     MF_NOBLOCKMAP | MF_DROPOFF | MF_TRANSLUCENT,        // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 
@@ -13605,7 +13605,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF | MF_TRANSLUCENT,    // flags
      MF2_NOTELEPORT             // flags2
      },
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -139,6 +139,7 @@ static void CrispyVsync(int option);
 static void CrispyBrightmaps(int option);
 static void CrispySmoothLighting(int option);
 static void CrispySoundMono(int option);
+static void CrispyTranslucency(int option);
 static void CrispySndChannels(int option);
 static void CrispyPlayerCoords(int options);
 static void CrispyFreelook(int option);
@@ -373,10 +374,7 @@ static MenuItem_t Crispness1Items[] = {
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_LRFUNC2, "BRIGHTMAPS:", CrispyBrightmaps, 0, MENU_NONE},
     {ITT_LRFUNC2, "SMOOTH DIMINISHING LIGHTING:", CrispySmoothLighting, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
-    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
-    {ITT_LRFUNC2, "MONO SFX:", CrispySoundMono, 0, MENU_NONE},
-    {ITT_LRFUNC2, "SOUND CHANNELS:", CrispySndChannels, 0, MENU_NONE},
+    {ITT_LRFUNC2, "ENABLE TRANSLUCENCY:", CrispyTranslucency, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EFUNC, "NEXT PAGE", CrispyNextPage, 0, MENU_NONE},
 };
@@ -384,12 +382,16 @@ static MenuItem_t Crispness1Items[] = {
 static Menu_t Crispness1Menu = {
     68, 35,
     DrawCrispnessMenu,
-    16, Crispness1Items,
+    13, Crispness1Items,
     0,
     MENU_OPTIONS
 };
 
 static MenuItem_t Crispness2Items[] = {
+    {ITT_LRFUNC2, "MONO SFX:", CrispySoundMono, 0, MENU_NONE},
+    {ITT_LRFUNC2, "SOUND CHANNELS:", CrispySndChannels, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},   
     {ITT_LRFUNC2, "SHOW PLAYER COORDS:", CrispyPlayerCoords, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
@@ -405,7 +407,7 @@ static MenuItem_t Crispness2Items[] = {
 static Menu_t Crispness2Menu = {
     68, 35,
     DrawCrispnessMenu,
-    10, Crispness2Items,
+    14, Crispness2Items,
     0,
     MENU_OPTIONS
 };
@@ -472,6 +474,14 @@ static const multiitem_t multiitem_difficulties[NUM_SKILLS] =
     {SKILL_NIGHTMARE, "VERY HARD"},
     {SKILL_ITYTD, "VERY EASY"},
     {SKILL_HNTR, "EASY"},
+};
+
+multiitem_t multiitem_translucency[NUM_TRANSLUCENCY] =
+{
+    {TRANSLUCENCY_OFF, "OFF"},
+    {TRANSLUCENCY_MISSILE, "PROJECTILES"},
+    {TRANSLUCENCY_ITEM, "WEAPON FLASHES"},
+    {TRANSLUCENCY_BOTH, "BOTH"},
 };
 
 static const multiitem_t multiitem_sndchannels[3] =
@@ -1757,6 +1767,11 @@ static void CrispySoundMono(int option)
     crispy->soundmono = !crispy->soundmono;
 }
 
+static void CrispyTranslucency(int choice)
+{
+    ChangeSettingEnum(&crispy->translucency, choice, NUM_TRANSLUCENCY);
+}
+
 static void CrispySndChannels(int option)
 {
     S_UpdateSndChannels(option);
@@ -2998,39 +3013,42 @@ static void DrawCrispness1(void)
     // Smooth Diminishing Lighting
     DrawCrispnessItem(crispy->smoothlight, 257, 125);
 
-    DrawCrispnessSubheader("AUDIBLE", 145);
-
-    // Mono SFX
-    DrawCrispnessItem(crispy->soundmono, 137, 155);
-
-    // Sound Channels
-    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 165, multiitem_sndchannels, false);
+    // Translucency
+    DrawCrispnessMultiItem(crispy->translucency, 218, 135, multiitem_translucency, false);
 }
 
 static void DrawCrispness2(void)
 {
     DrawCrispnessHeader("CRISPNESS 2/2");
 
-    DrawCrispnessSubheader("NAVIGATIONAL", 25);
+    DrawCrispnessSubheader("AUDIBLE", 25);
+
+    // Mono SFX
+    DrawCrispnessItem(crispy->soundmono, 137, 35);
+
+    // Sound Channels
+    DrawCrispnessMultiItem(snd_Channels >> 4, 181, 45, multiitem_sndchannels, false);
+
+    DrawCrispnessSubheader("NAVIGATIONAL", 65);
 
     // Player coordinates
-    DrawCrispnessMultiItem(crispy->playercoords, 211, 35, multiitem_widgets, false);
+    DrawCrispnessMultiItem(crispy->playercoords, 211, 75, multiitem_widgets, false);
 
-    DrawCrispnessSubheader("TACTICAL", 55);
+    DrawCrispnessSubheader("TACTICAL", 95);
 
     // Freelook
-    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 65, multiitem_freelook_hh, false);
+    DrawCrispnessMultiItem(crispy->freelook_hh, 175, 105, multiitem_freelook_hh, false);
 
     // Mouselook
-    DrawCrispnessItem(crispy->mouselook, 220, 75);
+    DrawCrispnessItem(crispy->mouselook, 220, 115);
 
     // Bobfactor
-    DrawCrispnessMultiItem(crispy->bobfactor, 265, 85, multiitem_bobfactor, false);
+    DrawCrispnessMultiItem(crispy->bobfactor, 265, 125, multiitem_bobfactor, false);
 
     // Weapon attack alignment
-    DrawCrispnessMultiItem(crispy->centerweapon, 245, 95, multiitem_centerweapon,
+    DrawCrispnessMultiItem(crispy->centerweapon, 245, 135, multiitem_centerweapon,
             crispy->bobfactor == BOBFACTOR_OFF);
 
     // Default difficulty
-    DrawCrispnessMultiItem(crispy->defaultskill, 200, 105, multiitem_difficulties, false);
+    DrawCrispnessMultiItem(crispy->defaultskill, 200, 145, multiitem_difficulties, false);
 }

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -958,7 +958,10 @@ void R_DrawPlayerSprites(void)
         if (psp->state)
         {
             // [crispy] draw base frame for transparent or deactivated weapon flashes
-            if (crispy->translucency & TRANSLUCENCY_ITEM)
+            if (crispy->translucency & TRANSLUCENCY_ITEM && 
+                (!(viewplayer->class == PCLASS_CLERIC) || !(viewplayer->powers[pw_invulnerability]) || 
+                        !((viewplayer->powers[pw_invulnerability] > 4*32 || viewplayer->powers[pw_invulnerability] & 8) && 
+                        (viewplayer->mo->flags2 & MF2_DONTDRAW || viewplayer->mo->flags & MF_SHADOW)))) // [crispy] when cleric is non-translucent during invul
             {
                 tmpframe = psp->state->frame;
 

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -61,6 +61,9 @@ boolean LevelUseFullBright;
 ===============================================================================
 */
 
+// [crispy] check if player sprite is translucent due to active power
+static boolean R_CheckPowerBasedTranslucency(void);
+
 // variables used to look up and range check thing_t sprites patches
 spritedef_t *sprites;
 int numsprites;
@@ -968,10 +971,7 @@ void R_DrawPlayerSprites(void)
         if (psp->state)
         {
             // [crispy] draw base frame for transparent or deactivated weapon flashes
-            if (crispy->translucency & TRANSLUCENCY_ITEM && 
-                (!(viewplayer->class == PCLASS_CLERIC) || !(viewplayer->powers[pw_invulnerability]) || 
-                        !((viewplayer->powers[pw_invulnerability] > 4*32 || viewplayer->powers[pw_invulnerability] & 8) && 
-                            viewplayer->mo->flags & MF_SHADOW))) // [crispy] when cleric is non-translucent during invul
+            if (crispy->translucency & TRANSLUCENCY_ITEM && !R_CheckPowerBasedTranslucency())
             {
                 tmpframe = psp->state->frame;
 
@@ -1010,6 +1010,24 @@ void R_DrawPlayerSprites(void)
     }
 }
 
+/*
+========================
+=
+= [crispy] R_CheckPowerBasedTranslucency
+=
+= Check if player sprite is translucent due to active power
+========================
+*/
+
+static boolean R_CheckPowerBasedTranslucency(void)
+{
+    if (viewplayer->class == PCLASS_CLERIC && viewplayer->powers[pw_invulnerability] &&
+        ((viewplayer->powers[pw_invulnerability] > 4*32 || viewplayer->powers[pw_invulnerability] & 8) && 
+         viewplayer->mo->flags & MF_SHADOW))
+        return true;
+    else
+        return false;
+}
 
 /*
 ========================

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -69,6 +69,8 @@ spriteframe_t sprtemp[30];
 int maxframe;
 static const char *spritename;
 
+
+
 /*
 =================
 =

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -427,7 +427,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
             ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT - 8));
     }
     // [crispy] translucent sprites
-    else if (crispy->translucency && vis->mobjflags & MF_TRANSLUCENT)
+    else if (colfunc != R_DrawAltTLColumn && crispy->translucency && vis->mobjflags & MF_TRANSLUCENT)
     {
     	if ((crispy->translucency & TRANSLUCENCY_MISSILE) ||
             (vis->psprite && crispy->translucency & TRANSLUCENCY_ITEM))

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -431,7 +431,12 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
     {
     	if ((crispy->translucency & TRANSLUCENCY_MISSILE) ||
             (vis->psprite && crispy->translucency & TRANSLUCENCY_ITEM))
-	        colfunc = tlcolfunc;
+            {
+	            colfunc = tlcolfunc;
+            }
+#ifdef CRISPY_TRUECOLOR
+            blendfunc = vis->blendfunc;
+#endif
     }
 
     dc_iscale = abs(vis->xiscale) >> detailshift;
@@ -675,7 +680,7 @@ void R_ProjectSprite(mobj_t * thing)
 #ifdef CRISPY_TRUECOLOR
     // [crispy] not using additive blending (I_BlendAdd) here for full
     // bright states to preserve look & feel of original Hexen's translucency
-    if (thing->flags & MF_SHADOW)
+    if (thing->flags & MF_SHADOW || thing->flags & MF_TRANSLUCENT)
     {
         vis->blendfunc = I_BlendOverTinttab;
     }
@@ -878,6 +883,9 @@ void R_DrawPSprite(pspdef_t * psp, int translucent) // [crispy] translucency for
     if (translucent)
     {
         vis->mobjflags |= MF_TRANSLUCENT;
+#ifdef CRISPY_TRUECOLOR
+        vis->blendfunc = I_BlendOverTinttab;
+#endif        
     }
 
     // [crispy] interpolate weapon bobbing

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -427,7 +427,7 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
             ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT - 8));
     }
     // [crispy] translucent sprites
-    else if (colfunc != R_DrawAltTLColumn && crispy->translucency && vis->mobjflags & MF_TRANSLUCENT)
+    else if (crispy->translucency && vis->mobjflags & MF_TRANSLUCENT)
     {
     	if ((crispy->translucency & TRANSLUCENCY_MISSILE) ||
             (vis->psprite && crispy->translucency & TRANSLUCENCY_ITEM))

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -961,7 +961,7 @@ void R_DrawPlayerSprites(void)
             if (crispy->translucency & TRANSLUCENCY_ITEM && 
                 (!(viewplayer->class == PCLASS_CLERIC) || !(viewplayer->powers[pw_invulnerability]) || 
                         !((viewplayer->powers[pw_invulnerability] > 4*32 || viewplayer->powers[pw_invulnerability] & 8) && 
-                        (viewplayer->mo->flags2 & MF2_DONTDRAW || viewplayer->mo->flags & MF_SHADOW)))) // [crispy] when cleric is non-translucent during invul
+                            viewplayer->mo->flags & MF_SHADOW))) // [crispy] when cleric is non-translucent during invul
             {
                 tmpframe = psp->state->frame;
 

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -35,29 +35,6 @@ typedef struct
     int bottomclip;
 } maskdraw_t;
 
-typedef enum
-{
-    SPR_GWND_F1,
-    SPR_GWND_F2,
-    SPR_GWND_F3,
-    SPR_BLSR_F1,
-    SPR_BLSR_F2,
-    SPR_BLSR_F3,
-    SPR_HROD_F1,
-    SPR_HROD_F2_5,
-    SPR_HROD_F6,
-    SPR_PHNX_F1,
-    SPR_PHNX_F2,
-    SPR_PHNX_F3, 
-    NUMSOFFSETS
-} spriteoffsetenum_t;
-
-typedef struct
-{
-    spriteoffsetenum_t sprite;
-    int offset;
-} spriteoffset_t;
-
 /*
 
 Sprite rotation 0 is facing the viewer, rotation 1 is one angle turn CLOCKWISE around the axis.
@@ -91,23 +68,6 @@ int numsprites;
 spriteframe_t sprtemp[30];
 int maxframe;
 static const char *spritename;
-
-
-// [crispy] Y-Offsets for various sprite frames used for weapon fire translucency
-spriteoffset_t spriteoffsets[NUMSOFFSETS] = {
-    {SPR_GWND_F1, 0 * FRACUNIT},
-    {SPR_GWND_F2, 8 * FRACUNIT},
-    {SPR_GWND_F3, 4 * FRACUNIT},
-    {SPR_BLSR_F1, 0 * FRACUNIT},
-    {SPR_BLSR_F2, 1 * FRACUNIT},
-    {SPR_BLSR_F3, 4 * FRACUNIT},
-    {SPR_HROD_F1, 5 * FRACUNIT},
-    {SPR_HROD_F2_5, 0 * FRACUNIT},
-    {SPR_HROD_F6, 4 * FRACUNIT},
-    {SPR_PHNX_F1, 0 * FRACUNIT},
-    {SPR_PHNX_F2, 12 * FRACUNIT},
-    {SPR_PHNX_F3, 6 * FRACUNIT}
-};
 
 /*
 =================
@@ -780,7 +740,7 @@ int PSpriteSY[NUMCLASSES][NUMWEAPONS] = {
 
 boolean pspr_interp = true; // [crispy] interpolate weapon bobbing
 
-void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y-offset and translucency for weapon flash translucency
+void R_DrawPSprite(pspdef_t * psp, int translucent) // [crispy] translucency for weapon flash translucency
 {
     fixed_t tx;
     int x1, x2;
@@ -844,7 +804,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
     vis->psprite = true;
     vis->floorclip = 0;
     vis->texturemid = (BASEYCENTER << FRACBITS) /* + FRACUNIT / 2 */
-        - (psp->sy2 - spritetopoffset[lump] + psyoffset);
+        - (psp->sy2 - spritetopoffset[lump]);
     if (viewheight == SCREENHEIGHT)
     {
         vis->texturemid -= PSpriteSY[viewplayer->class]
@@ -969,7 +929,7 @@ void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y
 void R_DrawPlayerSprites(void)
 {
     int i, lightnum;
-    int tmpframe, offset, drawbase = 0; // [crispy] for drawing base frames
+    int tmpframe, drawbase = 0; // [crispy] for drawing base frames
     pspdef_t *psp;
 
 //
@@ -1000,54 +960,39 @@ void R_DrawPlayerSprites(void)
             // [crispy] draw base frame for transparent or deactivated weapon flashes
             if (crispy->translucency & TRANSLUCENCY_ITEM)
             {
-                drawbase = 1;
                 tmpframe = psp->state->frame;
 
                 switch (psp->state->sprite)
                 {         
                     case SPR_MWND:
-                        if (tmpframe == 32769)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else
-                            drawbase = 0;
+                        if (tmpframe == (1 | FF_FULLBRIGHT))
+                            drawbase = 1;
                         break;
                     case SPR_MSTF:
-                        if (tmpframe == 6)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else 
-                        if (tmpframe == 32775)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else
-                        if (tmpframe == 8)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else
-                            drawbase = 0;
+                        if ((tmpframe >= 6 && tmpframe <= 9) ||
+                                tmpframe == (7 | FF_FULLBRIGHT))
+                            drawbase = 1;
                         break;
                     case SPR_CSSF:
                         if (tmpframe == 9)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else
-                            drawbase = 0;
+                            drawbase = 1;
                         break;
                     case SPR_CHLY:
-                        if (tmpframe >= 32768 && tmpframe <= 32773)
-                            offset = spriteoffsets[SPR_GWND_F1].offset;
-                        else
-                            drawbase = 0;
+                        if (tmpframe >= (0 | FF_FULLBRIGHT) && tmpframe <= (5 | FF_FULLBRIGHT))
+                            drawbase = 1;
                         break;
                     default:
-                        offset = 0x0;
                         drawbase = 0;
                         break;
                 }
                 if (drawbase)
                 {
                     psp->state->frame = 0; // set base frame
-                    R_DrawPSprite(psp, offset, 0);
+                    R_DrawPSprite(psp, 0);
                     psp->state->frame = tmpframe; // restore attack frame
                 }
             }
-            R_DrawPSprite(psp, 0x0, drawbase); // [crispy] translucent when base was drawn
+            R_DrawPSprite(psp, drawbase); // [crispy] translucent when base was drawn
         }      
     }
 }

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -997,78 +997,56 @@ void R_DrawPlayerSprites(void)
     {
         if (psp->state)
         {
-            // // [crispy] draw base frame for transparent or deactivated weapon flashes
-            // if (!a11y_weapon_pspr ||
-            //         (crispy->translucency & TRANSLUCENCY_ITEM &&
-            //         !(viewplayer->powers[pw_invisibility] > 4*32 || viewplayer->powers[pw_invisibility] & 8)))
-            // {
-            //     drawbase = 1;
-            //     tmpframe = psp->state->frame;
+            // [crispy] draw base frame for transparent or deactivated weapon flashes
+            if (crispy->translucency & TRANSLUCENCY_ITEM)
+            {
+                drawbase = 1;
+                tmpframe = psp->state->frame;
 
-            //     switch (psp->state->sprite)
-            //     {         
-            //         case SPR_GWND:
-            //             if (tmpframe == 1)
-            //                 offset = spriteoffsets[SPR_GWND_F1].offset;
-            //             else 
-            //             if (tmpframe == 2)
-            //                 offset = spriteoffsets[SPR_GWND_F2].offset;
-            //             else 
-            //             if (tmpframe == 3)
-            //                 offset = spriteoffsets[SPR_GWND_F3].offset;
-            //             else
-            //                 drawbase = 0;
-            //             break;
-            //         case SPR_BLSR:
-            //             if (tmpframe == 1)
-            //                 offset = spriteoffsets[SPR_BLSR_F1].offset;
-            //             else 
-            //             if (tmpframe == 2)
-            //                 offset = spriteoffsets[SPR_BLSR_F2].offset;
-            //             else 
-            //             if (tmpframe == 3)
-            //                 offset = spriteoffsets[SPR_BLSR_F3].offset;
-            //             else
-            //                 drawbase = 0;
-            //             break;
-            //         case SPR_HROD:
-            //             if (tmpframe == 1)
-            //                 offset = spriteoffsets[SPR_HROD_F1].offset;
-            //             else 
-            //             if (tmpframe > 1 && tmpframe < 6)
-            //                 offset = spriteoffsets[SPR_HROD_F2_5].offset;
-            //             else 
-            //             if (tmpframe == 6)
-            //                 offset = spriteoffsets[SPR_HROD_F6].offset;
-            //             else
-            //                 drawbase = 0;
-            //             break;
-            //         case SPR_PHNX:
-            //             if (tmpframe == 1)
-            //                 offset = spriteoffsets[SPR_PHNX_F1].offset;
-            //             else 
-            //             if (tmpframe == 2 || tmpframe > 3)
-            //                 offset = spriteoffsets[SPR_PHNX_F2].offset;
-            //             else 
-            //             if (tmpframe == 3)
-            //                 offset = spriteoffsets[SPR_PHNX_F3].offset;
-            //             else
-            //                 drawbase = 0;
-            //             break;
-            //         default:
-            //             offset = 0x0;
-            //             drawbase = 0;
-            //             break;
-            //     }
-            //     if (drawbase && psp->state->sprite != SPR_GAUN)
-            //     {
-            //         psp->state->frame = 0; // set base frame
-            //         R_DrawPSprite(psp, offset, 0);
-            //         psp->state->frame = tmpframe; // restore attack frame
-            //     }
-            // }
-            // if (!a11y_weapon_pspr && drawbase) 
-            //     continue; // [crispy] A11Y no weapon flash, use base instead
+                switch (psp->state->sprite)
+                {         
+                    case SPR_MWND:
+                        if (tmpframe == 32769)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else
+                            drawbase = 0;
+                        break;
+                    case SPR_MSTF:
+                        if (tmpframe == 6)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else 
+                        if (tmpframe == 32775)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else
+                        if (tmpframe == 8)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else
+                            drawbase = 0;
+                        break;
+                    case SPR_CSSF:
+                        if (tmpframe == 9)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else
+                            drawbase = 0;
+                        break;
+                    case SPR_CHLY:
+                        if (tmpframe >= 32768 && tmpframe <= 32773)
+                            offset = spriteoffsets[SPR_GWND_F1].offset;
+                        else
+                            drawbase = 0;
+                        break;
+                    default:
+                        offset = 0x0;
+                        drawbase = 0;
+                        break;
+                }
+                if (drawbase)
+                {
+                    psp->state->frame = 0; // set base frame
+                    R_DrawPSprite(psp, offset, 0);
+                    psp->state->frame = tmpframe; // restore attack frame
+                }
+            }
             R_DrawPSprite(psp, 0x0, drawbase); // [crispy] translucent when base was drawn
         }      
     }

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -35,6 +35,29 @@ typedef struct
     int bottomclip;
 } maskdraw_t;
 
+typedef enum
+{
+    SPR_GWND_F1,
+    SPR_GWND_F2,
+    SPR_GWND_F3,
+    SPR_BLSR_F1,
+    SPR_BLSR_F2,
+    SPR_BLSR_F3,
+    SPR_HROD_F1,
+    SPR_HROD_F2_5,
+    SPR_HROD_F6,
+    SPR_PHNX_F1,
+    SPR_PHNX_F2,
+    SPR_PHNX_F3, 
+    NUMSOFFSETS
+} spriteoffsetenum_t;
+
+typedef struct
+{
+    spriteoffsetenum_t sprite;
+    int offset;
+} spriteoffset_t;
+
 /*
 
 Sprite rotation 0 is facing the viewer, rotation 1 is one angle turn CLOCKWISE around the axis.
@@ -70,6 +93,21 @@ int maxframe;
 static const char *spritename;
 
 
+// [crispy] Y-Offsets for various sprite frames used for weapon fire translucency
+spriteoffset_t spriteoffsets[NUMSOFFSETS] = {
+    {SPR_GWND_F1, 0 * FRACUNIT},
+    {SPR_GWND_F2, 8 * FRACUNIT},
+    {SPR_GWND_F3, 4 * FRACUNIT},
+    {SPR_BLSR_F1, 0 * FRACUNIT},
+    {SPR_BLSR_F2, 1 * FRACUNIT},
+    {SPR_BLSR_F3, 4 * FRACUNIT},
+    {SPR_HROD_F1, 5 * FRACUNIT},
+    {SPR_HROD_F2_5, 0 * FRACUNIT},
+    {SPR_HROD_F6, 4 * FRACUNIT},
+    {SPR_PHNX_F1, 0 * FRACUNIT},
+    {SPR_PHNX_F2, 12 * FRACUNIT},
+    {SPR_PHNX_F3, 6 * FRACUNIT}
+};
 
 /*
 =================
@@ -428,6 +466,13 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
             + vis->class * ((maxplayers - 1) * 256) +
             ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT - 8));
     }
+    // [crispy] translucent sprites
+    else if (crispy->translucency && vis->mobjflags & MF_TRANSLUCENT)
+    {
+    	if ((crispy->translucency & TRANSLUCENCY_MISSILE) ||
+            (vis->psprite && crispy->translucency & TRANSLUCENCY_ITEM))
+	        colfunc = tlcolfunc;
+    }
 
     dc_iscale = abs(vis->xiscale) >> detailshift;
     dc_texturemid = vis->texturemid;
@@ -735,7 +780,7 @@ int PSpriteSY[NUMCLASSES][NUMWEAPONS] = {
 
 boolean pspr_interp = true; // [crispy] interpolate weapon bobbing
 
-void R_DrawPSprite(pspdef_t * psp)
+void R_DrawPSprite(pspdef_t * psp, int psyoffset, int translucent) // [crispy] y-offset and translucency for weapon flash translucency
 {
     fixed_t tx;
     int x1, x2;
@@ -799,7 +844,7 @@ void R_DrawPSprite(pspdef_t * psp)
     vis->psprite = true;
     vis->floorclip = 0;
     vis->texturemid = (BASEYCENTER << FRACBITS) /* + FRACUNIT / 2 */
-        - (psp->sy2 - spritetopoffset[lump]);
+        - (psp->sy2 - spritetopoffset[lump] + psyoffset);
     if (viewheight == SCREENHEIGHT)
     {
         vis->texturemid -= PSpriteSY[viewplayer->class]
@@ -869,6 +914,12 @@ void R_DrawPSprite(pspdef_t * psp)
     }
     vis->brightmap = R_BrightmapForState(psp->state - states);
 
+    // [crispy] translucent weapon flash sprites
+    if (translucent)
+    {
+        vis->mobjflags |= MF_TRANSLUCENT;
+    }
+
     // [crispy] interpolate weapon bobbing
     if (crispy->uncapped)
     {
@@ -918,6 +969,7 @@ void R_DrawPSprite(pspdef_t * psp)
 void R_DrawPlayerSprites(void)
 {
     int i, lightnum;
+    int tmpframe, offset, drawbase = 0; // [crispy] for drawing base frames
     pspdef_t *psp;
 
 //
@@ -942,9 +994,84 @@ void R_DrawPlayerSprites(void)
 // add all active psprites
 //
     for (i = 0, psp = viewplayer->psprites; i < NUMPSPRITES; i++, psp++)
+    {
         if (psp->state)
-            R_DrawPSprite(psp);
+        {
+            // // [crispy] draw base frame for transparent or deactivated weapon flashes
+            // if (!a11y_weapon_pspr ||
+            //         (crispy->translucency & TRANSLUCENCY_ITEM &&
+            //         !(viewplayer->powers[pw_invisibility] > 4*32 || viewplayer->powers[pw_invisibility] & 8)))
+            // {
+            //     drawbase = 1;
+            //     tmpframe = psp->state->frame;
 
+            //     switch (psp->state->sprite)
+            //     {         
+            //         case SPR_GWND:
+            //             if (tmpframe == 1)
+            //                 offset = spriteoffsets[SPR_GWND_F1].offset;
+            //             else 
+            //             if (tmpframe == 2)
+            //                 offset = spriteoffsets[SPR_GWND_F2].offset;
+            //             else 
+            //             if (tmpframe == 3)
+            //                 offset = spriteoffsets[SPR_GWND_F3].offset;
+            //             else
+            //                 drawbase = 0;
+            //             break;
+            //         case SPR_BLSR:
+            //             if (tmpframe == 1)
+            //                 offset = spriteoffsets[SPR_BLSR_F1].offset;
+            //             else 
+            //             if (tmpframe == 2)
+            //                 offset = spriteoffsets[SPR_BLSR_F2].offset;
+            //             else 
+            //             if (tmpframe == 3)
+            //                 offset = spriteoffsets[SPR_BLSR_F3].offset;
+            //             else
+            //                 drawbase = 0;
+            //             break;
+            //         case SPR_HROD:
+            //             if (tmpframe == 1)
+            //                 offset = spriteoffsets[SPR_HROD_F1].offset;
+            //             else 
+            //             if (tmpframe > 1 && tmpframe < 6)
+            //                 offset = spriteoffsets[SPR_HROD_F2_5].offset;
+            //             else 
+            //             if (tmpframe == 6)
+            //                 offset = spriteoffsets[SPR_HROD_F6].offset;
+            //             else
+            //                 drawbase = 0;
+            //             break;
+            //         case SPR_PHNX:
+            //             if (tmpframe == 1)
+            //                 offset = spriteoffsets[SPR_PHNX_F1].offset;
+            //             else 
+            //             if (tmpframe == 2 || tmpframe > 3)
+            //                 offset = spriteoffsets[SPR_PHNX_F2].offset;
+            //             else 
+            //             if (tmpframe == 3)
+            //                 offset = spriteoffsets[SPR_PHNX_F3].offset;
+            //             else
+            //                 drawbase = 0;
+            //             break;
+            //         default:
+            //             offset = 0x0;
+            //             drawbase = 0;
+            //             break;
+            //     }
+            //     if (drawbase && psp->state->sprite != SPR_GAUN)
+            //     {
+            //         psp->state->frame = 0; // set base frame
+            //         R_DrawPSprite(psp, offset, 0);
+            //         psp->state->frame = tmpframe; // restore attack frame
+            //     }
+            // }
+            // if (!a11y_weapon_pspr && drawbase) 
+            //     continue; // [crispy] A11Y no weapon flash, use base instead
+            R_DrawPSprite(psp, 0x0, drawbase); // [crispy] translucent when base was drawn
+        }      
+    }
 }
 
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2591,7 +2591,7 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(crispy_statsformat),
 
     //!
-    // @game doom heretic
+    // @game doom heretic hexen
     //
     // Enable translucency.
     //

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -131,6 +131,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_playercoords",    &crispy->playercoords);
         M_BindIntVariable("crispy_smoothscaling",   &crispy->smoothscaling);
         M_BindIntVariable("crispy_soundmono",       &crispy->soundmono);
+        M_BindIntVariable("crispy_translucency",    &crispy->translucency);
         M_BindIntVariable("crispy_uncapped",        &crispy->uncapped);
         M_BindIntVariable("crispy_vsync",           &crispy->vsync);
         M_BindIntVariable("crispy_widescreen",      &crispy->widescreen);


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1276

**Changes Summary**

- Adding Translucency Option to Hexen based upon Doom/Heretic solution
- Translucency supported for:

Option 1 (Projectiles):
- Own Weapon Projectiles
- Enemy Projectiles and Enemy Special Effects
- Various Environmental Things (Fireballs, Teleporter Stuff...)

Option 2 (vanilla Weapon flash)
- Weapon firing flashes to be transparent when using vanilla weapon sprites, by drawing transparent firing-frames over weapon idle-frames. This affects the following weapons: Mage Wand and Ultimate Weapon, Cleric Wand and Ultimate weapon. 

.. or both Options together.

