### PR TITLE
Heretic/Hexen: Artifact selectbox always opaque

### DIFF
--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1138,9 +1138,11 @@ void DrawFullScreenStuff(void)
             x = inv_ptr - curpos;
             for (i = 0; i < 7; i++)
             {
+                // [crispy] check for translucent HUD
+                SB_Translucent(TRANSLUCENT_HUD);
                 V_DrawSBPatch(50 + i * 31, 168,
                               W_CacheLumpName(DEH_String("ARTIBOX"), PU_CACHE));
-                SB_Translucent(false); // listed artifacts are always opaque
+                SB_Translucent(false); // listed artifacts and selectbox are always opaque
                 if (CPlayer->inventorySlotNum > x + i
                     && CPlayer->inventory[x + i].type != arti_none)
                 {
@@ -1150,10 +1152,7 @@ void DrawFullScreenStuff(void)
                     DrSmallNumber(CPlayer->inventory[x + i].count, 69 + i * 31,
                                   190);
                 }
-                // [crispy] check for translucent HUD
-                SB_Translucent(TRANSLUCENT_HUD);
             }
-            SB_Translucent(false); // selectbox is always opaque
             V_DrawSBPatch(50 + curpos * 31, 197, PatchSELECTBOX);
             // [crispy] check for translucent HUD
             SB_Translucent(TRANSLUCENT_HUD);

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1153,7 +1153,10 @@ void DrawFullScreenStuff(void)
                 // [crispy] check for translucent HUD
                 SB_Translucent(TRANSLUCENT_HUD);
             }
+            SB_Translucent(false); // selectbox is always opaque
             V_DrawSBPatch(50 + curpos * 31, 197, PatchSELECTBOX);
+            // [crispy] check for translucent HUD
+            SB_Translucent(TRANSLUCENT_HUD);
             if (x != 0)
             {
                 V_DrawSBPatch(38, 167, !(leveltime & 4) ? PatchINVLFGEM1 :

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1597,7 +1597,10 @@ void DrawFullScreenStuff(void)
                 // [crispy] check for translucent HUD
                 SB_Translucent(TRANSLUCENT_HUD);
             }
+            SB_Translucent(false); // selectbox is always opaque
             V_DrawSBPatch(48 + curpos * 31, 167, PatchSELECTBOX);
+            // [crispy] check for translucent HUD
+            SB_Translucent(TRANSLUCENT_HUD);
             if (x != 0)
             {
                 V_DrawSBPatch(xPosGem1, 167, !(leveltime & 4) ? PatchINVLFGEM1 :

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1578,9 +1578,11 @@ void DrawFullScreenStuff(void)
             x = inv_ptr - curpos;
             for (i = 0; i < 7; i++)
             {
+                // [crispy] check for translucent HUD
+                SB_Translucent(TRANSLUCENT_HUD);
                 V_DrawSBPatch(50 + i * 31, 168, W_CacheLumpName("ARTIBOX",
                                                                 PU_CACHE));
-                SB_Translucent(false); // listed artifacts are always opaque
+                SB_Translucent(false); // listed artifacts and selectbox are always opaque
                 if (CPlayer->inventorySlotNum > x + i
                     && CPlayer->inventory[x + i].type != arti_none)
                 {
@@ -1594,10 +1596,7 @@ void DrawFullScreenStuff(void)
                                       66 + i * 31, 189);
                     }
                 }
-                // [crispy] check for translucent HUD
-                SB_Translucent(TRANSLUCENT_HUD);
             }
-            SB_Translucent(false); // selectbox is always opaque
             V_DrawSBPatch(48 + curpos * 31, 167, PatchSELECTBOX);
             // [crispy] check for translucent HUD
             SB_Translucent(TRANSLUCENT_HUD);


### PR DESCRIPTION
Related Issue:
None

**Changes Summary**
The artifact selectbox should be always opaque when a transparent HUD is active. This allows for a better item selection in hasty moments, especially in Hexen. 