### PR TITLE
Hexen/Heretic: Minor translucency changes

### DIFF
--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -505,6 +505,7 @@ boolean P_GiveArtifact(player_t * player, artitype_t arti, mobj_t * mo)
 void P_SetDormantArtifact(mobj_t * arti)
 {
     arti->flags &= ~MF_SPECIAL;
+    arti->flags |= MF_TRANSLUCENT; // [crispy] artifact pickup translucent
     if (deathmatch && (arti->type != MT_ARTIINVULNERABILITY)
         && (arti->type != MT_ARTIINVISIBILITY))
     {
@@ -525,6 +526,7 @@ void P_SetDormantArtifact(mobj_t * arti)
 
 void A_RestoreArtifact(mobj_t * arti, player_t *player, pspdef_t *psp)
 {
+    arti->flags &= ~MF_TRANSLUCENT; // [crispy] artifact respawn opaque
     arti->flags |= MF_SPECIAL;
     P_SetMobjState(arti, arti->info->spawnstate);
     S_StartSound(arti, sfx_respawn);
@@ -538,6 +540,7 @@ void A_RestoreArtifact(mobj_t * arti, player_t *player, pspdef_t *psp)
 
 void P_HideSpecialThing(mobj_t * thing)
 {
+    thing->flags |= MF_TRANSLUCENT; // [crispy] special translucent
     thing->flags &= ~MF_SPECIAL;
     thing->flags2 |= MF2_DONTDRAW;
     P_SetMobjState(thing, S_HIDESPECIAL1);
@@ -569,6 +572,7 @@ void A_RestoreSpecialThing1(mobj_t * thing, player_t *player, pspdef_t *psp)
 
 void A_RestoreSpecialThing2(mobj_t * thing, player_t *player, pspdef_t *psp)
 {
+    thing->flags &= ~MF_TRANSLUCENT; // [crispy] thing respawn opaque
     thing->flags |= MF_SPECIAL;
     P_SetMobjState(thing, thing->info->spawnstate);
 }

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -861,6 +861,7 @@ boolean P_GiveArtifact(player_t * player, artitype_t arti, mobj_t * mo)
 static void SetDormantArtifact(mobj_t * arti)
 {
     arti->flags &= ~MF_SPECIAL;
+    arti->flags |= MF_TRANSLUCENT; // [crispy] artifact pickup translucent
     if (deathmatch && !(arti->flags2 & MF2_DROPPED))
     {
         if (arti->type == MT_ARTIINVULNERABILITY)
@@ -890,6 +891,7 @@ static void SetDormantArtifact(mobj_t * arti)
 
 void A_RestoreArtifact(mobj_t *arti, player_t *player, pspdef_t *psp)
 {
+    arti->flags &= ~MF_TRANSLUCENT; // [crispy] artifact respawn opaque
     arti->flags |= MF_SPECIAL;
     P_SetMobjState(arti, arti->info->spawnstate);
     S_StartSound(arti, SFX_RESPAWN);

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -132,6 +132,7 @@ void P_ClearMessage(player_t * player)
 
 void P_HideSpecialThing(mobj_t * thing)
 {
+    thing->flags |= MF_TRANSLUCENT; // [crispy] special translucent
     thing->flags &= ~MF_SPECIAL;
     thing->flags2 |= MF2_DONTDRAW;
     P_SetMobjState(thing, S_HIDESPECIAL1);
@@ -919,6 +920,7 @@ void A_RestoreSpecialThing1(mobj_t * thing, player_t *player, pspdef_t *psp)
 
 void A_RestoreSpecialThing2(mobj_t * thing, player_t *player, pspdef_t *psp)
 {
+    thing->flags &= ~MF_TRANSLUCENT; // [crispy] thing respawn opaque
     thing->flags |= MF_SPECIAL;
     P_SetMobjState(thing, thing->info->spawnstate);
 }

--- a/src/hexen/p_mobj.c
+++ b/src/hexen/p_mobj.c
@@ -146,6 +146,9 @@ void P_ExplodeMissile(mobj_t * mo)
     //mo->tics -= P_Random()&3;
     mo->flags &= ~MF_MISSILE;
 
+    if (mo->type == MT_RIPPERBALL)
+        mo->flags |= MF_TRANSLUCENT;
+
     switch (mo->type)
     {
         case MT_SORCBALL1:


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**

After playing through hexen, some minor translucency changes I would like to bring in:

- Hexen: Making ripperball explosion translucent
- Hexen/Heretic: Making artifact pickup effect translucent
- Hexen/Heretic: (Deathmatch) Making artifact & thing respawn effects translucent