### PR TITLE
Heretic: Further optimizing weapon sound leveling

### DIFF
--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -313,22 +313,14 @@ static void S_LevelWeaponSound(mobj_t *origin, int sound_id, int *vol)
             case sfx_gntuse:
             case sfx_gntact:
                 // [crispy] lower gauntlet sfx
-                *vol -= snd_MaxVolume * 4;
+                *vol -= (snd_MaxVolume >> 1) * 7;
                 break;
             case sfx_blshit:
-                // [crispy] lower dragonclaw impact sfx
-                *vol -= snd_MaxVolume * 2;
             case sfx_blssht:
-                // [crispy] lower dragonclaw shot main sfx
-                if (viewplayer->powers[pw_weaponlevel2])
-                    *vol -= snd_MaxVolume * 3;
-                else
-                    *vol -= snd_MaxVolume * 4;
-                break;
             case sfx_gldhit:
-                // [crispy] lower dragonclaw shot secondary sfx
+                // [crispy] lower dragonclaw sfx
                 if (viewplayer->readyweapon == wp_blaster)
-                    *vol -= snd_MaxVolume * 2;
+                    *vol -= (snd_MaxVolume >> 1) * 7;
                 break;
         }        
     }

--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -313,14 +313,14 @@ static void S_LevelWeaponSound(mobj_t *origin, int sound_id, int *vol)
             case sfx_gntuse:
             case sfx_gntact:
                 // [crispy] lower gauntlet sfx
-                *vol -= (snd_MaxVolume >> 1) * 7;
+                *vol -= snd_MaxVolume * 3 + (snd_MaxVolume/2+1);
                 break;
             case sfx_blshit:
             case sfx_blssht:
             case sfx_gldhit:
                 // [crispy] lower dragonclaw sfx
                 if (viewplayer->readyweapon == wp_blaster)
-                    *vol -= (snd_MaxVolume >> 1) * 7;
+                    *vol -= snd_MaxVolume * 3 + (snd_MaxVolume/2+1);
                 break;
         }        
     }


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**
After revisiting the option, I found that the reduction was slightly over-done and that the different reduction values per effect sounded weird when fighting certain enemies. That is why I would like to increase the sound volume slightly by half a unit and simplifiy it. I should have given it more time initially 😉. 