### PR TITLE
Heretic/Hexen: Fix translucent numbers in Automap-Statusbar

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -1991,11 +1991,14 @@ void AM_Drawer(void)
         numepisodes = 3;
     }
 
+    // [crispy] check for translucent HUD
+    SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
     if (gameepisode <= numepisodes && gamemap < 10)
     {
         level_name = LevelNames[(gameepisode - 1) * 9 + gamemap - 1];
         MN_DrTextA(DEH_String(level_name), 20, 145);
     }
+    SB_Translucent(false);
 //  I_Update();
 //  V_MarkRect(f_x, f_y, f_w, f_h);
 }

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -272,8 +272,6 @@ void D_Display(void)
         case GS_LEVEL:
             if (!gametic)
                 break;
-            // [crispy] check for translucent HUD
-            SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
             if (automapactive && !crispy->automapoverlay)
             {
                 // [crispy] update automap while playing
@@ -287,6 +285,8 @@ void D_Display(void)
                 AM_Drawer();
                 BorderNeedRefresh = true;
             }
+            // [crispy] check for translucent HUD
+            SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
             CT_Drawer();
             UpdateState |= I_FULLVIEW;
             SB_Drawer();

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -1845,6 +1845,8 @@ void AM_Drawer(void)
         AM_drawGrid(GRIDCOLORS);
     AM_drawWalls();
     AM_drawPlayers();
+    // [crispy] check for translucent HUD
+    SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
     DrawWorldTimer();
 
     if (cheating == 2)
@@ -1853,8 +1855,8 @@ void AM_Drawer(void)
 //  AM_drawCrosshair(XHAIRCOLORS);
 //  AM_drawMarks();
 //      if(gameskill == sk_baby) AM_drawkeys();
-
     MN_DrTextA(P_GetMapName(gamemap), 38, 144);
+    SB_Translucent(false);
     if (ShowKills && netgame && deathmatch)
     {
         AM_DrawDeathmatchStats();

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -1117,8 +1117,6 @@ static void DrawAndBlit(void)
             {
                 break;
             }
-            // [crispy] check for translucent HUD
-            SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
             if (automapactive && !crispy->automapoverlay)
             {
                 // [crispy] update automap while playing
@@ -1134,6 +1132,8 @@ static void DrawAndBlit(void)
                 AM_Drawer();
                 BorderNeedRefresh = true;
             }
+            // [crispy] check for translucent HUD
+            SB_Translucent(TRANSLUCENT_HUD && (!automapactive || crispy->automapoverlay));
             CT_Drawer();
             UpdateState |= I_FULLVIEW;
             SB_Drawer();


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**
I noticed a bug that can cause the numbers to be displayed translucent in the automap statusbar sporadically (timing-dependend), when a translucent hud is active:
![2025-03-25 20_36_38-Heretic_ Shadow of the Serpent Riders - Crispy Doom 7 0 0](https://github.com/user-attachments/assets/1088bd79-a8e9-428c-9012-77380858f268)

Moving the check for the translucency directly into AM_Drawer resolved the issue, however I couldn't pin point the root-cause directly. I presume the R_RenderPlayerView Updates were causing it. 