### PR TITLE
Hexen: Translucent Wyvern explosion

### DIFF
--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -11823,7 +11823,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP,             // flags
+     MF_NOBLOCKMAP | MF_TRANSLUCENT,             // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_DONTDRAW     // flags2
      },
 


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**
While playing Hexen DKDC, I noticed that the Wyvern fire on the ground was not yet translucent with the option enabled. I would like to hereby change that.

Sorry for bringing up yet another translucency finding. One day, I hopefully caught them all. 😉 