### PR TITLE
Hexen: heresiarch opaque mana cubes & shield

### DIFF
--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -12984,7 +12984,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13011,7 +13011,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13038,7 +13038,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_TRANSLUCENT, // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13092,7 +13092,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_TRANSLUCENT,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      MF2_NOTELEPORT             // flags2
      },
 

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -1694,6 +1694,7 @@ void A_Explode(mobj_t *actor, player_t *player, pspdef_t *psp)
         case MT_SORCBALL3:
             distance = 255;
             damage = 255;
+            actor->flags |= MF_TRANSLUCENT; // [crispy]
             actor->args[0] = 1; // don't play bounce
             break;
         case MT_SORCFX1:       // Sorcerer spell 1


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**
For some reason, I just recently noticed that the Heresiarch mana cubes do detach upon his death, bounce and explode. Them being translucent makes it hard to see where they land and can cause confusing player deaths. With this change they remain opaque now and I did the same for the shield-bits flying around, to be consitent.

- Sorcball1-3 always opaque until explosion
- SORCFX2 (shield) always opaque for consitency reasons

![grafik](https://github.com/user-attachments/assets/50d76478-2e96-4e6d-a0c1-53044cdacb56)
