### PR TITLE
doom: Include top offset in finale text check

### DIFF
--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -327,8 +327,9 @@ void F_TextWrite (void)
 	    else
 	    break;
 	}
-	// [cispy] prevent text from being drawn off-screen vertically
-	if (cy + SHORT(hu_font[c]->height) > ORIGHEIGHT)
+	// [crispy] prevent text from being drawn off-screen vertically
+	if (cy + SHORT(hu_font[c]->height) - SHORT(hu_font[c]->topoffset) >
+	    ORIGHEIGHT)
 	{
 	    break;
 	}


### PR DESCRIPTION
Short explanation: fixes [this issue](https://www.doomworld.com/forum/post/2919478).

Long explanation: rust2.wad replaces some of the hu_font characters with "almost fullscreen" patches. These patches have carefully chosen top and left offsets to allow them to display correctly based on what the current text position is. (Pretty clever!) To allow this trick to function properly, account for the top offset when checking if a patch is going to be drawn off-screen vertically.

If you want to see this for yourself run: `crispy-doom -iwad doom.wad -gameversion 1.666 -file rust2.wad -warp 2 8`
and then use the `tntem` cheat to quickly end the level and advance up the finale. Be sure to wait until the end.