### PR TITLE
Strife: Adding A11Y Flickering

### DIFF
--- a/src/setup/accessibility.c
+++ b/src/setup/accessibility.c
@@ -64,12 +64,15 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                                         &a11y_weapon_flash));
     }
   
-    TXT_AddWidgets(window,
-                    TXT_NewCheckBox("Weapon Flash Sprite",
-                                    &a11y_weapon_pspr),
-                    TXT_NewCheckBox("Palette Changes",
-                                    &a11y_palette_changes),                                      
-                    NULL);
+    if (gamemission != strife)
+    {
+        TXT_AddWidgets(window,
+                        TXT_NewCheckBox("Weapon Flash Sprite",
+                                        &a11y_weapon_pspr),
+                        TXT_NewCheckBox("Palette Changes",
+                                        &a11y_palette_changes),                                      
+                        NULL);
+    }
 
     if (gamemission == doom || gamemission == heretic)
     {
@@ -85,12 +88,15 @@ void AccessibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
                                         &a11y_weapon_palette));
     }
 
-    TXT_SetTableColumns(window, 2);
+    if (gamemission != strife)
+    {
+        TXT_SetTableColumns(window, 2);
 
-    TXT_AddWidgets(window,
-                    TXT_NewLabel("Extra Lighting"),
-                    TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
-                    NULL);
+        TXT_AddWidgets(window,
+                        TXT_NewLabel("Extra Lighting"),
+                        TXT_NewSpinControl(&a11y_extra_lighting, 0, 8),
+                        NULL);
+    }
 
 }
 

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -235,13 +235,10 @@ void MainMenu(void)
         TXT_NewButton2("Compatibility",
                        (TxtWidgetSignalFunc) CompatibilitySettings, NULL),
 */
-    // [crispy]
-    if (gamemission == doom || gamemission == heretic || gamemission == hexen)
-    {
-        TXT_AddWidget(window,
-            TXT_NewButton2("Accessibility",
-                           (TxtWidgetSignalFunc) AccessibilitySettings, NULL));
-    }
+    // [crispy] A11Y Feature
+    TXT_AddWidget(window,
+        TXT_NewButton2("Accessibility",
+                        (TxtWidgetSignalFunc) AccessibilitySettings, NULL));
 
     TXT_AddWidgets(window,
         GetLaunchButton(),

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -48,6 +48,7 @@
 #include "f_finale.h"
 #include "f_wipe.h"
 
+#include "a11y.h" // [crispy] A11Y
 #include "m_argv.h"
 #include "m_config.h"
 #include "m_controls.h"
@@ -505,6 +506,7 @@ void D_BindVariables(void)
     M_BindIntVariable("show_talk",              &dialogshowtext);
     M_BindIntVariable("screensize",             &screenblocks);
     M_BindIntVariable("snd_channels",           &snd_channels);
+    M_BindIntVariable("a11y_sector_lighting",   &a11y_sector_lighting); // [crispy]
     M_BindIntVariable("vanilla_savegame_limit", &vanilla_savegame_limit);
     M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
     M_BindIntVariable("show_endoom",            &show_endoom);

--- a/src/strife/p_enemy.c
+++ b/src/strife/p_enemy.c
@@ -2658,6 +2658,7 @@ void A_CrystalExplode(mobj_t* actor)
 
     sector = actor->subsector->sector;
     sector->lightlevel = 0;
+    sector->rlightlevel = sector->lightlevel; // [crispy] A11Y
     sector->floorheight = P_FindLowestFloorSurrounding(sector);
 
     // spawn rubble

--- a/src/strife/p_lights.c
+++ b/src/strife/p_lights.c
@@ -60,8 +60,6 @@ void T_FireFlicker (fireflicker_t* flick)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         flick->sector->rlightlevel = flick->sector->lightlevel;
-    else
-        flick->sector->rlightlevel = flick->maxlight;
 }
 
 
@@ -123,8 +121,6 @@ void T_LightFlash (lightflash_t* flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-        flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -189,8 +185,6 @@ void T_StrobeFlash (strobe_t*           flash)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         flash->sector->rlightlevel = flash->sector->lightlevel;
-    else
-        flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -375,8 +369,6 @@ void T_Glow(glow_t*     g)
     // [crispy] A11Y
     if (a11y_sector_lighting)
         g->sector->rlightlevel = g->sector->lightlevel;
-    else
-        g->sector->rlightlevel = g->maxlight;
 }
 
 //

--- a/src/strife/p_lights.c
+++ b/src/strife/p_lights.c
@@ -24,6 +24,7 @@
 
 #include "doomdef.h"
 #include "p_local.h"
+#include "a11y.h" // [crispy] A11Y
 
 
 // State.
@@ -55,6 +56,12 @@ void T_FireFlicker (fireflicker_t* flick)
 
     // [STRIFE] flicker count made random!
     flick->count = (P_Random() & 3) + 1;
+
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+        flick->sector->rlightlevel = flick->sector->lightlevel;
+    else
+        flick->sector->rlightlevel = flick->maxlight;
 }
 
 
@@ -112,6 +119,12 @@ void T_LightFlash (lightflash_t* flash)
         flash->sector->lightlevel = flash->maxlight;
         flash->count = (P_Random()&flash->maxtime)+1;
     }
+
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+        flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+        flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -172,6 +185,12 @@ void T_StrobeFlash (strobe_t*           flash)
         flash-> sector->lightlevel = flash->minlight;
         flash->count =flash->darktime;
     }
+
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+        flash->sector->rlightlevel = flash->sector->lightlevel;
+    else
+        flash->sector->rlightlevel = flash->maxlight;
 }
 
 
@@ -269,6 +288,8 @@ void EV_TurnTagLightsOff(line_t* line)
                     min = tsec->lightlevel;
             }
             sector->lightlevel = min;
+            // [crispy] A11Y
+            sector->rlightlevel = sector->lightlevel;
         }
     }
 }
@@ -314,6 +335,8 @@ EV_LightTurnOn
                 }
             }
             sector-> lightlevel = bright;
+            // [crispy] A11Y
+            sector->rlightlevel = sector->lightlevel;
         }
     }
 }
@@ -348,6 +371,12 @@ void T_Glow(glow_t*     g)
         }
         break;
     }
+
+    // [crispy] A11Y
+    if (a11y_sector_lighting)
+        g->sector->rlightlevel = g->sector->lightlevel;
+    else
+        g->sector->rlightlevel = g->maxlight;
 }
 
 //

--- a/src/strife/p_saveg.c
+++ b/src/strife/p_saveg.c
@@ -27,6 +27,7 @@
 #include "m_misc.h"
 #include "p_local.h"
 #include "p_saveg.h"
+#include "a11y.h" // [crispy] A11Y
 
 // State.
 #include "doomstat.h"
@@ -1526,6 +1527,9 @@ static void saveg_read_lightflash_t(lightflash_t *str)
 
     // int mintime;
     str->mintime = saveg_read32();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_lightflash_t(lightflash_t *str)
@@ -1581,6 +1585,10 @@ static void saveg_read_strobe_t(strobe_t *str)
 
     // int brighttime;
     str->brighttime = saveg_read32();
+
+    // [crispy] Ensure maxlight among competing thinkers. 
+    if (!a11y_sector_lighting && str->sector->rlightlevel < str->maxlight)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_strobe_t(strobe_t *str)
@@ -1630,6 +1638,9 @@ static void saveg_read_glow_t(glow_t *str)
 
     // int direction;
     str->direction = saveg_read32();
+
+    if (!a11y_sector_lighting)
+        str->sector->rlightlevel = str->maxlight;
 }
 
 static void saveg_write_glow_t(glow_t *str)
@@ -1883,6 +1894,7 @@ void P_UnArchiveWorld (void)
         sec->floorpic = saveg_read16();
         //sec->ceilingpic = saveg_read16(); [STRIFE] not saved
         sec->lightlevel = saveg_read16();
+        sec->rlightlevel = sec->lightlevel; // [crispy] A11Y
         sec->special = saveg_read16();          // needed?
         //sec->tag = saveg_read16();              // needed? [STRIFE] not saved
         sec->specialdata = 0;

--- a/src/strife/p_setup.c
+++ b/src/strife/p_setup.c
@@ -329,6 +329,8 @@ void P_LoadSectors (int lump)
 	ss->floorpic = R_FlatNumForName(ms->floorpic);
 	ss->ceilingpic = R_FlatNumForName(ms->ceilingpic);
 	ss->lightlevel = SHORT(ms->lightlevel);
+	// [crispy] A11Y light level used for rendering
+	ss->rlightlevel = ss->lightlevel;
 	ss->special = SHORT(ms->special);
 	ss->tag = SHORT(ms->tag);
 	ss->thinglist = NULL;

--- a/src/strife/r_bsp.c
+++ b/src/strife/r_bsp.c
@@ -373,7 +373,7 @@ void R_AddLine (seg_t*	line)
     // and no middle texture.
     if (backsector->ceilingpic == frontsector->ceilingpic
 	&& backsector->floorpic == frontsector->floorpic
-	&& backsector->lightlevel == frontsector->lightlevel
+	&& backsector->rlightlevel == frontsector->rlightlevel
 	&& curline->sidedef->midtexture == 0)
     {
 	return;
@@ -554,7 +554,7 @@ void R_Subsector (int num)
     {
 	floorplane = R_FindPlane (frontsector->interpfloorheight,
 				  frontsector->floorpic,
-				  frontsector->lightlevel);
+				  frontsector->rlightlevel); // [crispy] A11Y
     }
     else
 	floorplane = NULL;
@@ -564,7 +564,7 @@ void R_Subsector (int num)
     {
 	ceilingplane = R_FindPlane (frontsector->interpceilingheight,
 				    frontsector->ceilingpic,
-				    frontsector->lightlevel);
+				    frontsector->rlightlevel); // [crispy] A11Y
     }
     else
 	ceilingplane = NULL;

--- a/src/strife/r_defs.h
+++ b/src/strife/r_defs.h
@@ -159,6 +159,9 @@ typedef	struct
 
     // [crispy] Enable/disable sector interpolation.
     boolean interpolate;
+
+    // [crispy] A11Y light level used for rendering
+    short	rlightlevel;
 } sector_t;
 
 

--- a/src/strife/r_segs.c
+++ b/src/strife/r_segs.c
@@ -206,7 +206,7 @@ R_RenderMaskedSegRange
     backsector = curline->backsector;
     texnum = texturetranslation[curline->sidedef->midtexture];
 	
-    lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (frontsector->rlightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
 
     // [crispy] smoother fake contrast
     lightnum += curline->fakecontrast;
@@ -705,7 +705,7 @@ R_StoreWallRange
 			
 	if (worldlow != worldbottom 
 	    || backsector->floorpic != frontsector->floorpic
-	    || backsector->lightlevel != frontsector->lightlevel)
+	    || backsector->rlightlevel != frontsector->rlightlevel)
 	{
 	    markfloor = true;
 	}
@@ -718,7 +718,7 @@ R_StoreWallRange
 			
 	if (worldhigh != worldtop 
 	    || backsector->ceilingpic != frontsector->ceilingpic
-	    || backsector->lightlevel != frontsector->lightlevel)
+	    || backsector->rlightlevel != frontsector->rlightlevel)
 	{
 	    markceiling = true;
 	}
@@ -799,7 +799,7 @@ R_StoreWallRange
 	// OPTIMIZE: get rid of LIGHTSEGSHIFT globally
 	if (!fixedcolormap)
 	{
-	    lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+	    lightnum = (frontsector->rlightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
 
 	    // [crispy] smoother fake contrast
 	    lightnum += curline->fakecontrast;

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -720,7 +720,7 @@ void R_AddSprites (sector_t* sec)
     // Well, now it will be done.
     sec->validcount = validcount;
 	
-    lightnum = (sec->lightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+    lightnum = (sec->rlightlevel >> LIGHTSEGSHIFT)+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
 
     if (lightnum < 0)		
 	spritelights = scalelight[0];
@@ -909,8 +909,8 @@ void R_DrawPlayerSprites (void)
     
     // get light level
     lightnum =
-	(viewplayer->mo->subsector->sector->lightlevel >> LIGHTSEGSHIFT) 
-	+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting
+	(viewplayer->mo->subsector->sector->rlightlevel >> LIGHTSEGSHIFT) 
+	+(extralight * LIGHTBRIGHT); // [crispy] smooth diminishing lighting, A11Y
 
     if (lightnum < 0)		
 	spritelights = scalelight[0];


### PR DESCRIPTION
Related Issue:
none

**Changes Summary**
Here we go again 😉: I also want to bring translucency and A11Y Features to Strife and starting with this, I added the A11Y Flickering option in the same style as for the remaining games. 

I verified it with a few demos against chocolate-strife on Map 06, 09, 15, 25, 30. 