### PR TITLE
Heretic: Yet another fine tuning of weapon sound leveling

### DIFF
--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -313,14 +313,14 @@ static void S_LevelWeaponSound(mobj_t *origin, int sound_id, int *vol)
             case sfx_gntuse:
             case sfx_gntact:
                 // [crispy] lower gauntlet sfx
-                *vol -= snd_MaxVolume * 3 + (snd_MaxVolume/2+1);
+                *vol -= snd_MaxVolume * 3;
                 break;
             case sfx_blshit:
             case sfx_blssht:
             case sfx_gldhit:
                 // [crispy] lower dragonclaw sfx
                 if (viewplayer->readyweapon == wp_blaster)
-                    *vol -= snd_MaxVolume * 3 + (snd_MaxVolume/2+1);
+                    *vol -= snd_MaxVolume * 3;
                 break;
         }        
     }


### PR DESCRIPTION
Related Issue:
None 

**Changes Summary**
Sorry for bringing this up again, but after revisiting the feature, I still think that the reduction was a tiny bit too much. With this, I would like to remove the fraction and "only" lower it by a multiple of 3. 