### PR TITLE
Add support for non-power-of-2 textures

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -637,20 +637,36 @@ void R_GenerateLookup (int texnum)
 //
 // R_GetColumn
 //
+
+// [crispy] wrapping column getter function for any non-power-of-two textures
 byte*
 R_GetColumn
 ( int		tex,
   int		col )
 {
-    int		ofs;
-	
-    col &= texturewidthmask[tex];
-    ofs = texturecolumnofs2[tex][col];
+  const int width = texturewidth[tex];
+  const int mask = texturewidthmask[tex];
+  int ofs;
 
-    if (!texturecomposite2[tex])
-	R_GenerateComposite (tex);
+  if (mask + 1 == width)
+  {
+    col &= mask;
+  }
+  else
+  {
+    while (col < 0)
+    {
+      col += width;
+    }
+    col %= width;
+  }
 
-    return texturecomposite2[tex] + ofs;
+  ofs  = texturecolumnofs2[tex][col];
+
+  if (!texturecomposite2[tex])
+    R_GenerateComposite(tex);
+
+  return texturecomposite2[tex] + ofs;
 }
 
 // [crispy] wrapping column getter function for composited translucent mid-textures on 2S walls
@@ -672,27 +688,6 @@ R_GetColumnMod
 
     return texturecomposite[tex] + ofs;
 }
-
-// [crispy] wrapping column getter function for non-power-of-two wide sky textures
-byte*
-R_GetColumnMod2
-( int		tex,
-  int		col )
-{
-    int		ofs;
-
-    while (col < 0)
-	col += texturewidth[tex];
-
-    col %= texturewidth[tex];
-    ofs = texturecolumnofs2[tex][col];
-
-    if (!texturecomposite2[tex])
-	R_GenerateComposite(tex);
-
-    return texturecomposite2[tex] + ofs;
-}
-
 
 static void GenerateTextureHashTable(void)
 {

--- a/src/doom/r_data.h
+++ b/src/doom/r_data.h
@@ -29,6 +29,7 @@
 #define LOOKDIRS	(LOOKDIRMIN+1+LOOKDIRMAX) // [crispy] lookdir range: -110..0..90
 
 // Retrieve column data for span blitting.
+// [crispy] wrapping column getter function for any non-power-of-two textures
 byte*
 R_GetColumn
 ( int		tex,
@@ -39,13 +40,6 @@ byte*
 R_GetColumnMod
 ( int		tex,
   int		col );
-
-// [crispy] wrapping column getter function for non-power-of-two wide sky textures
-byte*
-R_GetColumnMod2
-( int		tex,
-  int		col );
-
 
 // I/O, setting up the stuff.
 void R_InitData (void);

--- a/src/doom/r_data.h
+++ b/src/doom/r_data.h
@@ -29,7 +29,6 @@
 #define LOOKDIRS	(LOOKDIRMIN+1+LOOKDIRMAX) // [crispy] lookdir range: -110..0..90
 
 // Retrieve column data for span blitting.
-// [crispy] wrapping column getter function for any non-power-of-two textures
 byte*
 R_GetColumn
 ( int		tex,

--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -498,7 +498,7 @@ void R_DrawPlanes (void)
 		{
 		    angle = ((an + xtoviewangle[x])^flip)>>ANGLETOSKYSHIFT;
 		    dc_x = x;
-		    dc_source = R_GetColumnMod2(texture, angle);
+		    dc_source = R_GetColumn(texture, angle);
 		    colfunc ();
 		}
 	    }


### PR DESCRIPTION
Pulled from Woof: https://github.com/fabiangreffrath/woof/commit/d8f50be53e2d121ea42f8446fffedd6ef28901a3 and https://github.com/fabiangreffrath/woof/pull/2303

Testing with 386px texture:
![crispy_non_po2](https://github.com/user-attachments/assets/49accedc-abaa-402b-ae56-ba0b273e4698)
