### PR TITLE
Doom: masterlevels.wad kex support secret level & skyboxes

### DIFF
--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -463,13 +463,19 @@ int D_CheckMasterlevelKex (void)
 	lumpnum = W_CheckNumForName("MWILV17");
 	if (lumpnum == -1)
 	{
-		// loaded as PWAD
+		// loaded as PWAD?
 		lumpnum = W_CheckNumForName("CWILV17");
 	}
-	patch = W_CacheLumpNum(lumpnum, PU_CACHE);
-	if (patch != NULL)
+
+	if (lumpnum > -1)
 	{
+		patch = W_CacheLumpNum(lumpnum, PU_CACHE);
 		width = patch->width;
+	}
+	else
+	{
+		// something's wrong
+		return masterlevels_kex = false;
 	}
 
 	// read width of patch CWILV14

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -160,7 +160,7 @@ void F_StartFinale (void)
     }
 
     // Hack for kex masterlevels finale text
-    if (gamemission == pack_master && D_CheckMasterlevelKex() && players[consoleplayer].didsecret)
+    if (logical_gamemission == pack_master && D_CheckMasterlevelKex() && players[consoleplayer].didsecret)
     {
         finaletext = M2TEXT;
     }

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -214,6 +214,7 @@ void F_Ticker (void)
 	if (gamemission == pack_nerve && gamemap == 8)
 	  F_StartCast ();
 	else
+    // [crispy] kex lvl 20 (checked in G_WorldDone), psn/unity lvl 20 or 21
 	if (gamemission == pack_master && (gamemap == 20 || gamemap == 21))
 	  F_StartCast ();
 	else

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -40,6 +40,7 @@
 #include "m_controls.h" // [crispy] key_*
 #include "m_misc.h" // [crispy] M_StringDuplicate()
 #include "m_random.h" // [crispy] Crispy_Random()
+#include "d_pwad.h" // [crispy] kex secret level
 
 typedef enum
 {
@@ -156,6 +157,12 @@ void F_StartFinale (void)
             finaletext = screen->text;
             finaleflat = screen->background;
         }
+    }
+
+    // Hack for kex masterlevels
+    if (D_CheckMasterlevelKex() && players[consoleplayer].didsecret)
+    {
+        finaletext = M2TEXT;
     }
 
     // Do dehacked substitutions of strings

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -159,8 +159,8 @@ void F_StartFinale (void)
         }
     }
 
-    // Hack for kex masterlevels
-    if (D_CheckMasterlevelKex() && players[consoleplayer].didsecret)
+    // Hack for kex masterlevels finale text
+    if (gamemission == pack_master && D_CheckMasterlevelKex() && players[consoleplayer].didsecret)
     {
         finaletext = M2TEXT;
     }

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1004,42 +1004,53 @@ void G_DoLoadLevel (void)
     {
         const char *skytexturename;
 
-        if((gameepisode == 3 || gamemission == pack_master) && D_CheckMasterlevelKex())
+        if (gamemap < 12 && (gameepisode == 2 || gamemission == pack_nerve))
         {
-            // masterlevels kex skies
-            if (gamemap == 10)
-                skytexturename = "SKY3";                
-            else
-            if (gamemap <= 9)
-                skytexturename = "SKYM1";
-            else
-            if (gamemap >= 16)
-                skytexturename = "SKYM3";
-            else
-            skytexturename = "SKYM2";   
-        }        
-        else if (gamemap < 12)
-        {
-            if ((gameepisode == 2 || gamemission == pack_nerve) && gamemap >= 4 && gamemap <= 8)
+            // nerve skies
+            if (gamemap >= 4 && gamemap <= 8)
                 skytexturename = "SKY3";
             else
-            skytexturename = "SKY1";
-        }
-        else if (gamemap < 21)
-        {
-            // [crispy] BLACKTWR (MAP25) and TEETH (MAP31 and MAP32)
-            if ((gameepisode == 3 || gamemission == pack_master) && gamemap >= 19)
-                skytexturename = "SKY3";
-            else
-            // [crispy] BLOODSEA and MEPHISTO (both MAP07)
-            if ((gameepisode == 3 || gamemission == pack_master) && (gamemap == 14 || gamemap == 15))
                 skytexturename = "SKY1";
-            else
-            skytexturename = "SKY2";
         }
+        else if (gamemap < 21 && (gameepisode == 3 || gamemission == pack_master))
+        {
+            // masterlevel skies
+            if (D_CheckMasterlevelKex())
+            {
+                // masterlevels kex skies
+                if (gamemap == 10)
+                    skytexturename = "SKY3";                
+                else
+                if (gamemap <= 9)
+                    skytexturename = "SKYM1";
+                else
+                if (gamemap >= 16)
+                    skytexturename = "SKYM3";
+                else
+                skytexturename = "SKYM2";   
+            }
+            else
+            {
+                // masterlevels psn/unity skies
+                if (gamemap < 12 || gamemap == 14 || gamemap == 15)
+                    skytexturename = "SKY1";                
+                else
+                if (gamemap >= 19)
+                    skytexturename = "SKY3";
+                else
+                skytexturename = "SKY2";   
+            }
+        }        
         else
         {
-            skytexturename = "SKY3";
+            // doom2 skies
+            if (gamemap < 12)
+                skytexturename = "SKY1";
+            else
+            if (gamemap < 21)
+                skytexturename = "SKY2";
+            else
+                skytexturename = "SKY3";
         }
 
         skytexturename = DEH_String(skytexturename);
@@ -2162,20 +2173,17 @@ void G_DoCompleted (void)
     else
     if ( gamemission == pack_master && gamemap <= 21 )
     {
-    if (D_CheckMasterlevelKex() && gamemap == 18 && secretexit)
-    {
-        // [crispy] bad dream secret exit in TEETH
-        wminfo.next = 20;
-    }
-    else if (D_CheckMasterlevelKex() && gamemap == 21)
-    {
-        // [crispy] bloodsea keep after bad dream secret
-        wminfo.next = 18;
-    }
-    else
-    {
         wminfo.next = gamemap;
-    }
+        // [crispy] kex masterlevel secret detour?
+        if (D_CheckMasterlevelKex())
+        {
+            // [crispy] bad dream secret exit in TEETH
+            if (gamemap == 18 && secretexit)
+                wminfo.next = 20;
+            // [crispy] bloodsea keep after bad dream secret
+            if(gamemap == 21)
+                wminfo.next = 18;
+        }
     }
     else
     if ( gamemode == commercial)

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -988,6 +988,36 @@ void G_DoLoadLevel (void)
 { 
     int             i; 
 
+    // [crispy] NRFTL / The Master Levels
+    if (crispy->havenerve || crispy->havemaster)
+    {
+        if (crispy->havemaster && gameepisode == 3)
+        {
+            gamemission = pack_master;
+        }
+        else
+        if (crispy->havenerve && gameepisode == 2)
+        {
+            gamemission = pack_nerve;
+        }
+        else
+        {
+            gamemission = doom2;
+        }
+    }
+    else
+    {
+        if (gamemission == pack_master)
+        {
+            gameepisode = 3;
+        }
+        else
+        if (gamemission == pack_nerve)
+        {
+            gameepisode = 2;
+        }
+    }
+
     // Set the sky map.
     // First thing, we have a dummy sky texture name,
     //  a flat. The data is in the WAD only because

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1004,7 +1004,21 @@ void G_DoLoadLevel (void)
     {
         const char *skytexturename;
 
-        if (gamemap < 12)
+        if((gameepisode == 3 || gamemission == pack_master) && D_CheckMasterlevelKex())
+        {
+            // masterlevels kex skies
+            if (gamemap == 10)
+                skytexturename = "SKY3";                
+            else
+            if (gamemap <= 9)
+                skytexturename = "SKYM1";
+            else
+            if (gamemap >= 16)
+                skytexturename = "SKYM3";
+            else
+            skytexturename = "SKYM2";   
+        }        
+        else if (gamemap < 12)
         {
             if ((gameepisode == 2 || gamemission == pack_nerve) && gamemap >= 4 && gamemap <= 8)
                 skytexturename = "SKY3";

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -81,6 +81,8 @@
 #include "deh_main.h" // [crispy] for demo footer
 #include "memio.h"
 
+#include "d_pwad.h" // [crispy] kex secret level
+
 #define SAVEGAMESIZE	0x2c000
 
 void	G_ReadDemoTiccmd (ticcmd_t* cmd); 
@@ -2146,7 +2148,20 @@ void G_DoCompleted (void)
     else
     if ( gamemission == pack_master && gamemap <= 21 )
     {
-	wminfo.next = gamemap;
+    if (D_CheckMasterlevelKex() && gamemap == 18 && secretexit)
+    {
+        // [crispy] bad dream secret exit in TEETH
+        wminfo.next = 20;
+    }
+    else if (D_CheckMasterlevelKex() && gamemap == 21)
+    {
+        // [crispy] bloodsea keep after bad dream secret
+        wminfo.next = 18;
+    }
+    else
+    {
+        wminfo.next = gamemap;
+    }
     }
     else
     if ( gamemode == commercial)
@@ -2331,6 +2346,13 @@ void G_WorldDone (void)
     else
     if ( gamemission == pack_master )
     {
+    if (D_CheckMasterlevelKex())
+    {
+        if (gamemap == 20)
+        F_StartFinale ();
+    }
+    else
+    {
 	switch (gamemap)
 	{
 	  case 20:
@@ -2339,7 +2361,8 @@ void G_WorldDone (void)
 	  case 21:
 	    F_StartFinale ();
 	    break;
-	}
+	}      
+    }
     }
     else
     if ( gamemode == commercial )

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1004,22 +1004,22 @@ void G_DoLoadLevel (void)
     {
         const char *skytexturename;
 
+        // nerve skies
         if (gamemap < 12 && (gameepisode == 2 || gamemission == pack_nerve))
         {
-            // nerve skies
             if (gamemap >= 4 && gamemap <= 8)
                 skytexturename = "SKY3";
             else
                 skytexturename = "SKY1";
         }
+        // masterlevel skies
         else if (gamemap < 21 && (gameepisode == 3 || gamemission == pack_master))
         {
-            // masterlevel skies
             if (D_CheckMasterlevelKex())
             {
                 // masterlevels kex skies
                 if (gamemap == 10)
-                    skytexturename = "SKY3";                
+                    skytexturename = "SKY3";
                 else
                 if (gamemap <= 9)
                     skytexturename = "SKYM1";
@@ -1027,23 +1027,23 @@ void G_DoLoadLevel (void)
                 if (gamemap >= 16)
                     skytexturename = "SKYM3";
                 else
-                skytexturename = "SKYM2";   
+                    skytexturename = "SKYM2";
             }
             else
             {
                 // masterlevels psn/unity skies
                 if (gamemap < 12 || gamemap == 14 || gamemap == 15)
-                    skytexturename = "SKY1";                
+                    skytexturename = "SKY1";
                 else
                 if (gamemap >= 19)
                     skytexturename = "SKY3";
                 else
-                skytexturename = "SKY2";   
+                    skytexturename = "SKY2";
             }
-        }        
+        }
+        // doom2 skies
         else
         {
-            // doom2 skies
             if (gamemap < 12)
                 skytexturename = "SKY1";
             else

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2211,7 +2211,7 @@ void G_DoCompleted (void)
             if (gamemap == 18 && secretexit)
                 wminfo.next = 20;
             // [crispy] bloodsea keep after bad dream secret
-            if(gamemap == 21)
+            else if (gamemap == 21)
                 wminfo.next = 18;
         }
     }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -66,6 +66,8 @@
 
 #include "v_trans.h" // [crispy] colored "invert mouse" message
 
+#include "d_pwad.h" // [crispy] kex secret level
+
 //
 // defaulted values
 //
@@ -2229,6 +2231,14 @@ static int G_GotoNextLevel(void)
         doom2_next[1] = 3;
         doom2_next[14] = 16;
         doom2_next[20] = 1;
+        if (D_CheckMasterlevelKex())
+        {
+            // [crispy] kex secret detour
+            doom2_next[17] = 21;
+            doom2_next[20] = 19;
+            doom2_next[18] = 20;
+            doom2_next[19] = 1;
+        }
       }
     }
     else

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -1137,36 +1137,6 @@ P_SetupLevel
 	    = players[i].itemcount = 0;
     }
 
-    // [crispy] NRFTL / The Master Levels
-    if (crispy->havenerve || crispy->havemaster)
-    {
-        if (crispy->havemaster && episode == 3)
-        {
-            gamemission = pack_master;
-        }
-        else
-        if (crispy->havenerve && episode == 2)
-        {
-            gamemission = pack_nerve;
-        }
-        else
-        {
-            gamemission = doom2;
-        }
-    }
-    else
-    {
-        if (gamemission == pack_master)
-        {
-            episode = gameepisode = 3;
-        }
-        else
-        if (gamemission == pack_nerve)
-        {
-            episode = gameepisode = 2;
-        }
-    }
-
     // Initial height of PointOfView
     // will be set by player think.
     players[consoleplayer].viewz = 1; 

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -47,6 +47,8 @@
 #include "st_stuff.h" // [crispy] ST_DrawDemoTimer()
 #include "wi_stuff.h"
 
+#include "d_pwad.h" // [crispy] kex secret level
+
 //
 // Data needed to add patches to full screen intermission pics.
 // Patches are statistics messages, and animations.
@@ -878,7 +880,7 @@ void WI_drawShowNextLoc(void)
 
     if ((gamemission == pack_nerve && wbs->last == 7) ||
         (gamemission == pack_master && wbs->last == 19 && !secretexit) ||
-        (gamemission == pack_master && wbs->last == 20))
+        (gamemission == pack_master && !D_CheckMasterlevelKex() && wbs->last == 20))
         return;
 
     // draws which level you are entering..


### PR DESCRIPTION
Related PR:
https://github.com/fabiangreffrath/crispy-doom/pull/1311

**Changes Summary**

- Allow secret level to work correctly in kex sequence (TEETH SecretExit -> Bad Dreams -> Bloodsea Keep)
- Adaption of GotoNextLevel for kex sequence
- Support of masterlevels.wad kex skyboxes
- Fixing bug having wrong skyboxes when switching between gamemissions