### PR TITLE
Heretic: add support for H+H brightmaps

### DIFF
--- a/src/heretic/r_bmaps.c
+++ b/src/heretic/r_bmaps.c
@@ -267,6 +267,11 @@ static const fullbright_t fullbright_walls[] = {
     {"SW1OFF",   surfaces},
     {"SW2ON",    surfaces},
     {"SW2OFF",   surfaces},
+    // [crispy] H+H IWAD textures
+    {"DOOREXI3", surfaces},
+    {"DOOREXI4", surfaces},
+    {"METLSIG1", surfaces},
+    {"METLSIG2", surfaces},
 };
 
 const byte *R_BrightmapForTexName (const char *texname)


### PR DESCRIPTION
There’s a lot of new textures, and they’re all very well made. However, only four of them were suitable for brightmapping, following the logic of our original brightmaps.

Test map (E1M1): [hh_htic_bmaps.zip](https://github.com/user-attachments/files/21706927/hh_htic_bmaps.zip)

Overview:

<details>


❤️ **_Glamoúr of TrueColoúr!_** 💙
<img width="3360" height="1440" alt="HTIC02" src="https://github.com/user-attachments/assets/142dbc78-d6c1-47cc-ad1b-093f76f715d7" />

</details>