### PR TITLE
Heretic: add support for H+H animated textures

### DIFF
--- a/src/heretic/p_spec.c
+++ b/src/heretic/p_spec.c
@@ -194,6 +194,21 @@ animdef_t animdefs_vanilla[] = {
     {false, "FLATHUH4", "FLATHUH1", 8}, // Super Lava
     {true, "LAVAFL3", "LAVAFL1", 6},    // Texture: Lavaflow
     {true, "WATRWAL3", "WATRWAL1", 4},  // Texture: Waterfall
+    // [crispy] Support animated textures and flats from H+H IWAD.
+    {false, "FLTFLWS3", "FLTFLWS1", 9}, // River - South
+    {false, "FLTLAVF3", "FLTLAVF1", 6}, // River Lava - West
+    {false, "FLTLAVS3", "FLTLAVS1", 6}, // River Lava - South
+    {false, "FLTBLOD3", "FLTBLOD1", 8}, // Blood
+    {true, "BLUEGLO4", "BLUEGLO1", 6},  // Texture: Blue Glowing Gem
+    {true, "CANDLES3", "CANDLES1", 6},  // Texture: Candles
+    {true, "CISTDRN3", "CISTDRN1", 8},  // Texture: Cistern Drain
+    {true, "CISTERN3", "CISTERN1", 8},  // Texture: Cistern
+    {true, "IRONLMP4", "IRONLMP1", 8},  // Texture: Iron Lava Lamp
+    {true, "LAMPLAV4", "LAMPLAV1", 8},  // Texture: Double Lava Lamp
+    {true, "SEWPIP3", "SEWPIP1", 4},    // Texture: Sewer Pipe
+    {true, "WLLBLOD3", "WLLBLOD1", 6},  // Texture: Bloodfall
+    {true, "WLLMURK3", "WLLMURK1", 6},  // Texture: Murkyfall
+    {true, "WLLSLUD3", "WLLSLUD1", 6},  // Texture: Sludgefall
     {-1}
 };
 
@@ -214,6 +229,10 @@ struct
     { "FLTLAVA1", FLOOR_LAVA },
     { "FLATHUH1", FLOOR_LAVA },
     { "FLTSLUD1", FLOOR_SLUDGE },
+    // [crispy] Support terrain types from H+H IWAD.
+    { "FLTFLWS1", FLOOR_WATER },
+    { "FLTLAVF1", FLOOR_LAVA },
+    { "FLTLAVS1", FLOOR_LAVA },
     { "END", -1 }
 };
 


### PR DESCRIPTION
This pull request does not add `ANIMDEFS` support to Heretic, nor does it add support for Kex engine specifics. The animations and their timings, however, are taken directly from the H+H `ANIMDEFS` lump, descriptions are my own, just for consistency.

Test map: [hh_htic_liquids.zip](https://github.com/user-attachments/files/21721313/hh_htic_liquids.zip)

Notes on the test map:
* In Kex, flats in cycles **II** and **III** are not animated, whereas in our case any cycle texture is animated.
* Flats other than cycle **I** do not produce splashes. This behavior is already accounted for in the original Heretic.
* Blood flats do not produce splashes and do not create the sinking-into-liquid effect. Sadly.