### PR TITLE
Add H+H IWAD search folders

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -259,6 +259,14 @@ static registry_value_t root_path_keys[] =
         SOFTWARE_KEY "\\GOG.com\\Games\\1983497091",
         "PATH",
     },
+
+    // [crispy] Heretic + Hexen (not Chocolate Doom compatible)
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1776058590",
+        "PATH"
+    },
 };
 
 // Subdirectories of the above install path, where IWADs are installed.
@@ -272,6 +280,8 @@ static char *root_path_subdirs[] =
     "Plutonia",
     "TNT",
     "base\\wads",
+    "dos\\base\\heretic",
+    "dos\\base\\hexen",
 };
 
 // Location where Steam is installed
@@ -304,6 +314,14 @@ static char *steam_install_subdirs[] =
     "steamapps\\common\\Doom 2\\rerelease\\DOOM II_Data\\StreamingAssets",
     "steamapps\\common\\Ultimate Doom\\rerelease",
     "steamapps\\common\\Ultimate Doom\\rerelease\\DOOM_Data\\StreamingAssets",
+
+    // [crispy] Heretic + Hexen (not Chocolate Doom compatible):
+
+    "steamapps\\common\\Heretic + Hexen",
+    "steamapps\\common\\Heretic + Hexen\\base\\heretic",
+    "steamapps\\common\\Heretic + Hexen\\base\\hexen",
+    "steamapps\\common\\Heretic + Hexen\\dos\\base\\heretic",
+    "steamapps\\common\\Heretic + Hexen\\dos\\base\\hexen",
 
     // From Strife: Veteran Edition:
 
@@ -751,6 +769,11 @@ static void AddSteamDirs(void)
     AddIWADPath(steampath, "/Heretic Shadow of the Serpent Riders/base");
     AddIWADPath(steampath, "/Hexen/base");
     AddIWADPath(steampath, "/Hexen Deathkings of the Dark Citadel/base");
+    AddIWADPath(steampath, "/Heretic + Hexen");
+    AddIWADPath(steampath, "/Heretic + Hexen/base/heretic");
+    AddIWADPath(steampath, "/Heretic + Hexen/base/hexen");
+    AddIWADPath(steampath, "/Heretic + Hexen/dos/base/heretic");
+    AddIWADPath(steampath, "/Heretic + Hexen/dos/base/hexen");
     AddIWADPath(steampath, "/Strife");
     free(steampath);
 }


### PR DESCRIPTION
This Pull Request adds support for automatic detection of IWAD directories from the Heretic + Hexen re-release, specifically:

* Steam (Windows and Linux)
* GOG.com

Here are a few screenshots to demonstrate the detected folders:

<details>

### Steam (Windows)

<img width="1656" height="1286" alt="image" src="https://github.com/user-attachments/assets/c507663c-6577-4cc7-a2aa-736833d38ad4" />

### Steam (Linux / ZorinOS 🖤)

<img src="https://github.com/user-attachments/assets/0a60221a-463d-4c84-84b6-f121ed2b6ed4">

### GOG.com

<img src="https://github.com/user-attachments/assets/41a64db2-515f-4f15-9dc6-a06b2757475a">

</details>

Note: The folder `Heretic + Hexen\base\hexdk` (Hexen DeathKings) is also present, but it is not included in the automatic search. This is because **HEXDD.WAD** is not a standalone IWAD — it still requires **HEXEN.WAD** to run.