### PR TITLE
Doom: Loading Sigil v1.23 and _REG.wad

### DIFF
--- a/src/doom/d_pwad.c
+++ b/src/doom/d_pwad.c
@@ -43,6 +43,8 @@ static boolean LoadSigilWad (const char *iwaddir, boolean pwadtexture)
 	char *autoload_dir;
 
 	const char *const sigil_wads[] = {
+		"SIGIL_V1_23_REG.wad",
+		"SIGIL_V1_23.wad",
 		"SIGIL_v1_21.wad",
 		"SIGIL_v1_2.wad",
 		"SIGIL.wad"


### PR DESCRIPTION
Related Issue:
None

**Changes Summary**
Adding support for sideloading the latest sigil v1.23 base wad and _REG.wad version.