### PR TITLE
Add new option to Crispness Menu to either show or skip ExM8 end-of-level tally in Doom/Chex and Heretic

### DIFF
--- a/src/crispy.c
+++ b/src/crispy.c
@@ -33,6 +33,7 @@ static crispy_t crispy_s = {
 #endif
 	.vsync = 1,
 	.widescreen = 1, // match screen by default
+	.bosscounters = 1, // mantain consistency with older behavior
 };
 crispy_t *const crispy = &crispy_s;
 

--- a/src/crispy.h
+++ b/src/crispy.h
@@ -42,6 +42,7 @@ typedef struct
 	int automaprotate;
 	int automapstats;
 	int bobfactor;
+    int bosscounters;
 	int brightmaps;
 	int btusetimer;
 	int centerweapon;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -450,6 +450,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_automaprotate",   &crispy->automaprotate);
     M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
     M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
+    M_BindIntVariable("crispy_bosscounters",    &crispy->bosscounters);
     M_BindIntVariable("crispy_btusetimer",      &crispy->btusetimer);
     M_BindIntVariable("crispy_brightmaps",      &crispy->brightmaps);
     M_BindIntVariable("crispy_centerweapon",    &crispy->centerweapon);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2133,24 +2133,26 @@ void G_DoCompleted (void)
         if (gameversion == exe_chex)
         {
             // [crispy] display tally screen after Chex Quest E1M5
-            /*
-            if (gamemap == 5)
+            // but ONLY if player wanted this to happen
+            if (gamemap == 5 && !crispy->bosscounters)
             {
                 gameaction = ga_victory;
                 return;
             }
-            */
         }
         else
         {
             switch(gamemap)
             {
             // [crispy] display tally screen after ExM8
-            /*
+            
               case 8:
-                gameaction = ga_victory;
-                return;
-            */
+                // but ONLY if player wanted this to happen
+                if (!crispy->bosscounters)
+                {
+                    gameaction = ga_victory;
+                    return;
+                }
               case 9: 
                 for (i=0 ; i<MAXPLAYERS ; i++) 
                     players[i].didsecret = true; 
@@ -2435,9 +2437,15 @@ void G_WorldDone (void)
     }
     // [crispy] display tally screen after ExM8
     else
-    if ( gamemap == 8 || (gameversion == exe_chex && gamemap == 5) )
     {
-	gameaction = ga_victory;
+        // but ONLY if player wanted this to happen
+        if (crispy->bosscounters)
+        {
+            if ( gamemap == 8 || (gameversion == exe_chex && gamemap == 5) )
+            {
+                gameaction = ga_victory;
+            }
+        }
     }
 } 
  

--- a/src/doom/m_crispy.c
+++ b/src/doom/m_crispy.c
@@ -202,6 +202,12 @@ void M_CrispyToggleBobfactor(int choice)
     ChangeSettingEnum(&crispy->bobfactor, choice, NUM_BOBFACTORS);
 }
 
+void M_CrispyToggleBossCounters(int choice)
+{
+    choice = 0;
+    crispy->bosscounters = !crispy->bosscounters;
+}
+
 void M_CrispyToggleBrightmaps(int choice)
 {
     ChangeSettingEnum(&crispy->brightmaps, choice, NUM_BRIGHTMAPS);

--- a/src/doom/m_crispy.h
+++ b/src/doom/m_crispy.h
@@ -48,6 +48,7 @@ extern multiitem_t multiitem_difficulties[NUM_SKILLS];
 
 extern void M_CrispyToggleAutomapstats(int choice);
 extern void M_CrispyToggleBobfactor(int choice);
+extern void M_CrispyToggleBossCounters(int choice);
 extern void M_CrispyToggleBrightmaps(int choice);
 extern void M_CrispyToggleCenterweapon(int choice);
 extern void M_CrispyToggleColoredblood(int choice);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -83,6 +83,7 @@ int			showMessages = 1;
 int			detailLevel = 0;
 int			screenblocks = 10; // [crispy] increased
 
+
 // temp for screenblocks (0-9)
 int			screenSize;
 
@@ -642,6 +643,10 @@ enum
     crispness_demobar,
     crispness_demousetimer,
     crispness_sep_demos_,
+    
+    crispness_sep_other,
+    crispness_bosscounters,
+    crispness_sep_other_,
 
     crispness4_next,
     crispness4_prev,
@@ -661,6 +666,9 @@ static menuitem_t Crispness4Menu[]=
     {3,"",	M_CrispyToggleDemoTimerDir,'a'},
     {3,"",	M_CrispyToggleDemoBar,'w'},
     {3,"",	M_CrispyToggleDemoUseTimer,'u'},
+    {-1,"",0,'\0'},
+    {-1,"",0,'\0'},
+    {3,"",	M_CrispyToggleBossCounters,'s'},
     {-1,"",0,'\0'},
     {1,"",	M_CrispnessNext,'n'},
     {1,"",	M_CrispnessPrev,'p'},
@@ -1661,6 +1669,10 @@ static void M_DrawCrispness4(void)
     M_DrawCrispnessMultiItem(crispness_demotimerdir, "Playback Timer Direction", multiitem_demotimerdir, crispy->demotimerdir + 1, crispy->demotimer & DEMOTIMER_PLAYBACK);
     M_DrawCrispnessItem(crispness_demobar, "Show Demo Progress Bar", crispy->demobar, true);
     M_DrawCrispnessItem(crispness_demousetimer, "\"Use\" Button Timer", crispy->btusetimer, true);
+    
+    M_DrawCrispnessSeparator(crispness_sep_other, "Other");
+    
+    M_DrawCrispnessItem(crispness_bosscounters, "Boss level tally (Doom 1/Chex)", crispy->bosscounters, true);
 
     M_DrawCrispnessGoto(crispness4_next, "First Page >");
     M_DrawCrispnessGoto(crispness4_prev, "< Prev Page");

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -895,6 +895,7 @@ void D_BindVariables(void)
     M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
     M_BindIntVariable("crispy_brightmaps",      &crispy->brightmaps);
     M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
+    M_BindIntVariable("crispy_bosscounters",    &crispy->bosscounters);
     M_BindIntVariable("crispy_centerweapon",    &crispy->centerweapon);
     M_BindIntVariable("crispy_crosshair",       &crispy->crosshair);
     M_BindIntVariable("crispy_crosshairtype",   &crispy->crosshairtype);

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2024,8 +2024,16 @@ void G_DoCompleted(void)
     }
     else if (gamemap == 8)
     {
-        // [crispy] track intermission at end of episode
-        finalintermission = true;
+        if (!crispy->bosscounters)
+        {
+            gameaction = ga_victory;
+            return;
+        }
+        else
+        {
+            // [crispy] track intermission at end of episode
+            finalintermission = true;
+        }
     }
     else
     {

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -78,6 +78,7 @@ typedef enum
     MENU_CRISPNESS1,
     MENU_CRISPNESS2,
     MENU_CRISPNESS3,
+    MENU_CRISPNESS4,
     MENU_NONE
 } MenuType_t;
 
@@ -152,6 +153,7 @@ static boolean CrispyCrosshairColor(int option);
 static boolean CrispyUncapped(int option);
 static boolean CrispyFpsLimit(int option);
 static boolean CrispyVsync(int option);
+static boolean CrispyBossCounters(int option);
 static boolean CrispyNextPage(int option);
 static boolean CrispyPrevPage(int option);
 static void DrawMainMenu(void);
@@ -170,6 +172,7 @@ static void DrawCrispness(void);
 static void DrawCrispness1(void);
 static void DrawCrispness2(void);
 static void DrawCrispness3(void);
+static void DrawCrispness4(void);
 void MN_LoadSlotText(void);
 
 // External Functions
@@ -366,7 +369,7 @@ static Menu_t Options2Menu = {
 
 static int crispnessmenupage;
 
-#define NUM_CRISPNESS_MENUS 3
+#define NUM_CRISPNESS_MENUS 4
 
 static MenuItem_t Crispness1Items[] = {
     {ITT_LRFUNC2, "HIGH RESOLUTION RENDERING:", CrispyHires, 0, MENU_NONE},
@@ -431,7 +434,7 @@ static MenuItem_t Crispness3Items[] = {
     {ITT_LRFUNC2, "CROSSHAIR COLOR:", CrispyCrosshairColor, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
     {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
-    {ITT_EFUNC, "FIRST PAGE", CrispyNextPage, 0, MENU_NONE},
+    {ITT_EFUNC, "NEXT PAGE", CrispyNextPage, 0, MENU_NONE},
     {ITT_EFUNC, "PREV PAGE", CrispyPrevPage, 0, MENU_NONE},
 };
 
@@ -443,16 +446,43 @@ static Menu_t Crispness3Menu = {
     MENU_OPTIONS
 };
 
+static MenuItem_t Crispness4Items[] = {
+    {ITT_LRFUNC2, "SHOW LEVEL TALLY FOR BOSS MAPS:", CrispyBossCounters, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EMPTY, NULL, NULL, 0, MENU_NONE},
+    {ITT_EFUNC, "FIRST PAGE", CrispyNextPage, 0, MENU_NONE},
+    {ITT_EFUNC, "PREV PAGE", CrispyPrevPage, 0, MENU_NONE},
+};
+
+static Menu_t Crispness4Menu = {
+    68, 35,
+    DrawCrispness,
+    14, Crispness4Items,
+    0,
+    MENU_OPTIONS
+};
+
 static void (*CrispnessMenuDrawers[])(void) = {
     &DrawCrispness1,
     &DrawCrispness2,
     &DrawCrispness3,
+    &DrawCrispness4,
 };
 
 static MenuType_t CrispnessMenus[] = {
     MENU_CRISPNESS1,
     MENU_CRISPNESS2,
     MENU_CRISPNESS3,
+    MENU_CRISPNESS4,
 };
 
 static const multiitem_t multiitem_bobfactor[NUM_BOBFACTORS] =
@@ -571,6 +601,7 @@ static Menu_t *Menus[] = {
     &Crispness1Menu,
     &Crispness2Menu,
     &Crispness3Menu,
+    &Crispness4Menu,
 };
 
 // [crispy] gamma correction messages
@@ -1912,6 +1943,12 @@ static boolean CrispyCrosshairColor(int option)
     return true;
 }
 
+static boolean CrispyBossCounters(int option)
+{
+    crispy->bosscounters = !crispy->bosscounters;
+    return true;
+}
+
 static boolean CrispyNextPage(int option)
 {
     crispnessmenupage++;
@@ -3089,7 +3126,7 @@ static void DrawCrispnessNumericItem(int item, int x, int y, const char *zero,
 
 static void DrawCrispness1(void)
 {
-    DrawCrispnessHeader("CRISPNESS 1/3");
+    DrawCrispnessHeader("CRISPNESS 1/4");
 
     DrawCrispnessSubheader("RENDERING", 25);
 
@@ -3125,7 +3162,7 @@ static void DrawCrispness1(void)
 
 static void DrawCrispness2(void)
 {
-    DrawCrispnessHeader("CRISPNESS 2/3");
+    DrawCrispnessHeader("CRISPNESS 2/4");
 
     DrawCrispnessSubheader("AUDIBLE", 25);
 
@@ -3154,7 +3191,7 @@ static void DrawCrispness2(void)
 
 static void DrawCrispness3(void)
 {
-    DrawCrispnessHeader("CRISPNESS 3/3");
+    DrawCrispnessHeader("CRISPNESS 3/4");
 
     DrawCrispnessSubheader("TACTICAL", 25);
 
@@ -3184,4 +3221,13 @@ static void DrawCrispness3(void)
 
     // Crosshair Color
     DrawCrispnessMultiItem(crispy->crosshaircolor+1, 185, 125, multiitem_he_crosshaircolor, !crispy->crosshair);
+}
+
+static void DrawCrispness4(void)
+{
+    DrawCrispnessHeader("CRISPNESS 4/4");
+
+    DrawCrispnessSubheader("OTHER", 25);
+
+    DrawCrispnessItem(crispy->bosscounters, 289, 35);
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2321,6 +2321,14 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(crispy_bobfactor),
+    
+    //!
+    // @game doom heretic
+    //
+    // Show level counters after boss levels. On by default.
+    //
+    
+    CONFIG_VARIABLE_INT(crispy_bosscounters),
 
     //!
     // @game doom

--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -53,6 +53,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("crispy_automaprotate",   &crispy->automaprotate);
         M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
         M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
+        M_BindIntVariable("crispy_bosscounters",    &crispy->bosscounters);
         M_BindIntVariable("crispy_btusetimer",      &crispy->btusetimer);
         M_BindIntVariable("crispy_brightmaps",      &crispy->brightmaps);
         M_BindIntVariable("crispy_centerweapon",    &crispy->centerweapon);
@@ -101,6 +102,7 @@ void BindCompatibilityVariables(void)
         M_BindIntVariable("vanilla_demo_limit",     &vanilla_demo_limit);
         M_BindIntVariable("crispy_automapstats",    &crispy->automapstats);
         M_BindIntVariable("crispy_bobfactor",       &crispy->bobfactor);
+        M_BindIntVariable("crispy_bosscounters",    &crispy->bosscounters);
         M_BindIntVariable("crispy_centerweapon",    &crispy->centerweapon);
         M_BindIntVariable("crispy_crosshair",       &crispy->crosshair);
         M_BindIntVariable("crispy_crosshairtype",   &crispy->crosshairtype);


### PR DESCRIPTION
This is intended to add the requested feature in #1003. This pull request adds the corresponding option and a new subsection to the crispness menu labeled "Other" for both Doom and Heretic. The option for each game is respectively named as such:

- `Boss level tally (Doom 1/Chex)`
- `Show level tally for boss maps`

Doom's option was named that because of space constraints, and to specify this doesn't affect Doom 2 or Final Doom, but _does_ affect Chex Quest. Heretic's option required creating a new page in the crispness menu, so there is a total of 4 pages now. This option is the only one in the final page.

By default, these come in the "on" setting (consistent with current behavior), which means finishing the corresponding ExM5 (Chex) or ExM8 (Doom and Heretic) will display end-of-level tally in the intermission screen. Changing the option to "off" will skip directly into end-of-episode text screen, much like both Vanilla and Chocolate Doom/Heretic.