### PR TITLE
Enhanced support for non-power-of-2 wide textures -- Heretic, Hexen & Strife

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -619,7 +619,7 @@ R_GetColumn
 
 // [crispy] wrapping column getter function for composited translucent mid-textures on 2S walls
 byte*
-R_GetColumnMod
+R_GetColumnMasked
 ( int		tex,
   int		col )
 {

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -595,16 +595,17 @@ R_GetColumn
   const int mask = texturewidthmask[tex];
   int ofs;
 
+  while (col < 0)
+  {
+    col += width;
+  }
+
   if (mask + 1 == width)
   {
     col &= mask;
   }
   else
   {
-    while (col < 0)
-    {
-      col += width;
-    }
     col %= width;
   }
 
@@ -622,12 +623,24 @@ R_GetColumnMod
 ( int		tex,
   int		col )
 {
-    int		ofs;
+    const int width = texturewidth[tex];
+    const int mask = texturewidthmask[tex];
+    int ofs;
 
     while (col < 0)
-	col += texturewidth[tex];
+    {
+        col += width;
+    }
 
-    col %= texturewidth[tex];
+    if (mask + 1 == width)
+    {
+        col &= mask;
+    }
+    else
+    {
+        col %= width;
+    }
+
     ofs = texturecolumnofs[tex][col];
 
     if (!texturecomposite[tex])
@@ -1503,7 +1516,3 @@ void R_PrecacheLevel (void)
 
     Z_Free(spritepresent);
 }
-
-
-
-

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1516,3 +1516,7 @@ void R_PrecacheLevel (void)
 
     Z_Free(spritepresent);
 }
+
+
+
+

--- a/src/doom/r_data.h
+++ b/src/doom/r_data.h
@@ -36,7 +36,7 @@ R_GetColumn
 
 // [crispy] wrapping column getter function for composited translucent mid-textures on 1S walls
 byte*
-R_GetColumnMod
+R_GetColumnMasked
 ( int		tex,
   int		col );
 

--- a/src/doom/r_segs.c
+++ b/src/doom/r_segs.c
@@ -299,7 +299,7 @@ R_RenderMaskedSegRange
 	    
 	    // draw the texture
 	    col = (column_t *)( 
-		(byte *)R_GetColumnMod(texnum,maskedtexturecol[dc_x]) -3);
+		(byte *)R_GetColumnMasked(texnum,maskedtexturecol[dc_x]) -3);
 			
 	    R_DrawMaskedColumn (col);
 	    maskedtexturecol[dc_x] = INT_MAX; // [crispy] 32-bit integer math
@@ -928,4 +928,3 @@ R_StoreWallRange
     }
     ds_p++;
 }
-

--- a/src/doom/r_segs.c
+++ b/src/doom/r_segs.c
@@ -928,3 +928,4 @@ R_StoreWallRange
     }
     ds_p++;
 }
+

--- a/src/hexen/r_data.c
+++ b/src/hexen/r_data.c
@@ -53,6 +53,7 @@ int firstspritelump, lastspritelump, numspritelumps;
 int numtextures;
 texture_t **textures;
 int *texturewidthmask;
+int *texturewidth; // [crispy] texture width for wrapping column getter function
 fixed_t *textureheight;         // needed for texture pegging
 int *texturecompositesize;
 short **texturecolumnlump;
@@ -525,6 +526,7 @@ void R_InitTextures(void)
     texturecomposite = Z_Malloc(numtextures * sizeof(byte *), PU_STATIC, 0);
     texturecompositesize = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
     texturewidthmask = Z_Malloc(numtextures * sizeof(int), PU_STATIC, 0);
+    texturewidth = Z_Malloc (numtextures * sizeof(*texturewidth), PU_STATIC, 0);
     textureheight = Z_Malloc(numtextures * sizeof(fixed_t), PU_STATIC, 0);
     texturebrightmap = Z_Malloc (numtextures * sizeof(*texturebrightmap), PU_STATIC, 0);
 
@@ -571,6 +573,9 @@ void R_InitTextures(void)
             j <<= 1;
         texturewidthmask[i] = j - 1;
         textureheight[i] = texture->height << FRACBITS;
+
+        // [crispy] texture width for wrapping column getter function
+        texturewidth[i] = texture->width;
     }
 
     Z_Free(patchlookup);

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -1150,3 +1150,7 @@ void R_PrecacheLevel (void)
 
     Z_Free(spritepresent);
 }
+
+
+
+

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -141,6 +141,7 @@ texture_t**     textures_hashtable;
 
 
 int*			texturewidthmask;
+int*			texturewidth; // [crispy] texture width for wrapping column getter function
 // needed for texture pegging
 fixed_t*		textureheight;		
 int*			texturecompositesize;
@@ -379,13 +380,27 @@ R_GetColumn
 ( int		tex,
   int		col )
 {
-    int		lump;
-    int		ofs;
-	
-    col &= texturewidthmask[tex];
+    const int width = texturewidth[tex];
+    const int mask = texturewidthmask[tex];
+    int lump, ofs;
+
+    while (col < 0)
+    {
+        col += width;
+    }
+
+    if (mask + 1 == width)
+    {
+        col &= mask;
+    }
+    else
+    {
+        col %= width;
+    }
+
     lump = texturecolumnlump[tex][col];
     ofs = texturecolumnofs[tex][col];
-    
+
     if (lump > 0)
 	return (byte *)W_CacheLumpNum(lump,PU_CACHE)+ofs;
 
@@ -518,6 +533,7 @@ void R_InitTextures (void)
     texturecomposite = Z_Malloc (numtextures * sizeof(*texturecomposite), PU_STATIC, 0);
     texturecompositesize = Z_Malloc (numtextures * sizeof(*texturecompositesize), PU_STATIC, 0);
     texturewidthmask = Z_Malloc (numtextures * sizeof(*texturewidthmask), PU_STATIC, 0);
+    texturewidth = Z_Malloc (numtextures * sizeof(*texturewidth), PU_STATIC, 0);
     textureheight = Z_Malloc (numtextures * sizeof(*textureheight), PU_STATIC, 0);
 
     //	Really complex printing shit...
@@ -599,6 +615,9 @@ void R_InitTextures (void)
 
         texturewidthmask[i] = j-1;
         textureheight[i] = texture->height<<FRACBITS;
+
+        // [crispy] texture width for wrapping column getter function
+        texturewidth[i] = texture->width;
     }
 
     Z_Free(patchlookup);
@@ -1131,7 +1150,3 @@ void R_PrecacheLevel (void)
 
     Z_Free(spritepresent);
 }
-
-
-
-

--- a/src/strife/r_data.c
+++ b/src/strife/r_data.c
@@ -400,7 +400,7 @@ R_GetColumn
 
     lump = texturecolumnlump[tex][col];
     ofs = texturecolumnofs[tex][col];
-
+    
     if (lump > 0)
 	return (byte *)W_CacheLumpNum(lump,PU_CACHE)+ofs;
 


### PR DESCRIPTION
The H+H re-release contains a good handful of new textures that do not fall on the power-of-2 scale (96px, 160px, 192px, etc) so I went ahead and updated all 4 games to include support for it.