### PR TITLE
Add rerelease H+H IWAD search folders

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -273,6 +273,7 @@ static registry_value_t root_path_keys[] =
 
 static char *root_path_subdirs[] =
 {
+    ".", // [crispy] moved to top, so reworked IWADs will be found before the legacy DOS ones
     "Doom2",
     "Final Doom",
     "Ultimate Doom",
@@ -281,7 +282,6 @@ static char *root_path_subdirs[] =
     "base\\wads",
     "dos\\base\\heretic",
     "dos\\base\\hexen",
-    ".",
 };
 
 // Location where Steam is installed


### PR DESCRIPTION
This PR adds search paths for the rerelease IWAD versions from H+H, which are not supported in Chocolate but already work in Crispy.

@fabiangreffrath, one question: would it perhaps make sense to restore the “[current directory first](https://github.com/fabiangreffrath/crispy-doom/blob/26b92e312592e360f5f1d855a6e8c370ebc0cda1/src/d_iwad.c#L284)” search logic to the top priority?