### PR TITLE
Fix artifact flash animation in uncapped framerate

### DIFF
--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -365,6 +365,11 @@ void SB_Ticker(void)
         }
         HealthMarker += delta;
     }
+    // [crispy] play artifact flash animation independently of framerate
+    if (ArtifactFlash > 0)
+    {
+        ArtifactFlash--;
+    }
     SB_PaletteFlash();
 }
 
@@ -968,7 +973,7 @@ void DrawMainBar(void)
         temp = W_GetNumForName(DEH_String("useartia")) + ArtifactFlash - 1;
 
         V_DrawPatch(182, 161, W_CacheLumpNum(temp, PU_CACHE));
-        ArtifactFlash--;
+        // ArtifactFlash--; [crispy] moved to SB_Ticker
         oldarti = -1;           // so that the correct artifact fills in after the flash
         UpdateState |= I_STATBAR;
     }

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -477,6 +477,11 @@ void SB_Ticker(void)
         }
         HealthMarker += delta;
     }
+    // [crispy] play artifact flash animation independently of framerate
+    if (ArtifactFlash > 0)
+    {
+        ArtifactFlash--;
+    }
     SB_PaletteFlash(false);
 }
 
@@ -1184,7 +1189,7 @@ void DrawMainBar(void)
         V_DrawPatch(144, 160, PatchARTICLEAR);
         V_DrawPatch(148, 164, W_CacheLumpNum(W_GetNumForName("useartia")
                                              + ArtifactFlash - 1, PU_CACHE));
-        ArtifactFlash--;
+        // ArtifactFlash--; [crispy] moved to SB_Ticker
         oldarti = -1;           // so that the correct artifact fills in after the flash
         UpdateState |= I_STATBAR;
     }


### PR DESCRIPTION
This PR fixes the artifact use animation in uncapped framerate mode: the animation is now tied to tics rather than frames.

What is this animation and how to check it? It’s the bright blue flash displayed on the status bar background when using an artifact. With capped framerate it plays as intended, but in uncapped — and especially with VSync disabled — the animation becomes far too fast.

Note that in H+H the animation speed was halved, but let’s stick to the _canonical_ rather than the _new-official_ approach.

<details>

<img src="https://github.com/user-attachments/assets/07d58842-29b3-40b0-b93a-7776ff865753" />

</details>