### PR TITLE
Doom: update lowres_turn upon joining demos

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2985,6 +2985,10 @@ void G_ReadDemoTiccmd (ticcmd_t* cmd)
 
 	gamekeydown[key_demo_quit] = false;
 
+	// [crispy] update turning resolution when joining a demo
+	// based upon longtics info taken from record
+	lowres_turn = !longtics;
+
 	// [crispy] redraw status bar to get rid of demo progress bar
 	ST_Drawer(viewheight == SCREENHEIGHT, true);
 


### PR DESCRIPTION
Related Issue:
Closes https://github.com/fabiangreffrath/crispy-doom/issues/1348

**Changes Summary**

- update lowres_turn upon joining demos to resolve the issue of having a high resolution turning enabled for an initially shorttics-recorded demo, leading to inconsistent controls.
