### PR TITLE
Strife: Update p_doors.c, fix for sliding doors

### DIFF
--- a/src/strife/p_doors.c
+++ b/src/strife/p_doors.c
@@ -1315,7 +1315,7 @@ void EV_SlidingDoor(line_t* line, mobj_t* thing)
         door = sec->specialdata;
         if(door->type == sdt_openAndClose)
         {
-            if(door->status == sd_waiting)
+            if(door->status == sd_waiting && sec->thinglist == NULL)
             {
                 door->status = sd_closing;
                 door->timer = SWAITTICS;    // villsa [STRIFE]


### PR DESCRIPTION
Sliding doors break when you are too close and manually close it.

If you are near it when it tries to automatically close, the checks work and it doesn't close.

But if you cross your nose over the line, far enough in to be considered in the door sector, but far enough out to manually close the door, the animation plays but the lines never become blocking and the ceiling never shuts. This leaves a "closed" door that blocks nothing.

Just adding a check for a mobj in the door sector before calling the function seems to have done the trick.