### PR TITLE
Fix for sliding doors being able to be manually closed in a half-state (looks closed, actually open)

### DIFF
--- a/src/strife/p_doors.c
+++ b/src/strife/p_doors.c
@@ -1335,8 +1335,12 @@ void EV_SlidingDoor(line_t* line, mobj_t* thing)
                     door->line1->flags |= ML_BLOCKING;
                     door->line2->flags |= ML_BLOCKING;
 
-                    // play close sound
-                    S_StartSound(&sec->soundorg, slideCloseSounds[door->whichDoorIndex]);
+                    // [crispy] play sound effect when the door is closed manually
+	                if (crispy->soundfix)
+	                {
+	                    S_StartSound(&sec->soundorg,
+	                                 slideCloseSounds[door->whichDoorIndex]);
+	                }
 
                     door->status = sd_closing;
                     door->timer = SWAITTICS;


### PR DESCRIPTION
If a player stands with their nose crossing into the sliding door sector and manually closes the door, the code doesn't do the same checks it does in earlier code for the automatic closing of a sliding door.

This allows one to manually close the door but ALSO interrupt the actual ceiling movement and application of line blocking flags. This leaves a sliding door which animates closed but remains completely open, passable, and doesn't block sight, sound, etc.

Basically, I duplicated the checks from the automatic closing routine a few lines above it for sliding doors so a manual close checks for a "crushed" actor (ceiling blocked) AND (and here is where my last deleted pull request comes in, as I misunderstood sec->thinglist, thinking it also contained the player) it checks for a mobj in the way in general, so it won't close on items.

Remove the " && sec->thinglist == NULL" if that last behavior is not vanilla. I added it because I *think* vanilla didn't close these doors on items, as that very check is also in the auto-close routine.