### PR TITLE
[WIP] Cover full range of Strife controls with joystick

### DIFF
--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -90,7 +90,8 @@ int joystick_look_sensitivity = 10;
 // Virtual to physical button joystick button mapping. By default this
 // is a straight mapping.
 static int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25
 };
 
 void I_ShutdownGamepad(void)

--- a/src/i_joystick.h
+++ b/src/i_joystick.h
@@ -24,7 +24,7 @@
 // Number of "virtual" joystick buttons defined in configuration files.
 // This needs to be at least as large as the number of different key
 // bindings supported by the higher-level game code (joyb* variables).
-#define NUM_VIRTUAL_BUTTONS 17
+#define NUM_VIRTUAL_BUTTONS 26
 
 // Max allowed number of virtual mappings. Chosen to be less than joybspeed
 // autorun value.

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -745,6 +745,79 @@ static default_t	doom_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(comport),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to use health.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_useHealth),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to query inventory.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invquery),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to display mission objective.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_mission),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to display inventory popup.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invPop),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to display keys popup.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invKey),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to jump to start of inventory.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invHome),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to jump to end of inventory.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invEnd),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to use inventory item.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invUse),
+
+    //!
+    // @game strife
+    //
+    // Joystick virtual button to drop an inventory item.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invDrop),
+
 };
 
 static default_collection_t doom_defaults =
@@ -1582,6 +1655,69 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(joystick_physical_button16),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #17.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button17),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #18.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button18),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #19.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button19),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #20.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button20),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #21.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button21),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #22.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button22),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #23.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button23),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #24.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button24),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #25.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button25),
 
     //!
     // If non-zero, use the SDL_GameController interface instead of the

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -240,6 +240,16 @@ int joybflyup = -1;
 int joybflydown = -1;
 int joybflycenter = -1;
 
+int joybusehealth = -1;
+int joybinvquery = -1;
+int joybmission = -1;
+int joybinvpop = -1;
+int joybinvkey = -1;
+int joybinvhome = -1;
+int joybinvend = -1;
+int joybinvuse = -1;
+int joybinvdrop = -1;
+
 // Control whether if a mouse button is double clicked, it acts like 
 // "use" has been pressed
 
@@ -394,6 +404,18 @@ void M_BindStrifeControls(void)
     M_BindIntVariable("key_invEnd",         &key_invend);
     M_BindIntVariable("key_invUse",         &key_invuse);
     M_BindIntVariable("key_invDrop",        &key_invdrop);
+
+    M_BindIntVariable("joyb_invleft",       &joybinvleft);
+    M_BindIntVariable("joyb_invright",      &joybinvright);
+    M_BindIntVariable("joyb_useHealth",     &joybusehealth);
+    M_BindIntVariable("joyb_invquery",      &joybinvquery);
+    M_BindIntVariable("joyb_mission",       &joybmission);
+    M_BindIntVariable("joyb_invPop",        &joybinvpop);
+    M_BindIntVariable("joyb_invKey",        &joybinvkey);
+    M_BindIntVariable("joyb_invHome",       &joybinvhome);
+    M_BindIntVariable("joyb_invEnd",        &joybinvend);
+    M_BindIntVariable("joyb_invUse",        &joybinvuse);
+    M_BindIntVariable("joyb_invDrop",       &joybinvdrop);
 
     // Strife also supports jump on mouse and joystick, and in the exact same
     // manner as Hexen!

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -199,6 +199,16 @@ extern int joybflyup;
 extern int joybflydown;
 extern int joybflycenter;
 
+extern int joybusehealth;
+extern int joybinvquery;
+extern int joybmission;
+extern int joybinvpop;
+extern int joybinvkey;
+extern int joybinvhome;
+extern int joybinvend;
+extern int joybinvuse;
+extern int joybinvdrop;
+
 extern int dclick_use;
 
 void M_BindBaseControls(void);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -100,7 +100,8 @@ int joystick_look_sensitivity = 10;
 
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25
 };
 
 static txt_button_t *joystick_button;
@@ -170,6 +171,15 @@ static const joystick_config_t empty_defaults[] =
     {"joyb_flyup",                 -1},
     {"joyb_flydown",               -1},
     {"joyb_flycenter",             -1},
+    {"joyb_useHealth",             -1},
+    {"joyb_invquery",              -1},
+    {"joyb_mission",               -1},
+    {"joyb_invPop",                -1},
+    {"joyb_invKey",                -1},
+    {"joyb_invHome",               -1},
+    {"joyb_invEnd",                -1},
+    {"joyb_invUse",                -1},
+    {"joyb_invDrop",               -1},
     {"joystick_physical_button0",  0},
     {"joystick_physical_button1",  1},
     {"joystick_physical_button2",  2},
@@ -187,6 +197,15 @@ static const joystick_config_t empty_defaults[] =
     {"joystick_physical_button14",  14},
     {"joystick_physical_button15",  15},
     {"joystick_physical_button16",  16},
+    {"joystick_physical_button17",  17},
+    {"joystick_physical_button18",  18},
+    {"joystick_physical_button19",  19},
+    {"joystick_physical_button20",  20},
+    {"joystick_physical_button21",  21},
+    {"joystick_physical_button22",  22},
+    {"joystick_physical_button23",  23},
+    {"joystick_physical_button24",  24},
+    {"joystick_physical_button25",  25},
     {NULL, 0},
 };
 
@@ -1191,12 +1210,29 @@ static void MoreControls(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     TXT_SetTableColumns(window, 6);
     TXT_SetColumnWidths(window, 18, 10, 1, 18, 10, 0);
 
-    AddJoystickControl(window, "Use artifact", &joybuseartifact);
-    AddJoystickControl(window, "Inventory left", &joybinvleft);
-    AddJoystickControl(window, "Inventory right", &joybinvright);
-    AddJoystickControl(window, "Fly up", &joybflyup);
-    AddJoystickControl(window, "Fly down", &joybflydown);
-    AddJoystickControl(window, "Fly center", &joybflycenter);
+    if (gamemission == heretic || gamemission == hexen)
+    {
+        AddJoystickControl(window, "Use artifact", &joybuseartifact);
+        AddJoystickControl(window, "Inventory left", &joybinvleft);
+        AddJoystickControl(window, "Inventory right", &joybinvright);
+        AddJoystickControl(window, "Fly up", &joybflyup);
+        AddJoystickControl(window, "Fly down", &joybflydown);
+        AddJoystickControl(window, "Fly center", &joybflycenter);
+    }
+    else if (gamemission == strife)
+    {
+        AddJoystickControl(window, "Use", &joybinvuse);
+        AddJoystickControl(window, "Drop", &joybinvdrop);
+        AddJoystickControl(window, "Inventory left", &joybinvleft);
+        AddJoystickControl(window, "Inventory right", &joybinvright);
+        AddJoystickControl(window, "Home", &joybinvhome);
+        AddJoystickControl(window, "End", &joybinvend);
+        AddJoystickControl(window, "Use health", &joybusehealth);
+        AddJoystickControl(window, "Query", &joybinvquery);
+        AddJoystickControl(window, "Show mission", &joybmission);
+        AddJoystickControl(window, "Show weapons", &joybinvpop);
+        AddJoystickControl(window, "Show keys", &joybinvkey);
+    }
 
     TXT_SetWindowAction(window, TXT_HORIZ_LEFT, NULL);
     TXT_SetWindowAction(window, TXT_HORIZ_CENTER,
@@ -1307,7 +1343,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     AddJoystickControl(window, "Toggle Automap", &joybautomap);
 
-    if (gamemission == heretic || gamemission == hexen)
+    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
     {
         TXT_AddWidget(window,
                        TXT_NewButton2("More controls...", MoreControls, NULL));

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -64,6 +64,15 @@ static int *all_joystick_buttons[NUM_VIRTUAL_BUTTONS] =
     &joybflyup,
     &joybflydown,
     &joybflycenter,
+    &joybusehealth,
+    &joybinvquery,
+    &joybmission,
+    &joybinvpop,
+    &joybinvkey,
+    &joybinvhome,
+    &joybinvend,
+    &joybinvuse,
+    &joybinvdrop,
 };
 
 // For indirection so that we're not dependent on item ordering in the

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -485,7 +485,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 
     // villsa [STRIFE] inventory use key
     // [crispy] mouse inventory use
-    if(gamekeydown[key_invuse] || mousebuttons[mousebinvuse])
+    if(gamekeydown[key_invuse] || mousebuttons[mousebinvuse] || joybuttons[joybinvuse])
     {
         if(player->numinventory > 0)
         {
@@ -499,7 +499,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     }
 
     // villsa [STRIFE] inventory drop key
-    if(gamekeydown[key_invdrop])
+    if(gamekeydown[key_invdrop] || joybuttons[joybinvdrop])
     {
         if(player->numinventory > 0)
         {
@@ -513,7 +513,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     }
 
     // villsa [STRIFE] use medkit
-    if(gamekeydown[key_usehealth])
+    if(gamekeydown[key_usehealth] || joybuttons[joybusehealth])
         cmd->buttons2 |= BT2_HEALTH;
 
 
@@ -1012,6 +1012,7 @@ void G_DoLoadLevel (void)
 static void SetJoyButtons(unsigned int buttons_mask)
 {
     int i;
+    player_t *const player = &players[consoleplayer]; // [crispy]
 
     for (i=0; i<MAX_JOY_BUTTONS; ++i)
     {
@@ -1030,6 +1031,31 @@ static void SetJoyButtons(unsigned int buttons_mask)
             else if (i == joybnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == joybinvleft) // [crispy] mouse inventory left
+            {
+                if (player->inventorycursor > 0)
+                    player->inventorycursor--;
+                st_invtics = 5 * 35; // [crispy] Crispy HUD
+            }
+            else if (i == joybinvright) // [crispy] mouse inventory right
+            {
+                if (player->inventorycursor < player->numinventory - 1)
+                    player->inventorycursor++;
+                st_invtics = 5 * 35; // [crispy] Crispy HUD
+            }
+            else if (i == joybinvhome)
+            {
+                player->inventorycursor = 0;
+                st_invtics = 5 * 35; // [crispy] Crispy HUD
+            }
+            else if (i == joybinvend)
+            {
+                if (player->numinventory)
+                    player->inventorycursor = player->numinventory - 1;
+                else
+                    player->inventorycursor = 0;
+                st_invtics = 5 * 35; // [crispy] Crispy HUD
             }
         }
 


### PR DESCRIPTION
Okay, this turned out harder than anticipated. Large part of the problem is that status-related keys are handled directly via `ST_Responder()` with distinction for keydown/keyup events. I couldn't think of a really good way of combining this with mask-based joystick events.

Particularly, the problem is that the function needs e.g. to show dialog on keydown or joystick event showing that a particular button started being pressed, and hide it on keyup or joystick event showing that a particular button stopped being pressed. I'd use some guidance here.

Also, it seems that `joybinvuse` doesn't work, for some reason.