### PR TITLE
Doom: Don't preserve palette index 109 for CR_DARK

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1263,7 +1263,7 @@ static void R_InitHSVColors(void)
 	{
 	    for (j = 0; j < 256; j++)
 	    {
-		cr[i][j] = V_Colorize(playpal, i, j, keepgray);
+		cr[i][j] = V_Colorize(playpal, i, j, i == CR_DARK ? false : keepgray);
 	    }
 
 	    M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);


### PR DESCRIPTION
It doesn't make much sense to preserve the gray drop shadow color for CR_DARK, when it's never used on the status bar numbers anyway. It _is_, however, used on other graphics that use that shade of gray (e.g. thermo graphics when the slider is at zero), and this causes them to appear a bit strange. For example:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/af1d79f7-1788-4db9-b8a9-e43109175dd6" /> <img width="328" alt="image" src="https://github.com/user-attachments/assets/4156cefd-d7ee-4fdf-9957-4cdbbf2dff54" />
(Left is current master, right is after this PR.)
