### PR TITLE
Update joystick fire delay logic to apply to dialogs only

### DIFF
--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -2391,7 +2391,10 @@ boolean M_Responder (event_t* ev)
                 key = key_menu_forward;
             }
             joywait = I_GetTime() + 5;
+            if (menuindialog || menuactive) // [crispy] fix joystick fire delay
+            {
             joystick_fire_countdown = 5;
+            }
         }
         if (JOY_BUTTON_PRESSED(joybuse))
         {


### PR DESCRIPTION
Mirror the logic from mouse fire delay to joystick.  However, apply it both to dialogs and regular menus, since (unlike with mouse) the latter are also affected, e.g. after saving a game with the attack button you end up attacking immediately.

Fixes #1390