### PR TITLE
Hexen: move S_InitScript and InitMapInfo into SV_LoadGame

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -39,7 +39,6 @@
 // External functions
 
 extern void R_ExecuteSetViewSize(void); // [crispy] for clean screenshot
-extern void S_InitScript(void); // [crispy] support multiple episodes
 
 // Functions
 
@@ -2099,11 +2098,6 @@ void G_DoSingleReborn(void)
 {
     gameaction = ga_nothing;
     SV_LoadGame(SV_GetRebornSlot());
-
-    // [crispy] re-init scripts and mapinfo to support multiple episodes
-    S_InitScript();
-    InitMapInfo();
-
     SB_SetClassData();
 }
 
@@ -2140,11 +2134,6 @@ void G_DoLoadGame(void)
     {                           // Copy the base slot to the reborn slot
         SV_UpdateRebornSlot();
     }
-
-    // [crispy] re-init scripts and mapinfo to support multiple episodes
-    S_InitScript();
-    InitMapInfo();
-
     SB_SetClassData();
 }
 

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -89,6 +89,7 @@ typedef struct
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 
+extern void S_InitScript(void); // [crispy] support multiple episodes
 void P_SpawnPlayer(mapthing_t * mthing);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
@@ -2151,6 +2152,10 @@ void SV_LoadGame(int slot)
 
     // [crispy] read more extended savegame data for game
     SV_ReadExtendedSaveGameData(EXTSAVEG_GAME);
+
+    // [crispy] re-init scripts and mapinfo to support multiple episodes
+    S_InitScript();
+    InitMapInfo();
 
     // Save player structs
     for (i = 0; i < maxplayers; i++)


### PR DESCRIPTION
Related Issue:
none

**Changes Summary**
A small overlook from PR #1386, I noticed when loading between Hexen and HEXDD saves, the sky only updates when loading a savegame twice, since the InitMapInfo was too late in the sequence. Thus, this PR moves S_InitScript and InitMapInfo into SV_LoadGame to make sure they are updated before the remaining init based upon the loaded episode value. Sorry for not spotting it earlier!