### PR TITLE
Hexen: move worldtimer when powers are active

### DIFF
--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -2049,9 +2049,9 @@ static void DrawWorldTimer(void)
     int minutes;
     int seconds;
     int worldTimer;
-    int offset_h = right_widget_h; // [crispy]
     char timeBuffer[15];
     char dayBuffer[20];
+    int offset_h = right_widget_h; // [crispy]
 
     worldTimer = players[consoleplayer].worldTimer;
 

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -2049,6 +2049,7 @@ static void DrawWorldTimer(void)
     int minutes;
     int seconds;
     int worldTimer;
+    int offset_h = right_widget_h; // [crispy]
     char timeBuffer[15];
     char dayBuffer[20];
 
@@ -2063,9 +2064,18 @@ static void DrawWorldTimer(void)
     worldTimer -= minutes * 60;
     seconds = worldTimer;
 
+    // [crispy] 30px spacing on active powers to avoid
+    // overlapping with the world timer
+    if (!offset_h &&
+        (players[consoleplayer].powers[pw_invulnerability] ||
+         players[consoleplayer].powers[pw_minotaur]))
+    {
+        offset_h = 30;
+    }
+
     M_snprintf(timeBuffer, sizeof(timeBuffer),
                "%.2d : %.2d : %.2d", hours, minutes, seconds);
-    MN_DrTextA(timeBuffer, 240 + WIDESCREENDELTA, 8 + right_widget_h);
+    MN_DrTextA(timeBuffer, 240 + WIDESCREENDELTA, 8 + offset_h);
 
     if (days)
     {
@@ -2077,10 +2087,10 @@ static void DrawWorldTimer(void)
         {
             M_snprintf(dayBuffer, sizeof(dayBuffer), "%.2d DAYS", days);
         }
-        MN_DrTextA(dayBuffer, 240 + WIDESCREENDELTA, 20 + right_widget_h);
+        MN_DrTextA(dayBuffer, 240 + WIDESCREENDELTA, 20 + offset_h);
         if (days >= 5)
         {
-            MN_DrTextA("YOU FREAK!!!", 230, 35 + right_widget_h);
+            MN_DrTextA("YOU FREAK!!!", 230, 35 + offset_h);
         }
     }
 }

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -2064,8 +2064,8 @@ static void DrawWorldTimer(void)
     worldTimer -= minutes * 60;
     seconds = worldTimer;
 
-    // [crispy] 30px spacing on active powers to avoid
-    // overlapping with the world timer
+    // [crispy] move world timer by 26px to avoid 
+    // overlapping with the power widgets
     if (!offset_h &&
         (players[consoleplayer].powers[pw_invulnerability] ||
          players[consoleplayer].powers[pw_minotaur]))

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -2070,7 +2070,7 @@ static void DrawWorldTimer(void)
         (players[consoleplayer].powers[pw_invulnerability] ||
          players[consoleplayer].powers[pw_minotaur]))
     {
-        offset_h = 30;
+        offset_h = 26;
     }
 
     M_snprintf(timeBuffer, sizeof(timeBuffer),


### PR DESCRIPTION
Related Issue:
none

**Changes Summary**
The world timer and active invul / minotaur widgets are overlapping in the automap (vanilla behavior). This attempts to fix it by moving the world timer down by 26 px when any of the two powers is active.

<img width="509" height="232" alt="grafik" src="https://github.com/user-attachments/assets/71e58dd1-bd0c-4a24-98f3-491c71eb4230" />
<img width="509" height="354" alt="grafik" src="https://github.com/user-attachments/assets/052e2210-f690-44fd-8977-e354678cd4a7" />

