### PR TITLE
Hexen: misc. demo fixes

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2185,7 +2185,7 @@ void G_DeferredNewGame(skill_t skill)
     {
         G_CheckDemoStatus();
         Z_Free(demoname);
-        G_RecordDemo(skill, 1, gameepisode, 1, orig_demoname);
+        G_RecordDemo(skill, 1, gameepisode, startmap, orig_demoname);
     }
 }
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2320,6 +2320,13 @@ boolean MN_Responder(event_t * event)
                     I_SetPalette(0);
 #endif
                     H2_StartTitle();    // go to intro/demo mode.
+                    // [crispy] re-init episode 1 for correct demo reel
+                    if (gameepisode > 1)
+                    {
+                        gameepisode = 1;
+                        S_InitScript();
+                        InitMapInfo();
+                    }
                     return false;
                 case 3:
                     P_SetMessage(&players[consoleplayer],


### PR DESCRIPTION
Related Issue:
none

**Changes Summary**
This PR addresses two demo related bugs in Hexen:
- Demo reel not working correctly after starting sideloaded Deathkings and then going back to Menu with "end game" option.
- Starting a new game while recording should consider the startmap, not necessarily map 1, DKDC e. g. starts with map 41.