### PR TITLE
Hexen: sideloading optimization & bugfixing

### DIFF
--- a/src/hexen/d_pwad.c
+++ b/src/hexen/d_pwad.c
@@ -44,7 +44,7 @@ static boolean CheckHEXDDLoaded (void)
 		!strcasecmp(P_GetMapName(i), "RUINED VILLAGE") &&
 	    !strcasecmp(P_GetMapName(j), "DARK CITADEL"))
 	{
-		gameepisode = 2;
+		gameepisode = prev_episode = 2;
 		return true;
 	}
 
@@ -134,13 +134,13 @@ static void CheckLoadHEXDD (void)
         }
     }
 
-	// [crispy] load WAD and DEH files from autoload directories
+	// [crispy] load WAD from autoload directories
 	if (!M_ParmExists("-noautoload"))
 	{
 		if ((autoload_dir = M_GetAutoloadDir(dd_basename, false)))
 		{
 			W_AutoLoadWADsRename(autoload_dir, hexdd_lumps, arrlen(hexdd_lumps));
-			//DEH_AutoLoadPatches(autoload_dir);
+			// TODO? DEH_AutoLoadPatches(autoload_dir);
 			free(autoload_dir);
 		}
 	}

--- a/src/hexen/d_pwad.c
+++ b/src/hexen/d_pwad.c
@@ -36,13 +36,11 @@ static boolean CheckHEXDDLoaded (void)
 {
 	int i, j;
 
-	i = P_TranslateMap(1);
-	j = P_TranslateMap(20);
-
-	// Check if HEXDD.WAD is already loaded by checking MapInfo Mapnames for warptarget 1 and 20
-	if (i >= 0 && j >= 0 &&
-		!strcasecmp(P_GetMapName(i), "RUINED VILLAGE") &&
-	    !strcasecmp(P_GetMapName(j), "DARK CITADEL"))
+	// Check if HEXDD.WAD is already loaded
+	if ((i = W_CheckNumForName("MAP41")) != -1 &&
+	    (j = W_CheckNumForName("MAP60")) != -1 &&
+	    !strcasecmp(W_WadNameForLump(lumpinfo[i]), "HEXDD.WAD") &&
+	    !strcasecmp(W_WadNameForLump(lumpinfo[j]), "HEXDD.WAD"))
 	{
 		gameepisode = prev_episode = 2;
 		return true;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -39,6 +39,7 @@
 // External functions
 
 extern void R_ExecuteSetViewSize(void); // [crispy] for clean screenshot
+extern void S_InitScript(void); // [crispy] multiple episodes
 
 // Functions
 
@@ -1918,6 +1919,9 @@ void G_StartNewGame(skill_t skill)
     int realMap;
 
     G_StartNewInit();
+    // [crispy] re-init scripts and mapinfo to support multiple episodes
+    S_InitScript();
+    InitMapInfo();
     realMap = P_TranslateMap(1);
     if (realMap == -1)
     {
@@ -2282,7 +2286,8 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
     paused = false;
     viewactive = true;
-    gameepisode = episode;
+    // [crispy] not required
+    // gameepisode = episode;
     gamemap = map;
     gameskill = skill;
     BorderNeedRefresh = true;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -39,6 +39,7 @@
 // External functions
 
 extern void R_ExecuteSetViewSize(void); // [crispy] for clean screenshot
+extern void S_InitScript(void); // [crispy] support multiple episodes
 
 // Functions
 
@@ -1918,6 +1919,9 @@ void G_StartNewGame(skill_t skill)
     int realMap;
 
     G_StartNewInit();
+    // [crispy] support multiple episodes
+    S_InitScript();
+    InitMapInfo();
     realMap = P_TranslateMap(1);
     if (realMap == -1)
     {
@@ -2287,6 +2291,10 @@ void G_InitNew(skill_t skill, int episode, int map)
     gameskill = skill;
     BorderNeedRefresh = true;
 
+    // [crispy] support multiple episodes
+    S_InitScript();
+    InitMapInfo();
+
     // Initialize the sky
     R_InitSky(map);
 
@@ -2606,6 +2614,10 @@ void G_DoPlayDemo(void)
 
     // Initialize world info, etc.
     G_StartNewInit();
+
+    // [crispy] support multiple episodes
+    S_InitScript();
+    InitMapInfo();
 
     precache = false;           // don't spend a lot of time in loadlevel
     G_InitNew(skill, episode, map);

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2286,7 +2286,7 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
     paused = false;
     viewactive = true;
-    // [crispy] not required
+    // [crispy] don't let e. g. demo episode overwrite gameepisode
     // gameepisode = episode;
     gamemap = map;
     gameskill = skill;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -70,6 +70,7 @@ gameaction_t gameaction;
 gamestate_t gamestate;
 skill_t gameskill;
 //boolean         respawnmonsters;
+int prev_episode;               // [crispy] previous episode up until InitEpisode
 int gameepisode;
 int gamemap;
 int prevmap;
@@ -1920,8 +1921,7 @@ void G_StartNewGame(skill_t skill)
 
     G_StartNewInit();
     // [crispy] re-init scripts and mapinfo to support multiple episodes
-    S_InitScript();
-    InitMapInfo();
+    H2_InitEpisode(false);
     realMap = P_TranslateMap(1);
     if (realMap == -1)
     {
@@ -2732,4 +2732,35 @@ boolean G_CheckDemoStatus(void)
     }
 
     return false;
+}
+
+/*
+===============================================================================
+
+						[crispy] Additional Functions
+
+===============================================================================
+*/
+
+/*
+===================
+=
+= H2_InitEpisode
+=
+= (Re-)Init episode related MapInfo and Sound Scripts
+= to support multiple episodes in Hexen.
+===================
+*/
+
+void H2_InitEpisode(bool forceinit)
+{
+    if (!crispy->havedeathkings)
+        return;
+
+    if (forceinit || (prev_episode != gameepisode))
+    {
+        S_InitScript();
+        InitMapInfo();
+        prev_episode = gameepisode;
+    }
 }

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -39,7 +39,6 @@
 // External functions
 
 extern void R_ExecuteSetViewSize(void); // [crispy] for clean screenshot
-extern void S_InitScript(void); // [crispy] support multiple episodes
 
 // Functions
 
@@ -1919,9 +1918,6 @@ void G_StartNewGame(skill_t skill)
     int realMap;
 
     G_StartNewInit();
-    // [crispy] support multiple episodes
-    S_InitScript();
-    InitMapInfo();
     realMap = P_TranslateMap(1);
     if (realMap == -1)
     {
@@ -2291,10 +2287,6 @@ void G_InitNew(skill_t skill, int episode, int map)
     gameskill = skill;
     BorderNeedRefresh = true;
 
-    // [crispy] support multiple episodes
-    S_InitScript();
-    InitMapInfo();
-
     // Initialize the sky
     R_InitSky(map);
 
@@ -2614,10 +2606,6 @@ void G_DoPlayDemo(void)
 
     // Initialize world info, etc.
     G_StartNewInit();
-
-    // [crispy] support multiple episodes
-    S_InitScript();
-    InitMapInfo();
 
     precache = false;           // don't spend a lot of time in loadlevel
     G_InitNew(skill, episode, map);

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -607,6 +607,17 @@ void D_DoomMain(void)
     // Generate the WAD hash table.  Speed things up a bit.
     W_GenerateHashTable();
 
+    //!
+    // @category mod
+    //
+    // Disable automatic loading of HEXDD.WAD (Deathkings)
+    //
+    if (!M_ParmExists("-nosideload") && gamemode != shareware &&
+        !demolumpname[0] && !M_CheckParmWithArgs("-record", 1))
+    {
+        D_LoadHEXDD();
+    }
+
     I_PrintStartupBanner(gamedescription);
 
     ST_Message("MN_Init: Init menu system.\n");
@@ -649,17 +660,6 @@ void D_DoomMain(void)
 
     ST_Message("P_Init: Init Playloop state.\n");
     P_Init();
-
-    //!
-    // @category mod
-    //
-    // Disable automatic loading of HEXDD.WAD (Deathkings)
-    //
-    if (!M_ParmExists("-nosideload") && gamemode != shareware &&
-        !demolumpname[0] && !M_CheckParmWithArgs("-record", 1))
-    {
-        D_LoadHEXDD();
-    }
 
     // Check for command line warping. Follows P_Init() because the
     // MAPINFO.TXT script must be already processed.

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -484,6 +484,7 @@ void D_DoomMain(void)
 
     I_AtExit(D_HexenQuitMessage, false);
     startepisode = 1;
+    gameepisode = prev_episode = startepisode; // [crispy]
     autostart = false;
     startmap = 1;
     gamemode = commercial;
@@ -606,17 +607,6 @@ void D_DoomMain(void)
     // Generate the WAD hash table.  Speed things up a bit.
     W_GenerateHashTable();
 
-    //!
-    // @category mod
-    //
-    // Disable automatic loading of HEXDD.WAD (Deathkings)
-    //
-    if (!M_ParmExists("-nosideload") && gamemode != shareware &&
-        !demolumpname[0] && !M_CheckParmWithArgs("-record", 1))
-    {
-        D_LoadHEXDD();
-    }
-
     I_PrintStartupBanner(gamedescription);
 
     ST_Message("MN_Init: Init menu system.\n");
@@ -659,6 +649,17 @@ void D_DoomMain(void)
 
     ST_Message("P_Init: Init Playloop state.\n");
     P_Init();
+
+    //!
+    // @category mod
+    //
+    // Disable automatic loading of HEXDD.WAD (Deathkings)
+    //
+    if (!M_ParmExists("-nosideload") && gamemode != shareware &&
+        !demolumpname[0] && !M_CheckParmWithArgs("-record", 1))
+    {
+        D_LoadHEXDD();
+    }
 
     // Check for command line warping. Follows P_Init() because the
     // MAPINFO.TXT script must be already processed.

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -484,7 +484,7 @@ void D_DoomMain(void)
 
     I_AtExit(D_HexenQuitMessage, false);
     startepisode = 1;
-    gameepisode = prev_episode = startepisode; // [crispy]
+    gameepisode = prev_episode = startepisode; // [crispy] init gameepisode
     autostart = false;
     startmap = 1;
     gamemode = commercial;

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -677,6 +677,7 @@ extern int Sky2Texture;
 extern gamestate_t gamestate;
 extern skill_t gameskill;
 //extern        boolean         respawnmonsters;
+extern int prev_episode;        // [crispy]
 extern int gameepisode;
 extern int gamemap;
 extern int prevmap;
@@ -755,6 +756,7 @@ void H2_GameLoop(void);
 
 void H2_StartTitle(void);
 
+void H2_InitEpisode(bool forceinit); // [crispy]
 
 extern boolean artiskip;
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2316,10 +2316,10 @@ boolean MN_Responder(event_t * event)
                     I_SetPalette(0);
 #endif
                     H2_StartTitle();    // go to intro/demo mode.
-                    // [crispy] re-init episode 1 for correct demo reel
-                    if (gameepisode > 1)
+                    // [crispy] re-init startepisode for correct demo reel
+                    if (crispy->havedeathkings && gameepisode != startepisode)
                     {
-                        gameepisode = prev_episode = 1;
+                        gameepisode = prev_episode = startepisode;
                         H2_InitEpisode(true);
                     }
                     return false;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -114,7 +114,6 @@ extern void I_ReInitGraphics(int reinit); // [crispy]
 extern void R_ExecuteSetViewSize(void); // [crispy]
 extern void AM_LevelInit(boolean reinit); // [crispy]
 extern void AM_initVariables(void); // [crispy]
-extern void S_InitScript(void); // [crispy]
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 
@@ -1580,6 +1579,7 @@ static void SCEpisode(int option)
     }
 
     // [crispy] Execude Episode Selection
+    prev_episode = gameepisode;
     gameepisode = option;
     SetMenu(MENU_CLASS);
 }
@@ -2319,9 +2319,8 @@ boolean MN_Responder(event_t * event)
                     // [crispy] re-init episode 1 for correct demo reel
                     if (gameepisode > 1)
                     {
-                        gameepisode = 1;
-                        S_InitScript();
-                        InitMapInfo();
+                        gameepisode = prev_episode = 1;
+                        H2_InitEpisode(true);
                     }
                     return false;
                 case 3:

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1582,8 +1582,8 @@ static void SCEpisode(int option)
     // Execude Episode Selection
     gameepisode = option;
 
-    S_InitScript();
-    InitMapInfo();
+    // S_InitScript();
+    // InitMapInfo();
     
     SetMenu(MENU_CLASS);
 }
@@ -2320,13 +2320,13 @@ boolean MN_Responder(event_t * event)
                     I_SetPalette(0);
 #endif
                     H2_StartTitle();    // go to intro/demo mode.
-                    // [crispy] re-init episode 1 for correct demo reel
-                    if (gameepisode > 1)
-                    {
-                        gameepisode = 1;
-                        S_InitScript();
-                        InitMapInfo();
-                    }
+                    // // [crispy] re-init episode 1 for correct demo reel
+                    // if (gameepisode > 1)
+                    // {
+                    //     gameepisode = 1;
+                    //     S_InitScript();
+                    //     InitMapInfo();
+                    // }
                     return false;
                 case 3:
                     P_SetMessage(&players[consoleplayer],

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1582,8 +1582,8 @@ static void SCEpisode(int option)
     // Execude Episode Selection
     gameepisode = option;
 
-    // S_InitScript();
-    // InitMapInfo();
+    S_InitScript();
+    InitMapInfo();
     
     SetMenu(MENU_CLASS);
 }
@@ -2320,13 +2320,13 @@ boolean MN_Responder(event_t * event)
                     I_SetPalette(0);
 #endif
                     H2_StartTitle();    // go to intro/demo mode.
-                    // // [crispy] re-init episode 1 for correct demo reel
-                    // if (gameepisode > 1)
-                    // {
-                    //     gameepisode = 1;
-                    //     S_InitScript();
-                    //     InitMapInfo();
-                    // }
+                    // [crispy] re-init episode 1 for correct demo reel
+                    if (gameepisode > 1)
+                    {
+                        gameepisode = 1;
+                        S_InitScript();
+                        InitMapInfo();
+                    }
                     return false;
                 case 3:
                     P_SetMessage(&players[consoleplayer],

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1579,12 +1579,8 @@ static void SCEpisode(int option)
         demoextend = false;
     }
 
-    // Execude Episode Selection
+    // [crispy] Execude Episode Selection
     gameepisode = option;
-
-    S_InitScript();
-    InitMapInfo();
-    
     SetMenu(MENU_CLASS);
 }
 

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -89,7 +89,6 @@ typedef struct
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 
-extern void S_InitScript(void); // [crispy] support multiple episodes
 void P_SpawnPlayer(mapthing_t * mthing);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
@@ -2129,6 +2128,7 @@ void SV_LoadGame(int slot)
 
     AssertSegment(ASEG_GAME_HEADER);
 
+    prev_episode = gameepisode; // [crispy]
     gameepisode = 1;
     gamemap = SV_ReadByte();
     gameskill = SV_ReadByte();
@@ -2154,8 +2154,7 @@ void SV_LoadGame(int slot)
     SV_ReadExtendedSaveGameData(EXTSAVEG_GAME);
 
     // [crispy] re-init scripts and mapinfo to support multiple episodes
-    S_InitScript();
-    InitMapInfo();
+    H2_InitEpisode(false);
 
     // Save player structs
     for (i = 0; i < maxplayers; i++)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -89,7 +89,7 @@ typedef struct
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 
-extern void S_InitScript(void); // [crispy] support multiple episodes
+// extern void S_InitScript(void); // [crispy] support multiple episodes
 void P_SpawnPlayer(mapthing_t * mthing);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
@@ -2153,9 +2153,9 @@ void SV_LoadGame(int slot)
     // [crispy] read more extended savegame data for game
     SV_ReadExtendedSaveGameData(EXTSAVEG_GAME);
 
-    // [crispy] re-init scripts and mapinfo to support multiple episodes
-    S_InitScript();
-    InitMapInfo();
+    // // [crispy] re-init scripts and mapinfo to support multiple episodes
+    // S_InitScript();
+    // InitMapInfo();
 
     // Save player structs
     for (i = 0; i < maxplayers; i++)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -89,7 +89,7 @@ typedef struct
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 
-// extern void S_InitScript(void); // [crispy] support multiple episodes
+extern void S_InitScript(void); // [crispy] support multiple episodes
 void P_SpawnPlayer(mapthing_t * mthing);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
@@ -2153,9 +2153,9 @@ void SV_LoadGame(int slot)
     // [crispy] read more extended savegame data for game
     SV_ReadExtendedSaveGameData(EXTSAVEG_GAME);
 
-    // // [crispy] re-init scripts and mapinfo to support multiple episodes
-    // S_InitScript();
-    // InitMapInfo();
+    // [crispy] re-init scripts and mapinfo to support multiple episodes
+    S_InitScript();
+    InitMapInfo();
 
     // Save player structs
     for (i = 0; i < maxplayers; i++)


### PR DESCRIPTION
Related PR:
https://github.com/fabiangreffrath/crispy-doom/pull/1386

**Changes Summary**
The following optimization / bugfixes are done with this PR:

- Optimization: Execute `S_InitScript()` and `InitMapInfo()` only when the episode changed, not every time.
- Bugfix: Do not init mapinfo and soundscript in episode selection (since it can alter the demo-reel), but when the game is started.
- Bugfix: Change `D_LoadHEXDD()` so check for already loaded HEXDD pwad can work correctly.

.. I hope this catches all remaining issues with the sideloading. Turns out, it was more complex than I anticipated. 😨 