### PR TITLE
Fix view jolting up/down too much when running across tiny height variations

### DIFF
--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -48,7 +48,8 @@
 static const fixed_t crispy_bobfactor[3] = {4, 3, 0};
 
 boolean		onground;
-
+int offgroundtics; // how many tics player has been in air
+#define AIRBOBFADETICS 4 // num tics to scale bobbing to 0 in midair
 
 //
 // P_Thrust
@@ -76,7 +77,7 @@ P_Thrust
 void P_CalcHeight (player_t* player) 
 {
     int		angle;
-    fixed_t	bob;
+    fixed_t	bob, totalviewoffset;
     
     // Regular movement bobbing
     // (needs to be calculated for gun swing
@@ -96,7 +97,9 @@ void P_CalcHeight (player_t* player)
     // [crispy] variable player view bob
     player->bob2 = crispy_bobfactor[crispy->bobfactor] * player->bob / 4;
 
-    if ((player->cheats & CF_NOMOMENTUM) || !onground)
+    offgroundtics = onground ? 0 : offgroundtics + 1;
+
+    if ((player->cheats & CF_NOMOMENTUM) || (!onground && (offgroundtics > AIRBOBFADETICS)))
     {
 	player->viewz = player->mo->z + VIEWHEIGHT;
 
@@ -113,7 +116,7 @@ void P_CalcHeight (player_t* player)
 
     
     // move viewheight
-    if (player->playerstate == PST_LIVE)
+    if (player->playerstate == PST_LIVE && onground)
     {
 	player->viewheight += player->deltaviewheight;
 
@@ -137,7 +140,12 @@ void P_CalcHeight (player_t* player)
 		player->deltaviewheight = 1;
 	}
     }
-    player->viewz = player->mo->z + player->viewheight + bob;
+    totalviewoffset = player->viewheight + bob - VIEWHEIGHT;
+    
+    if (!onground)
+        totalviewoffset = totalviewoffset * (AIRBOBFADETICS + 1 - offgroundtics) / AIRBOBFADETICS;
+    
+    player->viewz = player->mo->z + VIEWHEIGHT + totalviewoffset;
 
     if (player->viewz > player->mo->ceilingz-4*FRACUNIT)
 	player->viewz = player->mo->ceilingz-4*FRACUNIT;

--- a/src/strife/p_user.c
+++ b/src/strife/p_user.c
@@ -61,6 +61,8 @@ static char useinventorymsg[44];    // villsa [STRIFE]
 static const fixed_t crispy_bobfactor[3] = {4, 3, 0};
 
 boolean		onground;
+int offgroundtics; // how many tics player has been in air
+#define AIRBOBFADETICS 4 // num tics to scale bobbing to 0 in midair
 
 
 //
@@ -113,9 +115,11 @@ void P_CalcHeight (player_t* player)
     // [crispy] variable player view bob
     player->bob2 = crispy_bobfactor[crispy->bobfactor] * player->bob / 4;
 
+    offgroundtics = onground ? 0 : offgroundtics + 1;
+
     // haleyjd 20110205 [STRIFE]: No CF_NOMOMENTUM check, and Rogue also removed
     // the dead code inside.
-    if (!onground)
+    if (!onground && (offgroundtics > AIRBOBFADETICS))
     {
         /*
         player->viewz = player->mo->z + VIEWHEIGHT;
@@ -132,7 +136,7 @@ void P_CalcHeight (player_t* player)
     bob = FixedMul ( player->bob2/2, finesine[angle]); // [crispy] variable player view bob
 
     // move viewheight
-    if (player->playerstate == PST_LIVE)
+    if (player->playerstate == PST_LIVE && onground)
     {
         player->viewheight += player->deltaviewheight;
 
@@ -156,6 +160,10 @@ void P_CalcHeight (player_t* player)
                 player->deltaviewheight = 1;
         }
     }
+
+    if (!onground)
+        bob = bob * (AIRBOBFADETICS + 1 - offgroundtics) / AIRBOBFADETICS;
+
     player->viewz = player->mo->z + player->viewheight + bob;
 
     // villsa [STRIFE] account for terrain lowering the view


### PR DESCRIPTION
Cosmetic fix, same as https://github.com/fabiangreffrath/woof/pull/2815

Applied to Doom and Strife.
Heretic/Hexen are unaffected because they already continue bobbing in midair so they already don't get this jolting.

I can come back later and provide a limitremoving demonstration wad if needed.

As in the Woof PR, this is not put behind a config option because I can't think of reason for someone to prefer the original behavior.